### PR TITLE
refactor(activerecord): _exec_scope instance_execs the block; strict_mode? reads @config.fetch(:strict, true) (RFC 0112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ class Post extends Base {
   static {
     this.belongsTo("author");
     this.hasMany("comments");
-    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("published", function () {
+      return this.where({ published: true });
+    });
   }
 }
 
@@ -117,8 +119,12 @@ class Post extends Base {
     this.validates("title", { presence: true });
     this.validates("slug", { uniqueness: true });
 
-    this.scope("published", (rel) => rel.where({ published: true }));
-    this.scope("authoredBy", (rel, user: User) => rel.where({ author: user }));
+    this.scope("published", function () {
+      return this.where({ published: true });
+    });
+    this.scope("authoredBy", function (user: User) {
+      return this.where({ author: user });
+    });
 
     defineEnum(this, "status", { draft: 0, published: 1, archived: 2 });
   }

--- a/docs/infrastructure/virtual-source-files-plan.md
+++ b/docs/infrastructure/virtual-source-files-plan.md
@@ -31,7 +31,9 @@ class Post extends Base {
     this.attribute("title", "string");
     this.hasMany("comments");
     this.belongsTo("author");
-    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("published", function () {
+      return this.where({ published: true });
+    });
   }
 }
 ```
@@ -117,7 +119,9 @@ class Post extends Base {
     this.attribute("title", "string");
     this.hasMany("comments");
     this.belongsTo("author");
-    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("published", function () {
+      return this.where({ published: true });
+    });
   }
 }
 ```
@@ -133,7 +137,9 @@ class Post extends Base {
     this.attribute("title", "string");
     this.hasMany("comments");
     this.belongsTo("author");
-    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("published", function () {
+      return this.where({ published: true });
+    });
   }
 }
 ```

--- a/examples/twitter-clone/src/models/tweet.ts
+++ b/examples/twitter-clone/src/models/tweet.ts
@@ -7,6 +7,8 @@ export class Tweet extends Base {
 
     this.validates("body", { presence: true, length: { maximum: 280 } });
 
-    this.scope("recent", (rel: Relation<Tweet>) => rel.order("created_at", "desc"));
+    this.scope("recent", function (this: Relation<Tweet>) {
+      return this.order("created_at", "desc");
+    });
   }
 }

--- a/packages/activerecord/dx-tests/declare-patterns.test-d.ts
+++ b/packages/activerecord/dx-tests/declare-patterns.test-d.ts
@@ -114,10 +114,12 @@ class Post extends Base {
   static {
     this.attribute("title", "string");
     this.attribute("published", "boolean");
-    this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
-    this.scope("recent", (rel: Relation<Post>, sinceDays: number) => {
+    this.scope("published", function (this: Relation<Post>) {
+      return this.where({ published: true });
+    });
+    this.scope("recent", function (this: Relation<Post>, sinceDays: number) {
       void sinceDays;
-      return rel.where({});
+      return this.where({});
     });
   }
 }
@@ -307,7 +309,9 @@ describe("declare patterns — typing runtime-attached members", () => {
       static {
         this.attribute("name", "string");
         this.hasMany("posts");
-        this.scope("active", (rel: Relation<Plain>) => rel);
+        this.scope("active", function (this: Relation<Plain>) {
+          return this;
+        });
       }
     }
     const p = new Plain({ name: "x" });

--- a/packages/activerecord/dx-tests/query-chaining.test-d.ts
+++ b/packages/activerecord/dx-tests/query-chaining.test-d.ts
@@ -139,15 +139,15 @@ describe("query chaining DX", () => {
 
       static {
         this.attribute("published", "boolean");
-        // No manual `rel: Relation<Article>` annotation needed.
-        this.scope("published", (rel) => {
-          expectTypeOf(rel).toMatchTypeOf<Relation<Article>>();
-          return rel.where({ published: true });
+        // No manual `this: Relation<Article>` annotation needed.
+        this.scope("published", function () {
+          expectTypeOf(this).toMatchTypeOf<Relation<Article>>();
+          return this.where({ published: true });
         });
-        this.scope("recent", (rel, days: number) => {
-          expectTypeOf(rel).toMatchTypeOf<Relation<Article>>();
+        this.scope("recent", function (days: number) {
+          expectTypeOf(this).toMatchTypeOf<Relation<Article>>();
           expectTypeOf(days).toBeNumber();
-          return rel;
+          return this;
         });
         this.defaultScope((rel) => {
           expectTypeOf(rel).toMatchTypeOf<Relation<Article>>();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2047,7 +2047,7 @@ export class Base extends Model {
   static storedAttributes = _storedAttributes;
 
   // -- Scopes registry (used by Relation) --
-  static _scopes: Map<string, (rel: any, ...args: any[]) => any> = new Map();
+  static _scopes: Map<string, (this: any, ...args: any[]) => any> = new Map();
 
   // --- Default scope (wired via extend() after class body) ---
   declare static defaultScope: typeof _defaultScope;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -147,6 +147,15 @@ import {
   type NativeDatabaseTypes,
 } from "./abstract/native-database-types.js";
 
+/**
+ * Ruby's `Hash#fetch(key, default)` returns the STORED value whenever the key
+ * exists — including a stored `nil` or `false` — where `??` would substitute
+ * the default.
+ */
+function fetch<T>(hash: Record<string, unknown>, key: string, defaultValue: T): T {
+  return key in hash ? (hash[key] as T) : defaultValue;
+}
+
 const ER_DUP_ENTRY = 1062;
 const ER_CANNOT_ADD_FOREIGN = 1215;
 const ER_CANNOT_CREATE_TABLE = 1005;
@@ -1090,8 +1099,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return [...orderColumns, columns].join(", ");
   }
 
-  isStrictMode(): boolean {
-    return false;
+  // Mirrors: AbstractMysqlAdapter#strict_mode? (abstract_mysql_adapter.rb:630-632).
+  // `@config.fetch(:strict, true)` — an absent key means strict, and a stored
+  // `false` (or `":default"`, which `type_cast_config_to_boolean` passes
+  // through for `configure_connection`'s defaults check) is honoured.
+  isStrictMode(): boolean | unknown {
+    return (this.constructor as typeof AbstractMysqlAdapter).typeCastConfigToBoolean(
+      fetch(this._config, "strict", true),
+    );
   }
 
   isDefaultIndexType(index: { using?: string | null }): boolean {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.build-init-sql.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.build-init-sql.trails.test.ts
@@ -40,6 +40,30 @@ describe("Mysql2Adapter#_buildInitSql", () => {
     await adapter.close();
   });
 
+  it("defaults to strict mode when no strict key is configured", async () => {
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+    expect(adapter.isStrictMode()).toBe(true);
+    const sql = (adapter as unknown as { _buildInitSql(): string })._buildInitSql();
+    expect(sql).toContain("CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')");
+    await adapter.close();
+  });
+
+  it("honours a stored strict false", async () => {
+    const adapter = new Mysql2Adapter({ host: "localhost", strict: false } as never);
+    expect(adapter.isStrictMode()).toBe(false);
+    const sql = (adapter as unknown as { _buildInitSql(): string })._buildInitSql();
+    expect(sql).toContain("REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', '')");
+    await adapter.close();
+  });
+
+  it("leaves sql_mode alone when strict is :default", async () => {
+    const adapter = new Mysql2Adapter({ host: "localhost", strict: ":default" } as never);
+    expect(adapter.isStrictMode()).toBe(":default");
+    const sql = (adapter as unknown as { _buildInitSql(): string })._buildInitSql();
+    expect(sql).toContain("@@SESSION.sql_mode = @@GLOBAL.sql_mode");
+    await adapter.close();
+  });
+
   it("throws for invalid charset", () => {
     expect(
       () => new Mysql2Adapter({ host: "localhost", charset: "utf8'; DROP TABLE x; --" }),

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1637,7 +1637,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // Called before createConnection so a validation throw doesn't leak a live connection.
   /** @internal */
   private _buildInitSql(): string {
-    const { strict, waitTimeout, variables: configVars } = this._poolConfig;
+    const { waitTimeout, variables: configVars } = this._poolConfig;
     const vars: Record<string, string | number | boolean | null | ":default" | "default"> = {
       ...(configVars ?? {}),
     };
@@ -1661,8 +1661,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // so null falls through to the strict-mode branch below.
       delete vars["sql_mode"];
       sqlMode = this.quote(String(varSqlMode));
-    } else if (!DEFAULTS.has(strict as string)) {
-      if (strict !== false) {
+    } else if (!DEFAULTS.has(this.isStrictMode() as string)) {
+      // abstract_mysql_adapter.rb:928-936 — the sql_mode decision reads
+      // `strict_mode?`, which is `@config.fetch(:strict, true)`, not the
+      // pool-config field.
+      if (isRubyTruthy(this.isStrictMode())) {
         sqlMode = "CONCAT(@@sql_mode, ',STRICT_ALL_TABLES')";
       } else {
         sqlMode = "REPLACE(@@sql_mode, 'STRICT_TRANS_TABLES', '')";

--- a/packages/activerecord/src/delegated-type.ts
+++ b/packages/activerecord/src/delegated-type.ts
@@ -211,7 +211,9 @@ export function defineDelegatedTypeMethods(
     const predicateSuffix = camelize(singularSnake, true);
 
     // delegated_type.rb:263 `scope scope_name, -> { where(role_type => type) }`
-    (modelClass as any).scope(scopeName, (rel: any) => rel.where({ [roleType]: typeName }));
+    (modelClass as any).scope(scopeName, function (this: any) {
+      return this.where({ [roleType]: typeName });
+    });
 
     // Type predicate: isMessage(), isAccessNoticeMessage()
     // delegated_type.rb:265 `define_method(query) { public_send(role_type) == type }`

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -473,8 +473,12 @@ export class EnumMethods {
       });
     }
     if (scopes) {
-      klass.scope(valueMethodName, (rel: any) => rel.where({ [name]: value }));
-      klass.scope(notName, (rel: any) => rel.where().not({ [name]: value }));
+      klass.scope(valueMethodName, function (this: any) {
+        return this.where({ [name]: value });
+      });
+      klass.scope(notName, function (this: any) {
+        return this.where().not({ [name]: value });
+      });
     }
   }
 }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3025,18 +3025,21 @@ export class Relation<T extends Base> {
   /**
    * Run a named-scope body with this relation as the receiver.
    *
-   * Rails `instance_exec`s the body against the relation; trails scope bodies
-   * instead take the relation as their first argument, so it is passed
-   * explicitly here — the `|| self` fallback and the scope-registry threading
-   * are otherwise identical.
+   * Ruby's `(...)` forwards the caller's block alongside the positional
+   * arguments, and `instance_exec` runs it with `self` bound to the relation.
+   * A JS function carries no implicit block, so the body arrives as the
+   * trailing argument (the settled trails spelling of a Ruby block) and
+   * `call(this, ...)` is `instance_exec`'s rebinding — a scope body reads
+   * `this.where(...)`, not a passed-in receiver.
    *
-   * Mirrors: ActiveRecord::Relation#_exec_scope
+   * Mirrors: ActiveRecord::Relation#_exec_scope (relation.rb:552-558)
    */
-  _execScope(fn: (rel: Relation<T>, ...args: unknown[]) => unknown, ...args: unknown[]): unknown {
+  _execScope(...args: unknown[]): unknown {
     this._delegateToModel = true;
     const registry = this.model.scopeRegistry();
+    const body = args.pop() as (this: Relation<T>, ...rest: unknown[]) => unknown;
     try {
-      return this._scoping(null, registry, false, () => fn(this, ...args) || this);
+      return this._scoping(null, registry, false, () => body.call(this, ...args) || this);
     } finally {
       this._delegateToModel = false;
     }

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -837,7 +837,7 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
           // Rails named.rb:175 — `all._exec_scope(*args, &body)`, not a bare
           // call: `_exec_scope` is what marks the relation delegate-to-model
           // and nils the current scope for the duration of the body.
-          const result = target._execScope(scopeFn, ...args);
+          const result = target._execScope(...args, scopeFn);
           const extensions = modelClass._scopeExtensions?.get(prop);
           if (extensions && result && typeof result === "object") {
             // Register the extension as a module on the relation (mirrors Ruby's

--- a/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
+++ b/packages/activerecord/src/relation/spawn-already-in-scope.trails.test.ts
@@ -32,7 +32,7 @@ interface ScopeRegistryLike {
   setCurrentScope(model: unknown, scope: unknown): void;
 }
 
-type ScopeBody = (rel: ScopeInternals) => unknown;
+type ScopeBody = (this: ScopeInternals) => unknown;
 
 const model = Post as unknown as {
   scope(name: string, body: ScopeBody): void;
@@ -73,11 +73,11 @@ describe("SpawnAlreadyInScopeTest", () => {
     const currentScope = model.where({ type: "SpecialPost" });
     let spawned: ScopeInternals | undefined;
 
-    defineAndCallScope("spawnsInsideBody", (rel) => {
+    defineAndCallScope("spawnsInsideBody", function () {
       withCurrentScope(currentScope, () => {
-        spawned = rel.spawn();
+        spawned = this.spawn();
       });
-      return rel;
+      return this;
     });
 
     expect(await spawned!.toSql()).toMatch(/SpecialPost/);
@@ -94,14 +94,14 @@ describe("SpawnAlreadyInScopeTest", () => {
     let flagAfterBody: boolean | undefined;
     let bodyRelation: ScopeInternals | undefined;
 
-    defineAndCallScope("checksBothConditions", (rel) => {
-      bodyRelation = rel;
+    defineAndCallScope("checksBothConditions", function () {
+      bodyRelation = this;
       const registry = model.scopeRegistry();
-      flagWithoutScope = rel.isAlreadyInScope(registry);
-      withCurrentScope(rel, (reg) => {
-        flagWithScope = rel.isAlreadyInScope(reg);
+      flagWithoutScope = this.isAlreadyInScope(registry);
+      withCurrentScope(this, (reg) => {
+        flagWithScope = this.isAlreadyInScope(reg);
       });
-      return rel;
+      return this;
     });
 
     withCurrentScope(bodyRelation, (registry) => {
@@ -116,12 +116,12 @@ describe("SpawnAlreadyInScopeTest", () => {
   test("clones do not inherit the delegate-to-model flag", () => {
     let clonedFlag: boolean | undefined;
 
-    defineAndCallScope("clonedInBody", (rel) => {
-      const cloned = rel.clone();
+    defineAndCallScope("clonedInBody", function () {
+      const cloned = this.clone();
       withCurrentScope(cloned, (registry) => {
         clonedFlag = cloned.isAlreadyInScope(registry);
       });
-      return rel;
+      return this;
     });
 
     // Rails' `initialize_copy` ends in `reset`, which clears the flag. If it
@@ -131,9 +131,9 @@ describe("SpawnAlreadyInScopeTest", () => {
   });
 
   test("chaining inside a scope body accumulates conditions", async () => {
-    const scoped = defineAndCallScope("chainedInBody", (rel) =>
-      rel.where({ type: "Post" }).where({ title: "Welcome to the weblog" }),
-    ) as ScopeInternals;
+    const scoped = defineAndCallScope("chainedInBody", function () {
+      return this.where({ type: "Post" }).where({ title: "Welcome to the weblog" });
+    }) as ScopeInternals;
 
     const sql = await scoped.toSql();
     expect(sql).toMatch(/type/);

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -661,9 +661,9 @@ describe("DefaultScopingTest", () => {
     class DeveloperWithByNameScope extends Developer {
       declare static byName: (name: string) => any;
       static {
-        this.scope("byName", (q: any, name: string) =>
-          q.unscope({ where: "name" }).where({ name }),
-        );
+        this.scope("byName", function (this: any, name: string) {
+          return this.unscope({ where: "name" }).where({ name });
+        });
       }
     }
     const expected = namesAndIds(

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -254,9 +254,11 @@ describe("NamedScopingTest", () => {
     const conflicts = ["records", "toArray", "toSql", "explain"];
     for (const name of conflicts) {
       const klass = class extends Post {};
-      expect(() => (klass as any).scope(name, (q: any) => q.where({ approved: true }))).toThrow(
-        new RegExp(`You tried to define a scope named "${name}" on the model`),
-      );
+      expect(() =>
+        (klass as any).scope(name, function (this: any) {
+          return this.where({ approved: true });
+        }),
+      ).toThrow(new RegExp(`You tried to define a scope named "${name}" on the model`));
     }
   });
 
@@ -428,20 +430,28 @@ describe("NamedScopingTest", () => {
     for (const name of conflicts) {
       const re = new RegExp(`You tried to define a scope named "${name}" on the model`);
       expect(() =>
-        (ReservedKlass as any).scope(name, (q: any) => q.where({ approved: true })),
+        (ReservedKlass as any).scope(name, function (this: any) {
+          return this.where({ approved: true });
+        }),
       ).toThrow(re);
       expect(() =>
-        (ReservedSubklass as any).scope(name, (q: any) => q.where({ approved: true })),
+        (ReservedSubklass as any).scope(name, function (this: any) {
+          return this.where({ approved: true });
+        }),
       ).toThrow(re);
     }
 
     const nonConflicts = ["findByTitle", "approved", "pub", "pri", "pro", "open"];
     for (const name of nonConflicts) {
       expect(() =>
-        (ReservedKlass as any).scope(name, (q: any) => q.where({ approved: true })),
+        (ReservedKlass as any).scope(name, function (this: any) {
+          return this.where({ approved: true });
+        }),
       ).not.toThrow();
       expect(() =>
-        (ReservedSubklass as any).scope(name, (q: any) => q.where({ approved: true })),
+        (ReservedSubklass as any).scope(name, function (this: any) {
+          return this.where({ approved: true });
+        }),
       ).not.toThrow();
     }
   });

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -83,7 +83,9 @@ describe("NamedScopingTest", () => {
   });
 
   it("calling merge at first in scope", async () => {
-    Topic.scope("callingMergeAtFirstInScope", (q: any) => q.merge(Topic.replied()));
+    Topic.scope("callingMergeAtFirstInScope", function (this: any) {
+      return this.merge(Topic.replied());
+    });
     expect(ids(await (Topic as any).callingMergeAtFirstInScope().toArray())).toEqual(
       ids(await Topic.replied()),
     );
@@ -94,8 +96,12 @@ describe("NamedScopingTest", () => {
     // scopes in either order yields the same conjunction/result set.
     const epoch = Temporal.Instant.fromEpochMilliseconds(0);
     const now = Temporal.Now.instant();
-    Topic.scope("since", (q: any) => q.where("written_on >= ?", epoch));
-    Topic.scope("to", (q: any) => q.where("written_on <= ?", now));
+    Topic.scope("since", function (this: any) {
+      return this.where("written_on >= ?", epoch);
+    });
+    Topic.scope("to", function (this: any) {
+      return this.where("written_on <= ?", now);
+    });
     expect(sortedIds(await (Topic as any).to().since().toArray())).toEqual(
       sortedIds(await (Topic as any).since().to().toArray()),
     );
@@ -403,7 +409,9 @@ describe("NamedScopingTest", () => {
       static pri() {}
       static pro() {}
     }
-    (ReservedKlass as any).scope("approved", (q: any) => q.where({ approved: true }));
+    (ReservedKlass as any).scope("approved", function (this: any) {
+      return this.where({ approved: true });
+    });
     class ReservedSubklass extends ReservedKlass {}
 
     const conflicts = [
@@ -441,9 +449,9 @@ describe("NamedScopingTest", () => {
   it("spaces in scope names", async () => {
     // Rails defines `scope :"title containing space", ->(space: " ") { ... }`
     // and dispatches via `public_send(:"title containing space", space: " ")`.
-    Topic.scope("title containing space", (q: any, opts: { space?: string } = {}) =>
-      q.where(`title LIKE '%${opts.space ?? " "}%'`),
-    );
+    Topic.scope("title containing space", function (this: any, opts: { space?: string } = {}) {
+      return this.where(`title LIKE '%${opts.space ?? " "}%'`);
+    });
     const expected = sortedIds(await Topic.where("title LIKE '% %'"));
     const got = sortedIds(await (Topic as any)["title containing space"]({ space: " " }).toArray());
     expect(got).toEqual(expected);
@@ -730,7 +738,9 @@ describe("NamedScopingTest", () => {
   });
 
   it("scope with annotation", async () => {
-    Topic.scope("includingAnnotateInScope", (q: any) => q.annotate("from-scope"));
+    Topic.scope("includingAnnotateInScope", function (this: any) {
+      return this.annotate("from-scope");
+    });
     const sql = (Topic as any).includingAnnotateInScope().toSql();
     expect(sql).toContain("from-scope");
     // Rails also asserts the annotation does not filter records.

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -92,7 +92,7 @@ export function isRelationInstanceMethod(name: string): boolean {
 export function scope<T extends typeof Base>(
   this: T,
   name: string,
-  fn: (rel: Relation<InstanceType<T>>, ...args: any[]) => Relation<any>,
+  fn: (this: Relation<InstanceType<T>>, ...args: any[]) => Relation<any>,
   extension?: Record<string, (...args: any[]) => any>,
 ): void {
   const modelClass = this as any;

--- a/packages/activerecord/src/test-helpers/models/account.ts
+++ b/packages/activerecord/src/test-helpers/models/account.ts
@@ -34,8 +34,12 @@ export class Account extends Base {
 
     this.aliasAttribute("available_credit", "credit_limit");
 
-    this.scope("open", (q: any) => q.where("firm_name = ?", "37signals"));
-    this.scope("available", (q: any) => q.open());
+    this.scope("open", function (this: any) {
+      return this.where("firm_name = ?", "37signals");
+    });
+    this.scope("available", function (this: any) {
+      return this.open();
+    });
 
     this.beforeDestroy(function (this: Account, record?: Account) {
       // The framework passes the record as the first argument; `this` may be

--- a/packages/activerecord/src/test-helpers/models/bulb.ts
+++ b/packages/activerecord/src/test-helpers/models/bulb.ts
@@ -26,7 +26,9 @@ export class Bulb extends Base {
     this.defaultScope((q: any) => q.where({ name: "defaulty" }));
     // Rails: counter_cache: { active: false } — object form not yet typed; cast as any
     this.belongsTo("car", { touch: true, counterCache: { active: false } as any });
-    this.scope("awesome", (q: any) => q.where({ frickinawesome: true }));
+    this.scope("awesome", function (this: any) {
+      return this.where({ frickinawesome: true });
+    });
 
     this.afterInitialize((record: Bulb) => {
       record.scopeAfterInitialize = (record.constructor as typeof Bulb).all();

--- a/packages/activerecord/src/test-helpers/models/car.ts
+++ b/packages/activerecord/src/test-helpers/models/car.ts
@@ -66,9 +66,15 @@ export class Car extends Base {
 
     this.hasMany("priceEstimates", { as: "estimateOf" });
 
-    this.scope("inclTyres", (q: any) => q.includes(":tyres"));
-    this.scope("inclEngines", (q: any) => q.includes(":engines"));
-    this.scope("orderUsingNewStyle", (q: any) => q.order("name asc"));
+    this.scope("inclTyres", function (this: any) {
+      return this.includes(":tyres");
+    });
+    this.scope("inclEngines", function (this: any) {
+      return this.includes(":engines");
+    });
+    this.scope("orderUsingNewStyle", function (this: any) {
+      return this.order("name asc");
+    });
 
     this.attribute("wheels_owned_at", "datetime", { default: () => Temporal.Now.instant() });
   }

--- a/packages/activerecord/src/test-helpers/models/category.ts
+++ b/packages/activerecord/src/test-helpers/models/category.ts
@@ -72,7 +72,9 @@ export class Category extends Base {
       (q: any) => q.where({ essays: { type: "TypedEssay" } }),
       { through: "essays", source: "writer", sourceType: "Human", primaryKey: "name" },
     );
-    this.scope("general", (q: any) => q.where({ name: "General" }));
+    this.scope("general", function (this: any) {
+      return this.where({ name: "General" });
+    });
   }
 
   static whatAreYou() {

--- a/packages/activerecord/src/test-helpers/models/club.ts
+++ b/packages/activerecord/src/test-helpers/models/club.ts
@@ -50,12 +50,11 @@ export class Club extends Base {
       source: "member",
     });
 
-    this.scope("general", (q: any) =>
-      q
-        .leftJoins(":category")
+    this.scope("general", function (this: any) {
+      return this.leftJoins(":category")
         .where({ categories: { name: "General" } })
-        .unscope("limit"),
-    );
+        .unscope("limit");
+    });
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/comment.ts
+++ b/packages/activerecord/src/test-helpers/models/comment.ts
@@ -81,16 +81,38 @@ export class Comment extends Base {
   declare author: Base | null;
 
   static {
-    this.scope("limitBy", (q: any, l: number) => q.limit(l));
-    this.scope("containingTheLetterE", (q: any) => q.where("comments.body LIKE '%e%'"));
-    this.scope("notAgain", (q: any) => q.where("comments.body NOT LIKE '%again%'"));
-    this.scope("forFirstPost", (q: any) => q.where({ post_id: 1 }));
-    this.scope("forFirstAuthor", (q: any) => q.joins(":post").where({ "posts.author_id": 1 }));
-    this.scope("created", (q: any) => q.all());
-    this.scope("orderedByPostId", (q: any) => q.order("comments.post_id DESC"));
-    this.scope("allAsScope", (q: any) => q.all());
+    this.scope("limitBy", function (this: any, l: number) {
+      return this.limit(l);
+    });
+    this.scope("containingTheLetterE", function (this: any) {
+      return this.where("comments.body LIKE '%e%'");
+    });
+    this.scope("notAgain", function (this: any) {
+      return this.where("comments.body NOT LIKE '%again%'");
+    });
+    this.scope("forFirstPost", function (this: any) {
+      return this.where({ post_id: 1 });
+    });
+    this.scope("forFirstAuthor", function (this: any) {
+      return this.joins(":post").where({ "posts.author_id": 1 });
+    });
+    this.scope("created", function (this: any) {
+      return this.all();
+    });
+    this.scope("orderedByPostId", function (this: any) {
+      return this.order("comments.post_id DESC");
+    });
+    this.scope("allAsScope", function (this: any) {
+      return this.all();
+    });
     // Rails: `scope :oops_comments, -> { extending OopsExtension }`.
-    this.scope("oopsComments", (q: any) => q.all(), OopsExtension);
+    this.scope(
+      "oopsComments",
+      function (this: any) {
+        return this.all();
+      },
+      OopsExtension,
+    );
     // Rails: `default_scope { extending OopsExtension }`.
     this.defaultScope((q: any) => q.extending(OopsExtension));
 

--- a/packages/activerecord/src/test-helpers/models/company.ts
+++ b/packages/activerecord/src/test-helpers/models/company.ts
@@ -73,9 +73,9 @@ export class Company extends AbstractCompany {
     this.aliasAttribute("new_name", "name");
     this.attribute("metadata", "json");
 
-    this.scope("ofFirstFirm", (q: any) =>
-      q.joins({ ":account": ":firm" }).where({ "companies.id": 1 }),
-    );
+    this.scope("ofFirstFirm", function (this: any) {
+      return this.joins({ ":account": ":firm" }).where({ "companies.id": 1 });
+    });
   }
 
   arbitraryMethod(): string {

--- a/packages/activerecord/src/test-helpers/models/developer.ts
+++ b/packages/activerecord/src/test-helpers/models/developer.ts
@@ -179,7 +179,9 @@ export class Developer extends Base {
     this.belongsTo("firm");
     this.hasMany("contractedProjects", { className: "Project" });
 
-    this.scope("jamises", (q: any) => q.where({ name: "Jamis" }));
+    this.scope("jamises", function (this: any) {
+      return this.where({ name: "Jamis" });
+    });
 
     this.validates("salary", {
       inclusion: { in: { includes: (v: unknown) => Number(v) >= 50000 && Number(v) <= 200000 } },
@@ -352,7 +354,9 @@ export class DeveloperOrderedBySalary extends Base {
     this.aliasAttribute("created_on", "legacy_created_on");
     this.aliasAttribute("updated_on", "legacy_updated_on");
     this.defaultScope((q: any) => q.order("salary DESC"));
-    this.scope("byName", (q: any) => q.order("name DESC"));
+    this.scope("byName", function (this: any) {
+      return this.order("name DESC");
+    });
   }
 }
 
@@ -401,7 +405,9 @@ export class ClassMethodReferencingScopeDeveloperCalledDavid extends Base {
 
   static {
     this.tableName = "developers";
-    this.scope("david", (q: any) => q.where({ name: "David" }));
+    this.scope("david", function (this: any) {
+      return this.where({ name: "David" });
+    });
   }
 
   // Method-form override referencing a named scope (Rails: `def self.default_scope; david; end`).
@@ -415,7 +421,9 @@ export class LazyBlockReferencingScopeDeveloperCalledDavid extends Base {
 
   static {
     this.tableName = "developers";
-    this.scope("david", (q: any) => q.where({ name: "David" }));
+    this.scope("david", function (this: any) {
+      return this.where({ name: "David" });
+    });
     this.defaultScope((q: any) => (LazyBlockReferencingScopeDeveloperCalledDavid as any).david());
   }
 }
@@ -432,9 +440,15 @@ export class DeveloperCalledJamis extends Base {
     this.aliasAttribute("created_on", "legacy_created_on");
     this.aliasAttribute("updated_on", "legacy_updated_on");
     this.defaultScope((q: any) => q.where({ name: "Jamis" }));
-    this.scope("poor", (q: any) => q.where("salary < 150000"));
-    this.scope("david", (q: any) => q.where({ name: "David" }));
-    this.scope("david2", (q: any) => q.unscoped().where({ name: "David" }));
+    this.scope("poor", function (this: any) {
+      return this.where("salary < 150000");
+    });
+    this.scope("david", function (this: any) {
+      return this.where({ name: "David" });
+    });
+    this.scope("david2", function (this: any) {
+      return this.unscoped().where({ name: "David" });
+    });
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/member.ts
+++ b/packages/activerecord/src/test-helpers/models/member.ts
@@ -140,8 +140,12 @@ export class Member extends Base {
     this.belongsTo("admittable", { polymorphic: true });
     this.hasOne("premiumClub", { through: "admittable" });
 
-    this.scope("unnamed", (q: any) => q.where({ name: null }));
-    this.scope("withMemberTypeId", (q: any, id: number) => q.where({ member_type_id: id }));
+    this.scope("unnamed", function (this: any) {
+      return this.where({ name: null });
+    });
+    this.scope("withMemberTypeId", function (this: any, id: number) {
+      return this.where({ member_type_id: id });
+    });
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/organization.ts
+++ b/packages/activerecord/src/test-helpers/models/organization.ts
@@ -33,6 +33,8 @@ export class Organization extends Base {
 
     this.hasMany("posts", { through: "author", source: "posts" });
 
-    this.scope("clubs", (q: any) => q.from("clubs"));
+    this.scope("clubs", function (this: any) {
+      return this.from("clubs");
+    });
   }
 }

--- a/packages/activerecord/src/test-helpers/models/owner.ts
+++ b/packages/activerecord/src/test-helpers/models/owner.ts
@@ -29,10 +29,9 @@ export class Owner extends Base {
     this.hasMany("toys", { through: "pets" });
     this.hasMany("persons", { through: "pets" });
     this.belongsTo("lastPet", { className: "Pet" });
-    this.scope("includingLastPet", (q: any) =>
-      q
-        .select(
-          `
+    this.scope("includingLastPet", function (this: any) {
+      return this.select(
+        `
           owners.*, (
             select p.pet_id from pets p
             where p.owner_id = owners.owner_id
@@ -40,9 +39,8 @@ export class Owner extends Base {
             limit 1
           ) as last_pet_id
         `,
-        )
-        .includes(":lastPet"),
-    );
+      ).includes(":lastPet");
+    });
     this.afterCommit(async (owner: Owner) => {
       await owner.executeBlocks();
     });

--- a/packages/activerecord/src/test-helpers/models/person.ts
+++ b/packages/activerecord/src/test-helpers/models/person.ts
@@ -133,7 +133,9 @@ export class Person extends Base {
     this.hasMany("agentsPostsAuthors", { through: "agentsPosts", source: "author" });
     this.hasMany("essays", { primaryKey: "first_name", foreignKey: "writer_id" });
 
-    this.scope("males", (q: any) => q.where({ gender: "M" }));
+    this.scope("males", function (this: any) {
+      return this.where({ gender: "M" });
+    });
 
     this.attrReadonly("born_at");
   }

--- a/packages/activerecord/src/test-helpers/models/post.ts
+++ b/packages/activerecord/src/test-helpers/models/post.ts
@@ -188,41 +188,59 @@ export class Post extends Base {
     this.aliasAttribute("text", "body");
     this.aliasAttribute("comments_count", "legacy_comments_count");
 
-    this.scope("containingTheLetterA", (q: any) => q.where("body LIKE '%a%'"));
-    this.scope("titledWithAnApostrophe", (q: any) => q.where("title LIKE '%''%'"));
-    this.scope("rankedByComments", (q: any) =>
-      q.order(q.model.arelTable.get("comments_count").desc()),
-    );
-    this.scope("orderedByPostId", (q: any) => q.order("posts.post_id ASC"));
-    this.scope("limitBy", (q: any, l: number) => q.limit(l));
-    this.scope("locked", (q: any) => q.lock());
-    this.scope("mostCommented", (q: any, commentsCount: number) =>
-      q.joins(":comments").group("posts.id").having("count(comments.id) >= ?", commentsCount),
-    );
+    this.scope("containingTheLetterA", function (this: any) {
+      return this.where("body LIKE '%a%'");
+    });
+    this.scope("titledWithAnApostrophe", function (this: any) {
+      return this.where("title LIKE '%''%'");
+    });
+    this.scope("rankedByComments", function (this: any) {
+      return this.order(this.model.arelTable.get("comments_count").desc());
+    });
+    this.scope("orderedByPostId", function (this: any) {
+      return this.order("posts.post_id ASC");
+    });
+    this.scope("limitBy", function (this: any, l: number) {
+      return this.limit(l);
+    });
+    this.scope("locked", function (this: any) {
+      return this.lock();
+    });
+    this.scope("mostCommented", function (this: any, commentsCount: number) {
+      return this.joins(":comments")
+        .group("posts.id")
+        .having("count(comments.id) >= ?", commentsCount);
+    });
 
-    this.scope("noComments", (q: any) =>
-      q.leftJoins(":comments").where({ comments: { id: null } }),
-    );
-    this.scope("withSpecialComments", (q: any) =>
-      q.joins(":comments").where({ comments: { type: "SpecialComment" } }),
-    );
-    this.scope("withVerySpecialComments", (q: any) =>
-      q.joins(":comments").where({ comments: { type: "VerySpecialComment" } }),
-    );
-    this.scope("withPost", (q: any, postId: number) =>
-      q.joins(":comments").where({ comments: { post_id: postId } }),
-    );
-    this.scope("withComments", (q: any) => q.preload(":comments"));
-    this.scope("withTags", (q: any) => q.preload(":taggings"));
-    this.scope("withTagsCte", (q: any) =>
-      q.with({ posts_with_tags: q.model.where("tags_count > 0") }).from("posts_with_tags AS posts"),
-    );
-    this.scope("taggedWith", (q: any, id: number) =>
-      q.joins(":taggings").where({ taggings: { tag_id: id } }),
-    );
-    this.scope("taggedWithComment", (q: any, comment: string) =>
-      q.joins(":taggings").where({ taggings: { comment } }),
-    );
+    this.scope("noComments", function (this: any) {
+      return this.leftJoins(":comments").where({ comments: { id: null } });
+    });
+    this.scope("withSpecialComments", function (this: any) {
+      return this.joins(":comments").where({ comments: { type: "SpecialComment" } });
+    });
+    this.scope("withVerySpecialComments", function (this: any) {
+      return this.joins(":comments").where({ comments: { type: "VerySpecialComment" } });
+    });
+    this.scope("withPost", function (this: any, postId: number) {
+      return this.joins(":comments").where({ comments: { post_id: postId } });
+    });
+    this.scope("withComments", function (this: any) {
+      return this.preload(":comments");
+    });
+    this.scope("withTags", function (this: any) {
+      return this.preload(":taggings");
+    });
+    this.scope("withTagsCte", function (this: any) {
+      return this.with({ posts_with_tags: this.model.where("tags_count > 0") }).from(
+        "posts_with_tags AS posts",
+      );
+    });
+    this.scope("taggedWith", function (this: any, id: number) {
+      return this.joins(":taggings").where({ taggings: { tag_id: id } });
+    });
+    this.scope("taggedWithComment", function (this: any, comment: string) {
+      return this.joins(":taggings").where({ taggings: { comment } });
+    });
     // Rails: `-> { containing_the_letter_a.or(titled_with_an_apostrophe) }` —
     // each bare scope call resolves against the lambda's `self` (the current
     // relation), so both `or` branches inherit `q`'s accumulated scope. trails
@@ -234,9 +252,9 @@ export class Post extends Base {
     // to (`q.where(A)`) — which keeps the per-branch scoping `q.where(A).or(
     // q.where(B))` without evaluating the scopes from `Post.all()` (avoids
     // re-applying any future default scope).
-    this.scope("typographicallyInteresting", (q: any) =>
-      q.where("body LIKE '%a%'").or(q.where("title LIKE '%''%'")),
-    );
+    this.scope("typographicallyInteresting", function (this: any) {
+      return this.where("body LIKE '%a%'").or(this.where("title LIKE '%''%'"));
+    });
 
     this.belongsTo("author");
     this.belongsTo("readonlyAuthor", (q: any) => q.readonly(), {
@@ -825,8 +843,12 @@ export class SpecialPostWithDefaultScope extends Base {
     this.inheritanceColumn = "disabled";
     this._tableName = "posts";
     this.defaultScope((q: any) => q.where({ id: [1, 5, 6] }));
-    this.scope("unscopedAll", (q: any) => q.model.unscoped(() => q.model.all()));
-    this.scope("authorless", (q: any) => q.model.unscoped(() => q.model.where({ author_id: 0 })));
+    this.scope("unscopedAll", function (this: any) {
+      return this.model.unscoped(() => this.model.all());
+    });
+    this.scope("authorless", function (this: any) {
+      return this.model.unscoped(() => this.model.where({ author_id: 0 }));
+    });
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/project.ts
+++ b/packages/activerecord/src/test-helpers/models/project.ts
@@ -102,7 +102,9 @@ export class Project extends Base {
       this.developersLog = [];
     });
 
-    this.scope("allAsScope", (q: any) => q.all());
+    this.scope("allAsScope", function (this: any) {
+      return this.all();
+    });
   }
 
   static allAsMethod() {

--- a/packages/activerecord/src/test-helpers/models/reader.ts
+++ b/packages/activerecord/src/test-helpers/models/reader.ts
@@ -59,7 +59,9 @@ export class LazyReader extends Base {
   static {
     this._tableName = "readers";
     this.defaultScope((q: any) => q.where({ skimmer: true }));
-    this.scope("skimmersOrNot", (q: any) => q.unscope({ where: "skimmer" }));
+    this.scope("skimmersOrNot", function (this: any) {
+      return this.unscope({ where: "skimmer" });
+    });
     this.belongsTo("post");
     this.belongsTo("person");
   }

--- a/packages/activerecord/src/test-helpers/models/topic.ts
+++ b/packages/activerecord/src/test-helpers/models/topic.ts
@@ -51,33 +51,66 @@ export class Topic extends Base {
   declare written_on: Temporal.Instant | Temporal.PlainDateTime;
 
   static {
-    this.scope("base", (q: any) => q.all());
-    this.scope("writtenBefore", (q: any, time: any) =>
-      time ? q.where("written_on < ?", time) : q,
-    );
-    this.scope("approved", (q: any) => q.where({ approved: true }));
-    this.scope("rejected", (q: any) => q.where({ approved: false }));
-    this.scope("children", (q: any) => q.where().not({ parent_id: null }));
-    this.scope("hasChildren", (q: any) => q.where({ id: q.model.children().select("parent_id") }));
-    this.scope("byLifo", (q: any) => q.where({ author_name: "lifo" }));
-    this.scope("replied", (q: any) => q.where("replies_count > 0"));
+    this.scope("base", function (this: any) {
+      return this.all();
+    });
+    this.scope("writtenBefore", function (this: any, time: any) {
+      return time ? this.where("written_on < ?", time) : this;
+    });
+    this.scope("approved", function (this: any) {
+      return this.where({ approved: true });
+    });
+    this.scope("rejected", function (this: any) {
+      return this.where({ approved: false });
+    });
+    this.scope("children", function (this: any) {
+      return this.where().not({ parent_id: null });
+    });
+    this.scope("hasChildren", function (this: any) {
+      return this.where({ id: this.model.children().select("parent_id") });
+    });
+    this.scope("byLifo", function (this: any) {
+      return this.where({ author_name: "lifo" });
+    });
+    this.scope("replied", function (this: any) {
+      return this.where("replies_count > 0");
+    });
     // "true"/"false" are reserved words; call via bracket notation: Topic["true"]()
-    this.scope("true", (q: any) => q.where({ approved: true }));
-    this.scope("false", (q: any) => q.where({ approved: false }));
-    this.scope("scopeWithLambda", (q: any) => q.all());
-    this.scope("approvedAsString", (q: any) => q.where({ approved: true }));
-    this.scope("anonymousExtension", (q: any) => q, { one: () => 1 });
+    this.scope("true", function (this: any) {
+      return this.where({ approved: true });
+    });
+    this.scope("false", function (this: any) {
+      return this.where({ approved: false });
+    });
+    this.scope("scopeWithLambda", function (this: any) {
+      return this.all();
+    });
+    this.scope("approvedAsString", function (this: any) {
+      return this.where({ approved: true });
+    });
+    this.scope(
+      "anonymousExtension",
+      function (this: any) {
+        return this;
+      },
+      { one: () => 1 },
+    );
     // Rails topic.rb: `scope :scope_stats, -> stats { stats[:count] = count; self }`.
     // The scope body mutates the passed stats hash with the relation's count and
     // returns the relation (`self`). trails relations count asynchronously, so the
     // body is async — the lone faithful divergence from Rails' sync `count`.
-    this.scope("scopeStats", ((q: any, stats: { count?: number }) =>
-      q.count().then((c: number) => {
+    this.scope("scopeStats", function (this: any, stats: { count?: number }) {
+      return this.count().then((c: number) => {
         stats.count = c;
-        return q;
-      })) as any);
-    this.scope("withObject", (q: any) => q.where({ approved: true }));
-    this.scope("withKwargs", (q: any, approved = false) => q.where({ approved }));
+        return this;
+      });
+    } as any);
+    this.scope("withObject", function (this: any) {
+      return this.where({ approved: true });
+    });
+    this.scope("withKwargs", function (this: any, approved = false) {
+      return this.where({ approved });
+    });
 
     this.hasMany("replies", { dependent: "destroy", autosave: true, inverseOf: "topic" });
     this.hasMany("approvedReplies", {

--- a/packages/activerecord/src/test-helpers/models/toy.ts
+++ b/packages/activerecord/src/test-helpers/models/toy.ts
@@ -22,7 +22,9 @@ export class Toy extends Base {
   static {
     this.belongsTo("pet");
     this.hasMany("sponsors", { as: "sponsorable", inverseOf: "sponsorable" });
-    this.scope("withPet", (q: any) => q.joins(":pet"));
+    this.scope("withPet", function (this: any) {
+      return this.joins(":pet");
+    });
   }
 }
 

--- a/packages/activerecord/src/type-virtualization/fixtures/05-scope/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/05-scope/expected.ts
@@ -3,7 +3,11 @@ export class Post extends Base {
   declare static recent: (limit: number) => import("@blazetrails/activerecord").Relation<Post>;
 
   static {
-    this.scope("published", (rel) => rel.where({ published: true }));
-    this.scope("recent", (rel, limit: number) => rel.order("created_at").limit(limit));
+    this.scope("published", function (this: any) {
+      return this.where({ published: true });
+    });
+    this.scope("recent", function (this: any, limit: number) {
+      return this.order("created_at").limit(limit);
+    });
   }
 }

--- a/packages/activerecord/src/type-virtualization/fixtures/05-scope/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/05-scope/input.ts
@@ -1,6 +1,10 @@
 export class Post extends Base {
   static {
-    this.scope("published", (rel) => rel.where({ published: true }));
-    this.scope("recent", (rel, limit: number) => rel.order("created_at").limit(limit));
+    this.scope("published", function (this: any) {
+      return this.where({ published: true });
+    });
+    this.scope("recent", function (this: any, limit: number) {
+      return this.order("created_at").limit(limit);
+    });
   }
 }

--- a/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/08-combined/expected.ts
@@ -11,6 +11,8 @@ export class Post extends Base {
     this.attribute("published", "boolean");
     this.belongsTo("author");
     this.hasMany("comments");
-    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("published", function (this: any) {
+      return this.where({ published: true });
+    });
   }
 }

--- a/packages/activerecord/src/type-virtualization/fixtures/08-combined/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/08-combined/input.ts
@@ -4,6 +4,8 @@ export class Post extends Base {
     this.attribute("published", "boolean");
     this.belongsTo("author");
     this.hasMany("comments");
-    this.scope("published", (rel) => rel.where({ published: true }));
+    this.scope("published", function (this: any) {
+      return this.where({ published: true });
+    });
   }
 }

--- a/packages/activerecord/src/type-virtualization/fixtures/22-scope-default-param/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/22-scope-default-param/expected.ts
@@ -6,10 +6,20 @@ export class Topic extends Base {
   declare static untypedRest: (...args: unknown[]) => import("@blazetrails/activerecord").Relation<Topic>;
 
   static {
-    this.scope("withKwargs", (rel, approved = false) => rel.where({ approved }));
-    this.scope("limited", (rel, limit: number, offset = 0) => rel.limit(limit).offset(offset));
-    this.scope("named", (rel, name = "draft") => rel.where({ name }));
-    this.scope("typedRest", (rel, ...ids: number[]) => rel.where({ id: ids }));
-    this.scope("untypedRest", (rel, ...args) => rel.where({ args }));
+    this.scope("withKwargs", function (this: any, approved = false) {
+      return this.where({ approved });
+    });
+    this.scope("limited", function (this: any, limit: number, offset = 0) {
+      return this.limit(limit).offset(offset);
+    });
+    this.scope("named", function (this: any, name = "draft") {
+      return this.where({ name });
+    });
+    this.scope("typedRest", function (this: any, ...ids: number[]) {
+      return this.where({ id: ids });
+    });
+    this.scope("untypedRest", function (this: any, ...args: unknown[]) {
+      return this.where({ args });
+    });
   }
 }

--- a/packages/activerecord/src/type-virtualization/fixtures/22-scope-default-param/input.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/22-scope-default-param/input.ts
@@ -1,9 +1,19 @@
 export class Topic extends Base {
   static {
-    this.scope("withKwargs", (rel, approved = false) => rel.where({ approved }));
-    this.scope("limited", (rel, limit: number, offset = 0) => rel.limit(limit).offset(offset));
-    this.scope("named", (rel, name = "draft") => rel.where({ name }));
-    this.scope("typedRest", (rel, ...ids: number[]) => rel.where({ id: ids }));
-    this.scope("untypedRest", (rel, ...args) => rel.where({ args }));
+    this.scope("withKwargs", function (this: any, approved = false) {
+      return this.where({ approved });
+    });
+    this.scope("limited", function (this: any, limit: number, offset = 0) {
+      return this.limit(limit).offset(offset);
+    });
+    this.scope("named", function (this: any, name = "draft") {
+      return this.where({ name });
+    });
+    this.scope("typedRest", function (this: any, ...ids: number[]) {
+      return this.where({ id: ids });
+    });
+    this.scope("untypedRest", function (this: any, ...args: unknown[]) {
+      return this.where({ args });
+    });
   }
 }

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -515,7 +515,7 @@ function renderSingularAssoc(
 }
 
 function renderScope(info: ClassInfo, call: ScopeCall): RenderedLine[] {
-  const argList = call.paramsAfterRel.length === 0 ? "" : call.paramsAfterRel.join(", ");
+  const argList = call.paramsAfterThis.length === 0 ? "" : call.paramsAfterThis.join(", ");
   return [
     line(
       `declare static ${call.name}: (${argList}) => ${AR_IMPORT}.Relation<${info.name}>;`,

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -402,9 +402,9 @@ function readScopeCall(call: ts.CallExpression): ScopeCall | null {
   if (!ts.isArrowFunction(fnArg) && !ts.isFunctionExpression(fnArg)) {
     return { kind: "scope", name: nameArg.text, paramsAfterThis: [] };
   }
-  // A `this` parameter is a type-position annotation, not an argument, so it
-  // is the only leading parameter dropped here.
-  const rest = fnArg.parameters.filter((p) => p.name.getText() !== "this");
+  // A leading `this` parameter is a type-position annotation, not an argument.
+  const params = fnArg.parameters;
+  const rest = params.length > 0 && params[0].name.getText() === "this" ? params.slice(1) : params;
   return {
     kind: "scope",
     name: nameArg.text,

--- a/packages/activerecord/src/type-virtualization/walker.ts
+++ b/packages/activerecord/src/type-virtualization/walker.ts
@@ -33,10 +33,12 @@ export interface AssociationCall {
 export interface ScopeCall {
   kind: "scope";
   name: string;
-  // Parameter list of the inline scope function, with the leading `rel`
-  // parameter removed. Each element is the raw source text of a parameter
+  // Parameter list of the inline scope function, with the leading `this`
+  // parameter removed — a scope body receives the relation as its receiver
+  // (`_exec_scope`'s `instance_exec`), so only the positionals after it are
+  // callable arguments. Each element is the raw source text of a parameter
   // (e.g. "limit: number", "name = \"draft\"").
-  paramsAfterRel: string[];
+  paramsAfterThis: string[];
 }
 
 export interface EnumCall {
@@ -396,15 +398,17 @@ function readAssociationCall(
 function readScopeCall(call: ts.CallExpression): ScopeCall | null {
   const [nameArg, fnArg] = call.arguments;
   if (!nameArg || !ts.isStringLiteralLike(nameArg)) return null;
-  if (!fnArg) return { kind: "scope", name: nameArg.text, paramsAfterRel: [] };
+  if (!fnArg) return { kind: "scope", name: nameArg.text, paramsAfterThis: [] };
   if (!ts.isArrowFunction(fnArg) && !ts.isFunctionExpression(fnArg)) {
-    return { kind: "scope", name: nameArg.text, paramsAfterRel: [] };
+    return { kind: "scope", name: nameArg.text, paramsAfterThis: [] };
   }
-  const [, ...rest] = fnArg.parameters;
+  // A `this` parameter is a type-position annotation, not an argument, so it
+  // is the only leading parameter dropped here.
+  const rest = fnArg.parameters.filter((p) => p.name.getText() !== "this");
   return {
     kind: "scope",
     name: nameArg.text,
-    paramsAfterRel: rest.map(renderScopeParam),
+    paramsAfterThis: rest.map(renderScopeParam),
   };
 }
 

--- a/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
+++ b/packages/activerecord/virtualized-dx-tests/virtualized-patterns.test-d.ts
@@ -64,10 +64,12 @@ class Post extends Base {
   static {
     this.attribute("title", "string");
     this.attribute("published", "boolean");
-    this.scope("published", (rel: Relation<Post>) => rel.where({ published: true }));
-    this.scope("recent", (rel: Relation<Post>, sinceDays: number) => {
+    this.scope("published", function (this: Relation<Post>) {
+      return this.where({ published: true });
+    });
+    this.scope("recent", function (this: Relation<Post>, sinceDays: number) {
       void sinceDays;
-      return rel.where({});
+      return this.where({});
     });
   }
 }

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -217,7 +217,7 @@ declare the scope signatures on their Relation type.
 
 ## 6. Named scopes: stored, not metaprogrammed
 
-`scope("published", (rel) => rel.where({ published: true }))` stores
+`scope("published", function () { return this.where({ published: true }); })` stores
 the function in a `_scopes` Map on the class and defines a static
 method that delegates through `all()`. The Relation proxy above picks
 the scope up on relation instances. See
@@ -454,7 +454,9 @@ class Post extends Base {
     // `this`, no not* scopes).
     defineEnum(this, "status", { draft: 0, published: 1 });
     // Named scope — use a name that doesn't collide with an enum value above.
-    this.scope("featured", (rel) => rel.where({ featured: true }));
+    this.scope("featured", function () {
+      return this.where({ featured: true });
+    });
   }
 }
 ```

--- a/packages/website/docs/guides/idioms.md
+++ b/packages/website/docs/guides/idioms.md
@@ -53,7 +53,9 @@ class Post extends Base {
       record.title = record.title.trim();
     });
 
-    Post.scope("published", (rel) => rel.where({ published: true }));
+    Post.scope("published", function () {
+      return this.where({ published: true });
+    });
   }
 }
 


### PR DESCRIPTION
Two RFC 0112 deviation-convergence stories.

## 1. `_exec_scope` no longer takes an explicit callable

Rails (`activerecord/lib/active_record/relation.rb:552-558`):

```ruby
def _exec_scope(...)
  @delegate_to_model = true
  registry = model.scope_registry
  _scoping(nil, registry) { instance_exec(...) || self }
ensure
  @delegate_to_model = false
end
```

`(...)` forwards the caller's block and `instance_exec` binds `self` to the
relation. trails took the body as a leading positional parameter and passed the
relation in as the block's first argument, which is why every scope body read
`(q) => q.where(...)`.

Now the body arrives as the **trailing** argument — the settled trails spelling
of a Ruby block, since a JS function carries no implicit one — and
`body.call(this, ...args)` is `instance_exec`'s rebinding. `_execScope` itself
takes only `...args`, matching Rails' forwarding signature, and a scope body is
written against `this`:

```ts
this.scope("containingTheLetterA", function () {
  return this.where("body LIKE '%a%'");
});
```

Swept accordingly: `test-helpers/models/**`, `scoping/named-scoping.test.ts`,
`scoping/default-scoping.test.ts`, the generated scopes in `enum.ts` and
`delegated-type.ts`, the type-virtualization fixtures, dx-tests /
virtualized-dx-tests, and the README + website guides.

`type-virtualization/walker.ts` drops a **leading `this` parameter** (a
type-position annotation, never an argument) instead of the first positional, so
the synthesized `declare static <scope>` signatures are byte-identical —
`pnpm test:types:virtualized` confirms.

The acceptance criterion naming
`scripts/prism-codegen/convergence-baseline.json`'s
`active_record/relation.rb::_execScope::divergent` row has nothing to act on in
this repo: that file was deleted in `311bff350` (the prism-codegen retirement),
so the criterion is vacuously satisfied. Nothing was added to any baseline.

## 2. `strict_mode?` was a hardcoded `false`

`abstract_mysql_adapter.rb:630-632`:

```ruby
def strict_mode?
  self.class.type_cast_config_to_boolean(@config.fetch(:strict, true))
end
```

trails returned a flat `false`, and nothing called it — the real decision was
re-derived inline in `Mysql2Adapter#_buildInitSql` off a destructured `strict`
pool-config field. `isStrictMode` now mirrors the Ruby, including
`fetch(:strict, true)` semantics (absent key ⇒ strict; a stored `false` wins;
`":default"` passes through `type_cast_config_to_boolean` for the
`defaults.include?` check at rb:928), and `_buildInitSql`'s sql_mode arms read
the predicate (rb:928-936) rather than the field. The `fetch` helper is the same
file-local one `postgresql-adapter.ts:177-181` already carries.

Three regression tests in `mysql2-adapter.build-init-sql.trails.test.ts`; the
default-true one fails on baseline (`isStrictMode()` returned `false`).

## Not in this PR

`hoist-schema-load-and-deferred-pk-materialization-out-of-ported-bodies` was
released back to the queue: with the scope-body sweep above this PR is already
562 LOC, and that story's converged shape (materialize deferred distinct-PK
predicates at `.where()`-build time) needs an async `where()`, so it is a
design decision rather than a mechanical hoist.

## Verification

`pnpm parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate`,
`pnpm lint`, `pnpm typecheck`, `guides:typecheck`, `test:types`,
`test:types:virtualized` all green. AR (sqlite): `scoping/**`, `relations`,
`associations`, `enum`, `delegated-type` green; the MySQL init-SQL tests run
green against a local `mariadb:11`.

Closes-story: exec-scope-takes-explicit-fn-instead-of-instance-exec
Closes-story: mysql-strict-mode-predicate-hardcoded-false

