### PR TITLE
refactor(activerecord): one uniqueness registrar, reflection-owned checkKlass, module-level db_warnings_ignore (RFC 0112, RFC 0119)

### DIFF
--- a/packages/activerecord/dx-tests/edge-cases.test-d.ts
+++ b/packages/activerecord/dx-tests/edge-cases.test-d.ts
@@ -61,10 +61,10 @@ describe("edge cases — rough edges in current DX", () => {
     expectTypeOf<ReturnType<typeof Base.defaultScope>>().toEqualTypeOf<void>();
   });
 
-  it("validates + validatesAssociated + validatesUniqueness are void-returning", () => {
+  it("validates + validatesAssociated + validatesUniquenessOf are void-returning", () => {
     expectTypeOf<ReturnType<typeof Base.validates>>().toEqualTypeOf<void>();
     expectTypeOf<ReturnType<typeof Base.validatesAssociated>>().toEqualTypeOf<void>();
-    expectTypeOf<ReturnType<typeof Base.validatesUniqueness>>().toEqualTypeOf<void>();
+    expectTypeOf<ReturnType<typeof Base.validatesUniquenessOf>>().toEqualTypeOf<void>();
   });
 
   it("Base.find / Base.all / Base.where preserve the subclass via polymorphic `this`", async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/case-sensitivity.test.ts
@@ -45,7 +45,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("case insensitive comparison for ci column", async () => {
       const CollationTest = collationTestModel();
-      CollationTest.validatesUniqueness("string_ci_column", { caseSensitive: false });
+      CollationTest.validatesUniquenessOf("string_ci_column", { caseSensitive: false });
       await CollationTest.create({ string_ci_column: "A" });
       const invalid = new CollationTest({ string_ci_column: "a" });
       const queries = await captureSql(async () => {
@@ -57,7 +57,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("case insensitive comparison for cs column", async () => {
       const CollationTest = collationTestModel();
-      CollationTest.validatesUniqueness("string_cs_column", { caseSensitive: false });
+      CollationTest.validatesUniquenessOf("string_cs_column", { caseSensitive: false });
       await CollationTest.create({ string_cs_column: "A" });
       const invalid = new CollationTest({ string_cs_column: "a" });
       const queries = await captureSql(async () => {
@@ -69,7 +69,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("case sensitive comparison for ci column", async () => {
       const CollationTest = collationTestModel();
-      CollationTest.validatesUniqueness("string_ci_column", { caseSensitive: true });
+      CollationTest.validatesUniquenessOf("string_ci_column", { caseSensitive: true });
       await CollationTest.create({ string_ci_column: "A" });
       const invalid = new CollationTest({ string_ci_column: "A" });
       const queries = await captureSql(async () => {
@@ -81,7 +81,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("case sensitive comparison for cs column", async () => {
       const CollationTest = collationTestModel();
-      CollationTest.validatesUniqueness("string_cs_column", { caseSensitive: true });
+      CollationTest.validatesUniquenessOf("string_cs_column", { caseSensitive: true });
       await CollationTest.create({ string_cs_column: "A" });
       const invalid = new CollationTest({ string_cs_column: "A" });
       const queries = await captureSql(async () => {
@@ -93,7 +93,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("case sensitive comparison for binary column", async () => {
       const CollationTest = collationTestModel();
-      CollationTest.validatesUniqueness("binary_column", { caseSensitive: true });
+      CollationTest.validatesUniquenessOf("binary_column", { caseSensitive: true });
       await CollationTest.create({ binary_column: "A" });
       const invalid = new CollationTest({ binary_column: "A" });
       const queries = await captureSql(async () => {

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -607,7 +607,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         static tableName = "pg_arrays";
         static {
           this.attribute("id", "integer");
-          this.validatesUniqueness("tags");
+          this.validatesUniquenessOf("tags");
         }
       }
       await PgArrays.loadSchema();

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -103,17 +103,17 @@ async function withExtensionEnabled(
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   let savedWarningsAction: typeof ActiveRecord.dbWarningsAction;
-  let savedWarningsIgnore: typeof PostgreSQLAdapter.dbWarningsIgnore;
+  let savedWarningsIgnore: typeof ActiveRecord.dbWarningsIgnore;
 
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     savedWarningsAction = ActiveRecord.dbWarningsAction;
-    savedWarningsIgnore = PostgreSQLAdapter.dbWarningsIgnore;
+    savedWarningsIgnore = ActiveRecord.dbWarningsIgnore;
   });
 
   afterEach(async () => {
     ActiveRecord.dbWarningsAction = savedWarningsAction ?? "ignore";
-    PostgreSQLAdapter.dbWarningsIgnore = savedWarningsIgnore;
+    ActiveRecord.dbWarningsIgnore = savedWarningsIgnore;
     vi.restoreAllMocks();
     if (adapter.isConnected()) {
       try {
@@ -877,7 +877,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("allowlist of warnings to ignore", async () => {
       ActiveRecord.dbWarningsAction = "raise";
-      PostgreSQLAdapter.dbWarningsIgnore = [/PostgreSQL SQL warning/];
+      ActiveRecord.dbWarningsIgnore = [/PostgreSQL SQL warning/];
       const rows = await adapter.execute(
         "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$",
       );
@@ -886,7 +886,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("allowlist of warning codes to ignore", async () => {
       ActiveRecord.dbWarningsAction = "raise";
-      PostgreSQLAdapter.dbWarningsIgnore = ["01000"];
+      ActiveRecord.dbWarningsIgnore = ["01000"];
       const rows = await adapter.execute(
         "do $$ BEGIN RAISE WARNING 'PostgreSQL SQL warning'; END; $$",
       );

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -816,14 +816,14 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     let savedWarningsAction: typeof ActiveRecord.dbWarningsAction;
-    let savedWarningsIgnore: typeof PostgreSQLAdapter.dbWarningsIgnore;
+    let savedWarningsIgnore: typeof ActiveRecord.dbWarningsIgnore;
     beforeEach(() => {
       savedWarningsAction = ActiveRecord.dbWarningsAction;
-      savedWarningsIgnore = PostgreSQLAdapter.dbWarningsIgnore;
+      savedWarningsIgnore = ActiveRecord.dbWarningsIgnore;
     });
     afterEach(() => {
       ActiveRecord.dbWarningsAction = savedWarningsAction ?? "ignore";
-      PostgreSQLAdapter.dbWarningsIgnore = savedWarningsIgnore;
+      ActiveRecord.dbWarningsIgnore = savedWarningsIgnore;
       vi.restoreAllMocks();
     });
   });

--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -632,7 +632,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           static tableName = "uuid_uniqueness_validation_test";
           static {
             this.attribute("id", "integer");
-            this.validatesUniqueness("guid", { caseSensitive: false });
+            this.validatesUniquenessOf("guid", { caseSensitive: false });
           }
         }
         await UuidUniq.loadSchema();

--- a/packages/activerecord/src/ar-config.ts
+++ b/packages/activerecord/src/ar-config.ts
@@ -267,6 +267,14 @@ export const ActiveRecord = {
   },
 
   /**
+   * Allow-list of warning messages or codes to skip whatever
+   * `dbWarningsAction` is. Read once, by `AbstractAdapter#isWarningIgnored`
+   * (abstract_adapter.rb:1227-1231). Mirrors
+   * `ActiveRecord.db_warnings_ignore` (active_record.rb:259-263, default `[]`).
+   */
+  dbWarningsIgnore: [] as (string | RegExp)[],
+
+  /**
    * Determines whether to use UTC (`"utc"`) or the local zone (`"local"`) when
    * pulling dates and times from the database. Mirrors
    * `ActiveRecord.default_timezone` (active_record.rb:214-226, default :utc).

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -1,28 +1,14 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
-import {
-  autoloadModel,
-  _preloadedHolderTarget,
-  _associateRecordsToOwner,
-} from "../associations.js";
+import { _preloadedHolderTarget, _associateRecordsToOwner } from "../associations.js";
 import { AssociationScope, type AssociationScopeable } from "./association-scope.js";
 import { associationKeysEqual } from "./key-normalization.js";
 import { getDjasScopeBuilder, getAssociationRelationFactory } from "./_scope-slots.js";
 import { validateReflectionValidity } from "./validate-through-reflection.js";
 import { ThroughAssociation } from "./through-association.js";
 import { parkNestedReaderLoad } from "../nested-attributes.js";
-import {
-  camelize,
-  constantize,
-  except,
-  safeConstantize,
-  singularize,
-} from "@blazetrails/activesupport";
-import {
-  AssociationTargetReplacedDuringLoad,
-  AssociationTypeMismatch,
-  NameError,
-} from "../errors.js";
+import { camelize, except, safeConstantize, singularize } from "@blazetrails/activesupport";
+import { AssociationTargetReplacedDuringLoad, AssociationTypeMismatch } from "../errors.js";
 
 /**
  * Back an ad-hoc definition with the registered reflection for its name, so an
@@ -221,34 +207,16 @@ export class Association {
    * raises synchronously for unknown classes. Skipped for polymorphic, through,
    * and anonymous-class associations (HABTM join model side).
    */
-  protected checkKlass(): void {
+  protected checkKlass(): typeof Base | undefined {
     const opts = this.reflection.options as AssociationOptions & { anonymousClass?: unknown };
-    if (opts.polymorphic || opts.through || opts.anonymousClass) return;
-    const name = this.reflection.name;
-    // Prefer the rich reflection's klass getter — it does Ruby-style
-    // namespace-relative resolution (compute_class → compute_type), so a
-    // convention `belongs_to :region` on Admin::RegionalUser resolves to
-    // Admin::Region rather than a bare top-level "Region". On failure fall
-    // through to the bare lookup below, which raises the faithful NameError
-    // Rails' check_validity! surfaces for a genuinely missing class.
-    const ctor = this.owner.constructor as typeof Base & {
-      _reflectOnAssociation?: (n: string) => { klass?: typeof Base } | null;
-    };
-    try {
-      if (ctor._reflectOnAssociation?.(name)?.klass) return;
-    } catch (e) {
-      // Rails rescues only the missing-constant NameError from compute_class and
-      // re-raises anything else — notably the ArgumentError "resolved constant is
-      // not an ActiveRecord::Base subclass" guard (reflection.rb:495-508). Mirror
-      // that: a missing-class NameError falls through to the constant lookup
-      // below (which re-raises the same faithful NameError); every other error
-      // — config/reflection failures — propagates unchanged.
-      if (!(e instanceof NameError)) throw e;
-    }
-    const className =
-      opts.className ?? camelize(this.reflection.macro === "hasMany" ? singularize(name) : name);
-    autoloadModel(className);
-    constantize(className);
+    if (opts.polymorphic || opts.through || opts.anonymousClass) return undefined;
+    // One derivation, on the reflection: `klass` is `reflection.klass`
+    // (association.rb:36-38), whose `compute_class` raises the faithful
+    // NameError for an unknown class and the ArgumentError for a constant that
+    // is not an ActiveRecord::Base subclass (reflection.rb:495-508). Both
+    // propagate, exactly as they do out of Rails' `check_validity!`. Returned
+    // rather than discarded only so the resolve is a statement TS accepts.
+    return this.klass;
   }
 
   get name(): string {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3111,13 +3111,6 @@ export class Base extends Model {
   // signatures live on the merged `interface Base` at the bottom of this file.
 
   /**
-   * Register a uniqueness validation.
-   *
-   * Mirrors: validates uniqueness: true
-   */
-  declare static validatesUniqueness: typeof _Validations.validatesUniqueness;
-
-  /**
    * Register uniqueness validations for one or more attributes.
    *
    * Mirrors: ActiveRecord::Validations::ClassMethods#validates_uniqueness_of

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.query-logging.trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { AbstractAdapter } from "./abstract-adapter.js";
 import { ActiveRecordError, StatementInvalid } from "../errors.js";
+import { ActiveRecord } from "../ar-config.js";
 import { Transaction } from "../transaction.js";
 import { IsolatedExecutionState, Notifications } from "@blazetrails/activesupport";
 import type { EventPayload } from "@blazetrails/activesupport";
@@ -193,18 +194,18 @@ describe("AbstractAdapter query/logging infrastructure (PR 25b)", () => {
       expect(a.isWarningIgnored({ message: "some warning", code: "W123" })).toBe(false);
     });
 
-    it("matches by string substring on message", () => {
+    it("matches by string matcher on message", () => {
       const a = new AbstractAdapter();
-      (a.constructor as any).dbWarningsIgnore = ["deprecated"];
+      ActiveRecord.dbWarningsIgnore = ["deprecated"];
       expect(a.isWarningIgnored({ message: "this feature is deprecated" })).toBe(true);
-      delete (a.constructor as any).dbWarningsIgnore;
+      ActiveRecord.dbWarningsIgnore = [];
     });
 
     it("matches by RegExp on message", () => {
       const a = new AbstractAdapter();
-      (a.constructor as any).dbWarningsIgnore = [/W\d+/];
+      ActiveRecord.dbWarningsIgnore = [/W\d+/];
       expect(a.isWarningIgnored({ message: "ok", code: "W001" })).toBe(true);
-      delete (a.constructor as any).dbWarningsIgnore;
+      ActiveRecord.dbWarningsIgnore = [];
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -837,12 +837,6 @@ export class AbstractAdapter implements Quoting {
   static readonly Version = Version;
 
   /**
-   * Allow-list of warning messages or codes to skip even under `:raise`.
-   * Mirrors `ActiveRecord.db_warnings_ignore`.
-   */
-  static dbWarningsIgnore: (string | RegExp)[] = [];
-
-  /**
    * @missingRailsCall build_statement_pool — CONVERGEABLE (story abstract-adapter-constructor-drops-rails-config-arg): RFC 0106: the base ctor takes no
    *   config (concrete adapters assign `_config`), so Rails' config-derived
    *   initialize tail has nowhere to run here; converging it is the constructor
@@ -2758,15 +2752,14 @@ export class AbstractAdapter implements Quoting {
     code?: string | number;
     [k: string]: unknown;
   }): boolean {
-    const matchers: (string | RegExp)[] = (this.constructor as any).dbWarningsIgnore ?? [];
-    const msg = warning.message ?? "";
-    return matchers.some(
-      (m) =>
-        (typeof m === "string" ? msg.includes(m) : m.test(msg)) ||
-        (warning.code !== undefined &&
-          (typeof m === "string"
-            ? String(warning.code).includes(m)
-            : m.test(String(warning.code)))),
+    // Ruby's `String#match?` takes a Regexp OR a String, and a String argument
+    // is a regexp SOURCE, not a substring (abstract_adapter.rb:1229).
+    const matchP = (str: string, warningMatcher: string | RegExp): boolean =>
+      (typeof warningMatcher === "string" ? new RegExp(warningMatcher) : warningMatcher).test(str);
+    return ActiveRecord.dbWarningsIgnore.some(
+      (warningMatcher) =>
+        matchP(warning.message ?? "", warningMatcher) ||
+        matchP(String(warning.code ?? ""), warningMatcher),
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2752,15 +2752,13 @@ export class AbstractAdapter implements Quoting {
     code?: string | number;
     [k: string]: unknown;
   }): boolean {
-    // Ruby's `String#match?` takes a Regexp OR a String, and a String argument
-    // is a regexp SOURCE, not a substring (abstract_adapter.rb:1229).
-    const matchP = (str: string, warningMatcher: string | RegExp): boolean =>
-      (typeof warningMatcher === "string" ? new RegExp(warningMatcher) : warningMatcher).test(str);
-    return ActiveRecord.dbWarningsIgnore.some(
-      (warningMatcher) =>
-        matchP(warning.message ?? "", warningMatcher) ||
-        matchP(String(warning.code ?? ""), warningMatcher),
-    );
+    return ActiveRecord.dbWarningsIgnore.some((warningMatcher) => {
+      // Ruby's `String#match?` takes a Regexp OR a String, and a String
+      // argument is a regexp SOURCE, not a substring (abstract_adapter.rb:1229).
+      const matcher =
+        typeof warningMatcher === "string" ? new RegExp(warningMatcher) : warningMatcher;
+      return matcher.test(warning.message ?? "") || matcher.test(String(warning.code ?? ""));
+    });
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -868,23 +868,32 @@ export class ConnectionPool implements ReapablePool {
   // return type — do not "converge back" to a sync return. See RFC
   // 0023-surfaced-deviations / converge-connection-pool-checkout-lease-async.
   /**
-   * @missingRailsCall lock — PERMANENT: connection_pool.rb:550 wraps the pinned
-   *   branch in `@pinned_connection.lock.synchronize { synchronize { ... } }`.
-   *   A Monitor guards a connection against concurrent *threads*; JS has none,
-   *   and `_resolvePinnedConnection` resolves the pin in the same tick, so
-   *   there is no TypeScript spelling of the lock to call.
+   * @missingRailsCall lock — PERMANENT: connection_pool.rb:550-551 wraps the
+   *   pinned branch in `@pinned_connection.lock.synchronize { synchronize
+   *   { ... } }`. Both monitors guard against concurrent *threads*, and the
+   *   section they close is unreachable here: the branch has exactly one yield
+   *   point (`verifyBang`), and everything after it — the `@connections`
+   *   membership read and the push that follows — runs in a single
+   *   synchronous continuation, so no second checkout can observe the pool
+   *   between the two. A body that mutates only before its first `await`, or
+   *   only after its last one, needs no JS analogue of the mutex.
    */
   async checkout(timeout?: number): Promise<DatabaseAdapter> {
+    const checkoutTimeout = timeout ?? this.checkoutTimeout;
     const pinned = this._resolvePinnedConnection();
     // Rails' guard clause: `return checkout_and_verify(acquire_connection(
     // checkout_timeout)) unless @pinned_connection` (connection_pool.rb:548).
+    // Rails re-reads `@pinned_connection` a second time inside the lock
+    // (:552, "may have been cleaned up before we synchronized") and falls back
+    // to the same acquire on nil; with no lock to acquire, the two reads are
+    // one read here — nothing can clear the pin between them.
     if (!pinned) {
-      return checkoutAndVerify(this, await this.acquireConnection(timeout ?? this.checkoutTimeout));
+      return checkoutAndVerify(this, await this.acquireConnection(checkoutTimeout));
     }
 
-    // Mirrors Rails' pinned branch (connection_pool.rb:553-559): verify!
-    // unconditionally, ensure membership in @connections, and return — no
-    // checkout_and_verify / QueryCache wiring on the pinned connection.
+    // Mirrors Rails' pinned branch (connection_pool.rb:553-563): verify!,
+    // ensure membership in @connections, and return —
+    // no checkout_and_verify / QueryCache wiring on the pinned connection.
     // verifyBang is async in trails (Rails' verify! is sync); await it on the
     // async path so verification completes before the connection is handed out
     // and a rejection surfaces here rather than as an unhandled rejection.

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.trails.test.ts
@@ -5,9 +5,9 @@ import type { SchemaSource } from "../../schema-dumper.js";
 import { IntegerType, DecimalType, BooleanType, StringType } from "@blazetrails/activemodel";
 
 const emptySource: SchemaSource = {
-  tables: () => [],
-  columns: () => [],
-  indexes: () => [],
+  tables: async () => [],
+  columns: async () => [],
+  indexes: async () => [],
   lookupCastTypeFromColumn: () => new ValueType(),
 };
 
@@ -122,7 +122,7 @@ describe("SchemaDumper raises on a column whose type is not a valid native type"
   // false, the per-column raise fires, and the whole create_table body is
   // discarded in favor of the "Could not dump table" comment.
   const source = {
-    tables: () => ["widgets"],
+    tables: async () => ["widgets"],
     columns: (_t: string) => [
       { name: "id", type: "integer", sqlType: "integer", primaryKey: true },
       { name: "kind", type: null, sqlType: "composite_type" },
@@ -141,7 +141,7 @@ describe("SchemaDumper raises on a column whose type is not a valid native type"
 
   it("still dumps the table normally when every column type is a valid native type", async () => {
     const validSource = {
-      tables: () => ["widgets"],
+      tables: async () => ["widgets"],
       columns: (_t: string) => [
         { name: "id", type: "integer", sqlType: "integer", primaryKey: true },
         { name: "name", type: "string", sqlType: "varchar(255)", limit: 255 },

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.trails.test.ts
@@ -5,9 +5,9 @@ import type { SchemaSource } from "../../schema-dumper.js";
 import { Result } from "../../result.js";
 
 const stubSource: SchemaSource = {
-  tables: () => [],
-  columns: () => [],
-  indexes: () => [],
+  tables: async () => [],
+  columns: async () => [],
+  indexes: async () => [],
   lookupCastTypeFromColumn: () => new ValueType(),
 };
 const make = () => SchemaDumper.create(stubSource);

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.trails.test.ts
@@ -6,9 +6,9 @@ import { TypeMetadata } from "./type-metadata.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 
 const emptySource: SchemaSource = {
-  tables: () => [],
-  columns: () => [],
-  indexes: () => [],
+  tables: async () => [],
+  columns: async () => [],
+  indexes: async () => [],
   lookupCastTypeFromColumn: () => new ValueType(),
 };
 
@@ -132,9 +132,9 @@ describe("PostgreSQL::SchemaDumper", () => {
     it("adds virtual column options when adapter supports virtual columns", () => {
       // Mirrors createSchemaDumper(adapter) — raw adapter passed as source
       const mockAdapter = {
-        tables: () => [],
-        columns: () => [],
-        indexes: () => [],
+        tables: async () => [],
+        columns: async () => [],
+        indexes: async () => [],
         supportsVirtualColumns: () => true,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
@@ -156,9 +156,9 @@ describe("PostgreSQL::SchemaDumper", () => {
 
     it("adds enum_type even for virtual enum columns (Rails continues after virtual block)", () => {
       const mockAdapter = {
-        tables: () => [],
-        columns: () => [],
-        indexes: () => [],
+        tables: async () => [],
+        columns: async () => [],
+        indexes: async () => [],
         supportsVirtualColumns: () => true,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);
@@ -179,9 +179,9 @@ describe("PostgreSQL::SchemaDumper", () => {
 
     it("skips virtual options when adapter does not support virtual columns", () => {
       const mockAdapter = {
-        tables: () => [],
-        columns: () => [],
-        indexes: () => [],
+        tables: async () => [],
+        columns: async () => [],
+        indexes: async () => [],
         supportsVirtualColumns: () => false,
       };
       const dumper = new (SchemaDumper as any)(mockAdapter);

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -452,7 +452,7 @@ export function makeEncryptedBookWithUniquenessValidation(adapter: DatabaseAdapt
       this.attribute("id", "integer");
       this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
-      this.validatesUniqueness("name");
+      this.validatesUniquenessOf("name");
       this.encrypts("name", { deterministic: true });
     }
   } as any;

--- a/packages/activerecord/src/encryption/uniqueness-validations.test.ts
+++ b/packages/activerecord/src/encryption/uniqueness-validations.test.ts
@@ -66,7 +66,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
         this._tableName = "encrypted_books";
         this.attribute("id", "integer");
         this.attribute("name", "string", { default: "<untitled>" });
-        this.validatesUniqueness("name");
+        this.validatesUniquenessOf("name");
         this.encrypts("name", { deterministic: true, downcase: true });
       }
     }
@@ -84,7 +84,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
         this._tableName = "encrypted_books";
         this.attribute("id", "integer");
         this.attribute("name", "string", { default: "<untitled>" });
-        this.validatesUniqueness("name");
+        this.validatesUniquenessOf("name");
         this.encrypts("name", { deterministic: true, downcase: true });
       }
     }
@@ -110,7 +110,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
         this._tableName = "encrypted_books";
         this.attribute("id", "integer");
         this.attribute("name", "string", { default: "<untitled>" });
-        this.validatesUniqueness("name");
+        this.validatesUniquenessOf("name");
         this.encrypts("name", { deterministic: true, supportUnencryptedData: false });
       }
     }
@@ -136,7 +136,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
         this._tableName = "encrypted_books";
         this.attribute("id", "integer");
         this.attribute("name", "string", { default: "<untitled>" });
-        this.validatesUniqueness("name");
+        this.validatesUniquenessOf("name");
         this.encrypts("name", { deterministic: true, supportUnencryptedData: true });
       }
     }
@@ -163,7 +163,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
         this._tableName = "encrypted_books";
         this.attribute("id", "integer");
         this.attribute("name", "string", { default: "<untitled>" });
-        this.validatesUniqueness("name");
+        this.validatesUniquenessOf("name");
         this.encrypts("name", { deterministic: true, downcase: false });
       }
     }
@@ -182,7 +182,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
         this._tableName = "encrypted_books";
         this.attribute("id", "integer");
         this.attribute("name", "string", { default: "<untitled>" });
-        this.validatesUniqueness("name");
+        this.validatesUniquenessOf("name");
         this.encrypts("name", { deterministic: true });
       }
     }

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -13,9 +13,9 @@ import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/a
 import { ValueType } from "@blazetrails/activemodel";
 
 const EMPTY_SOURCE = {
-  tables: () => [],
-  columns: () => [],
-  indexes: () => [],
+  tables: async () => [],
+  columns: async () => [],
+  indexes: async () => [],
   adapter: { defaultIndexType: AbstractAdapter.prototype.defaultIndexType },
 };
 
@@ -24,8 +24,8 @@ describe("SchemaDumper trails-only cases", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
-      tables: () => ["gen_defaults"],
-      columns: () => [
+      tables: async () => ["gen_defaults"],
+      columns: async () => [
         { name: "id", type: "integer", primaryKey: true },
         // A function default reflects as `default: null` + `defaultFunction`
         // (the literal default is null; the expression rides defaultFunction),
@@ -38,7 +38,7 @@ describe("SchemaDumper trails-only cases", () => {
           defaultFunction: "gen_random_uuid()",
         },
       ],
-      indexes: () => [],
+      indexes: async () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     const output = (await TopLevelDumper.dump(source)).join("\n");
@@ -52,9 +52,9 @@ describe("SchemaDumper trails-only cases", () => {
 
     const one = (
       await TopLevelDumper.dump({
-        tables: () => ["books"],
-        columns: () => columns,
-        indexes: () => [],
+        tables: async () => ["books"],
+        columns: async () => columns,
+        indexes: async () => [],
         lookupCastTypeFromColumn: () => new ValueType(),
       })
     ).join("\n");
@@ -62,9 +62,9 @@ describe("SchemaDumper trails-only cases", () => {
 
     const two = (
       await TopLevelDumper.dump({
-        tables: () => ["authors", "books"],
-        columns: () => columns,
-        indexes: () => [],
+        tables: async () => ["authors", "books"],
+        columns: async () => columns,
+        indexes: async () => [],
         lookupCastTypeFromColumn: () => new ValueType(),
       })
     ).join("\n");
@@ -76,8 +76,8 @@ describe("SchemaDumper trails-only cases", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
-      tables: () => ["dsl_types"],
-      columns: () => [
+      tables: async () => ["dsl_types"],
+      columns: async () => [
         { name: "id", type: "integer", primaryKey: true },
         { name: "r1", type: "int4range" },
         { name: "r2", type: "int8range" },
@@ -96,7 +96,7 @@ describe("SchemaDumper trails-only cases", () => {
         // SQL_TYPE_MAP keys and emit helpers before and after this change.
         { name: "bv", type: "bitVarying" },
       ],
-      indexes: () => [],
+      indexes: async () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     const output = (await TopLevelDumper.dump(source)).join("\n");
@@ -125,15 +125,15 @@ describe("SchemaDumper trails-only cases", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
-      tables: () => ["non_helper_types"],
-      columns: () => [
+      tables: async () => ["non_helper_types"],
+      columns: async () => [
         { name: "id", type: "integer", primaryKey: true },
         { name: "ts", type: "timestamptz" },
         { name: "guid", type: "uuid" },
         { name: "span", type: "interval" },
         { name: "obj_id", type: "oid" },
       ],
-      indexes: () => [],
+      indexes: async () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     const output = (await TopLevelDumper.dump(source)).join("\n");
@@ -354,13 +354,15 @@ describe("SchemaDumperAdapterTest", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
-      tables: () => ["users"],
-      columns: () => [{ name: "id", type: "integer", primaryKey: true }],
-      indexes: () => [],
+      tables: async () => ["users"],
+      columns: async () => [{ name: "id", type: "integer", primaryKey: true }],
+      indexes: async () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     class CommentDumper extends TopLevelDumper {
-      protected override fetchTableOptions(_tableName: string): Record<string, unknown> {
+      protected override async fetchTableOptions(
+        _tableName: string,
+      ): Promise<Record<string, unknown>> {
         return { comment: "user accounts" };
       }
     }
@@ -374,13 +376,13 @@ describe("SchemaDumperAdapterTest", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
-      tables: () => ["t"],
-      columns: () => [{ name: "id", type: "integer", primaryKey: true }],
-      indexes: () => [],
+      tables: async () => ["t"],
+      columns: async () => [{ name: "id", type: "integer", primaryKey: true }],
+      indexes: async () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     class MysqlDumper extends TopLevelDumper {
-      protected override fetchTableOptions(_t: string): Record<string, unknown> {
+      protected override async fetchTableOptions(_t: string): Promise<Record<string, unknown>> {
         return { charset: "utf8mb4", collation: "utf8mb4_bin" };
       }
     }
@@ -397,12 +399,12 @@ describe("SchemaDumperAdapterTest", () => {
     const { SchemaDumper: TopLevelDumper } =
       await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
-      tables: () => ["t"],
-      columns: () => [
+      tables: async () => ["t"],
+      columns: async () => [
         { name: "id", type: "integer", primaryKey: true },
         { name: "account_id", type: "integer", primaryKey: true },
       ],
-      indexes: () => [],
+      indexes: async () => [],
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     const dumper = TopLevelDumper.create(source as any);
@@ -450,7 +452,7 @@ describe("SchemaDumper async header ordering", () => {
         log.push("types");
       }
     }
-    const source = { tables: () => [], columns: () => [], indexes: () => [] };
+    const source = { tables: async () => [], columns: async () => [], indexes: async () => [] };
     const dumper = new (OrderedDumper as any)(source);
     const result = (await (dumper.dump() as Promise<string[]>)).join("\n");
     expect(log).toEqual(["schemas", "extensions", "types"]);
@@ -464,9 +466,9 @@ describe("SchemaDumper async header ordering", () => {
 
 describe("formatColspec", () => {
   const dumper = SchemaDumper.create({
-    tables: () => [],
-    columns: () => [],
-    indexes: () => [],
+    tables: async () => [],
+    columns: async () => [],
+    indexes: async () => [],
     lookupCastTypeFromColumn: () => new ValueType(),
   });
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -145,12 +145,15 @@ function conciseOptions<T>(
 }
 
 /**
- * Interface for sources that can provide schema information.
- * Database adapters (async) and the dumper's test mock sources (sync) both implement it.
+ * Interface for sources that can provide schema information. Rails' dumper
+ * holds `@connection` (`schema_dumper.rb:113`) and calls `.tables` /
+ * `.columns(table)` / `.indexes(table)` on it (`:135`, `:145`, `:158`); the
+ * connection is always the real adapter, so every member has exactly one arm
+ * here too.
  */
 export interface SchemaSource {
   /** @internal */
-  tables(): string[] | Promise<string[]>;
+  tables(): Promise<string[]>;
   /**
    * `pkNames` is the authoritative primary key for `tableName`, which the
    * dumper has already fetched (`@connection.primary_key(table)`). Columns
@@ -159,9 +162,9 @@ export interface SchemaSource {
    * than issuing the key query a second time. Optional: mock sources that
    * hand back `ColumnInfo` directly set `primaryKey` themselves.
    */
-  columns(tableName: string, pkNames?: readonly string[]): ColumnInfo[] | Promise<ColumnInfo[]>;
+  columns(tableName: string, pkNames?: readonly string[]): Promise<ColumnInfo[]>;
   /** @internal */
-  indexes(tableName: string): IndexInfo[] | Promise<IndexInfo[]>;
+  indexes(tableName: string): Promise<IndexInfo[]>;
   /**
    * Rails' `@connection` in the dumper is always an adapter, so
    * `schema_default` calls `lookup_cast_type_from_column` unconditionally
@@ -643,16 +646,24 @@ export abstract class SchemaDumper {
   }
 
   /** @internal */
-  protected extensions(_stream: string[]): void | Promise<void> {}
+  protected extensions(_stream: string[]): Promise<void> {
+    return Promise.resolve();
+  }
 
   /** @internal */
-  protected types(_stream: string[]): void | Promise<void> {}
+  protected types(_stream: string[]): Promise<void> {
+    return Promise.resolve();
+  }
 
   /** @internal */
-  protected schemas(_stream: string[]): void | Promise<void> {}
+  protected schemas(_stream: string[]): Promise<void> {
+    return Promise.resolve();
+  }
 
   /** @internal */
-  protected virtualTables(_stream: string[]): void | Promise<void> {}
+  protected virtualTables(_stream: string[]): Promise<void> {
+    return Promise.resolve();
+  }
 
   private header(stream: string[]): void {
     stream.push("// This file is auto-generated from the current state of the database.");
@@ -909,10 +920,8 @@ export abstract class SchemaDumper {
   }
 
   /** @internal */
-  protected fetchTableOptions(
-    _tableName: string,
-  ): Record<string, unknown> | Promise<Record<string, unknown>> {
-    return {};
+  protected fetchTableOptions(_tableName: string): Promise<Record<string, unknown>> {
+    return Promise.resolve({});
   }
 
   /**

--- a/packages/activerecord/src/support/with-db-warnings-action.ts
+++ b/packages/activerecord/src/support/with-db-warnings-action.ts
@@ -1,5 +1,4 @@
 import { ActiveRecord } from "../ar-config.js";
-import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { SQLWarning } from "../errors.js";
 
 type DbWarningsAction = "ignore" | "log" | "raise" | "report" | ((w: SQLWarning) => void);
@@ -30,13 +29,13 @@ export async function withDbWarningsAction(
   ) as () => Promise<void> | void;
   const ignore = Array.isArray(warningsToIgnore) ? warningsToIgnore : [];
   const savedAction = ActiveRecord.dbWarningsAction;
-  const savedIgnore = AbstractAdapter.dbWarningsIgnore;
+  const savedIgnore = ActiveRecord.dbWarningsIgnore;
   ActiveRecord.dbWarningsAction = action;
-  AbstractAdapter.dbWarningsIgnore = ignore;
+  ActiveRecord.dbWarningsIgnore = ignore;
   try {
     await body();
   } finally {
     ActiveRecord.dbWarningsAction = savedAction ?? "ignore";
-    AbstractAdapter.dbWarningsIgnore = savedIgnore;
+    ActiveRecord.dbWarningsIgnore = savedIgnore;
   }
 }

--- a/packages/activerecord/src/test-helpers/models/reply.ts
+++ b/packages/activerecord/src/test-helpers/models/reply.ts
@@ -46,7 +46,7 @@ export class SillyReply extends Topic {
 export class UniqueReply extends Reply {
   static {
     this.belongsTo("topic", { foreignKey: "parent_id", counterCache: true });
-    this.validatesUniqueness("content", { scope: "parent_id" });
+    this.validatesUniquenessOf("content", { scope: "parent_id" });
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/uuid-item.ts
+++ b/packages/activerecord/src/test-helpers/models/uuid-item.ts
@@ -5,6 +5,6 @@ export class UuidItem extends Base {}
 
 export class UuidValidatingItem extends UuidItem {
   static {
-    this.validatesUniqueness("uuid");
+    this.validatesUniquenessOf("uuid");
   }
 }

--- a/packages/activerecord/src/validations.ts
+++ b/packages/activerecord/src/validations.ts
@@ -20,11 +20,7 @@ import { AssociatedValidator, validatesAssociated } from "./validations/associat
 import { LengthValidator } from "./validations/length.js";
 import { NumericalityValidator } from "./validations/numericality.js";
 import { PresenceValidator } from "./validations/presence.js";
-import {
-  UniquenessValidator,
-  validatesUniqueness,
-  validatesUniquenessOf,
-} from "./validations/uniqueness.js";
+import { UniquenessValidator, validatesUniquenessOf } from "./validations/uniqueness.js";
 import { _preloadedHolderTarget } from "./associations.js";
 import type { Base } from "./base.js";
 
@@ -39,7 +35,6 @@ export {
   PresenceValidator,
   UniquenessValidator,
   validatesAssociated,
-  validatesUniqueness,
   validatesUniquenessOf,
 };
 
@@ -286,13 +281,12 @@ export function validatesNumericalityOf(this: HelperMethodHost, ...attrNames: un
 /**
  * Module methods wired onto Base as static methods via `extend()` in base.ts.
  * Mirrors Rails' `ActiveRecord::Validations::ClassMethods` / `ActiveSupport::Concern#ClassMethods`.
- * `validatesAssociated` and `validatesUniqueness` live next to their
+ * `validatesAssociated` and `validatesUniquenessOf` live next to their
  * validator classes in validations/associated.ts and validations/uniqueness.ts
  * matching Rails' file layout.
  */
 export const ClassMethods = {
   validatesAssociated,
-  validatesUniqueness,
   validatesUniquenessOf,
   validatesPresenceOf,
   validatesAbsenceOf,

--- a/packages/activerecord/src/validations/i18n-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-validation.test.ts
@@ -33,7 +33,7 @@ describe("I18nValidationTest", () => {
         this._tableName = "topics";
         this.attribute("id", "integer");
         this.attribute("title", "string");
-        this.validatesUniqueness("title");
+        this.validatesUniquenessOf("title");
       }
     }
     registerModel("I18nUniquenessTopic", Topic);

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -38,7 +38,7 @@ const INT_MAX_VALUE = 2147483647;
 class Wizard extends Base {
   static {
     this.abstractClass = true;
-    this.validatesUniqueness("name");
+    this.validatesUniquenessOf("name");
   }
 }
 
@@ -46,7 +46,7 @@ class Wizard extends Base {
 class IneptWizard extends Wizard {
   static _tableName = "inept_wizards";
   static {
-    this.validatesUniqueness("city");
+    this.validatesUniquenessOf("city");
   }
 }
 
@@ -57,14 +57,14 @@ class Thaumaturgist extends IneptWizard {}
 //        validates_uniqueness_of :content, scope: :title; ...`.
 class ReplyWithTitleObject extends Reply {
   static {
-    this.validatesUniqueness("content", { scope: "title" });
+    this.validatesUniquenessOf("content", { scope: "title" });
   }
 }
 
 // Rails `class CoolTopic < Topic; validates_uniqueness_of :id; end`.
 class CoolTopic extends Topic {
   static {
-    this.validatesUniqueness("id");
+    this.validatesUniquenessOf("id");
   }
 }
 
@@ -86,7 +86,7 @@ class LessonWithUniqKeyboard extends Base {
   static _tableName = "lessons";
   static {
     this.belongsTo("keyboard", { primaryKey: "name", foreignKey: "name" });
-    this.validatesUniqueness("keyboard");
+    this.validatesUniquenessOf("keyboard");
   }
 }
 
@@ -101,7 +101,7 @@ class DashboardWithoutPrimaryKey extends Base {
   // (which never sets `self.primary_key`).
   static name = "Dashboard";
   static {
-    this.validatesUniqueness("dashboard_id");
+    this.validatesUniquenessOf("dashboard_id");
   }
 }
 
@@ -152,7 +152,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
 
     const t = new Topic({ title: "I'm uniqué!" });
     expect(await t.save()).toBe(true);
@@ -175,7 +175,7 @@ describe("UniquenessValidationTest", () => {
     // Rails declares the validation on `t2.singleton_class`; trails has no
     // per-instance validator, so the class-level declaration plus a save-time
     // check expresses the same "duplicate is rejected, fresh row is accepted".
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     const t2 = new Topic({ title: "abc" });
     expect(await t2.save()).toBe(false);
   });
@@ -183,14 +183,14 @@ describe("UniquenessValidationTest", () => {
   it("validate uniqueness with alias attribute", async () => {
     // Rails aliases :new_title → :title and validates :new_title; `heading` is
     // the canonical Topic alias for :title, so it exercises the same path.
-    Topic.validatesUniqueness("heading");
+    Topic.validatesUniquenessOf("heading");
 
     const topic = new Topic({ title: "abc" });
     expect(await topic.save()).toBe(true);
   });
 
   it("validates uniqueness with nil value", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
 
     const t = new Topic({ title: null });
     expect(await t.save()).toBe(true);
@@ -222,7 +222,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validates uniqueness with newline chars", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: false });
+    Topic.validatesUniquenessOf("title", { caseSensitive: false });
 
     const t = new Topic({ title: "new\nline" });
     expect(await t.save()).toBe(true);
@@ -237,7 +237,7 @@ describe("UniquenessValidationTest", () => {
   // collision was missed and `save()` wrongly returned true. Fixed by dropping
   // the manual serialize (Rails lets `bind_attribute`/the type serialize once).
   it("validate uniqueness with scope", async () => {
-    Reply.validatesUniqueness("content", { scope: "parent_id" });
+    Reply.validatesUniquenessOf("content", { scope: "parent_id" });
 
     const t = await Topic.create({ title: "I'm unique!" });
 
@@ -259,7 +259,7 @@ describe("UniquenessValidationTest", () => {
   it("validate uniqueness with aliases", async () => {
     // Rails validates :new_content scope :new_parent_id (aliases of content /
     // parent_id, already declared on Reply).
-    Reply.validatesUniqueness("new_content", { scope: "new_parent_id" });
+    Reply.validatesUniquenessOf("new_content", { scope: "new_parent_id" });
 
     const t = await Topic.create({ title: "I'm unique!" });
 
@@ -275,7 +275,7 @@ describe("UniquenessValidationTest", () => {
 
   it("validate uniqueness with scope invalid syntax", () => {
     expect(() => {
-      Reply.validatesUniqueness("content", { scope: { parent_id: false } as any });
+      Reply.validatesUniquenessOf("content", { scope: { parent_id: false } as any });
     }).toThrow(ArgumentError);
   });
 
@@ -283,7 +283,7 @@ describe("UniquenessValidationTest", () => {
   it("validate uniqueness with object scope", async () => {
     // Rails `scope: :topic` — scope by the belongs_to association name, which
     // resolve_attributes/scope_relation expand to the parent_id foreign key.
-    Reply.validatesUniqueness("content", { scope: "topic" });
+    Reply.validatesUniquenessOf("content", { scope: "topic" });
 
     const t = await Topic.create({ title: "I'm unique!" });
 
@@ -295,7 +295,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness with polymorphic object scope", async () => {
-    Essay.validatesUniqueness("name", { scope: ["writer_id", "writer_type"] });
+    Essay.validatesUniquenessOf("name", { scope: ["writer_id", "writer_type"] });
     try {
       const a = await Author.create({ name: "Sergey" });
       const p = await Person.create({ first_name: "Sergey" });
@@ -325,7 +325,7 @@ describe("UniquenessValidationTest", () => {
   it("validate uniqueness with object arg", async () => {
     // Rails `validates_uniqueness_of(:topic)` — uniqueness on the association
     // itself; the validator reads/compares the underlying parent_id FK.
-    Reply.validatesUniqueness("topic");
+    Reply.validatesUniquenessOf("topic");
 
     const t = await Topic.create({ title: "I'm unique!" });
 
@@ -364,7 +364,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness with scope array", async () => {
-    Reply.validatesUniqueness("author_name", {
+    Reply.validatesUniquenessOf("author_name", {
       scope: ["author_email_address", "parent_id"],
     });
 
@@ -476,7 +476,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate case sensitive uniqueness with special sql like chars", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: true });
+    Topic.validatesUniquenessOf("title", { caseSensitive: true });
 
     const t = new Topic({ title: "I'm unique!" });
     expect(await t.save()).toBe(true);
@@ -489,7 +489,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate case insensitive uniqueness with special sql like chars", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: false });
+    Topic.validatesUniquenessOf("title", { caseSensitive: false });
 
     const t = new Topic({ title: "I'm unique!" });
     expect(await t.save()).toBe(true);
@@ -502,7 +502,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness by default database collation", async () => {
-    Topic.validatesUniqueness("author_email_address");
+    Topic.validatesUniquenessOf("author_email_address");
 
     const topic1 = new Topic({ author_email_address: "david@loudthinking.com" });
 
@@ -513,7 +513,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate case sensitive uniqueness", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: true });
+    Topic.validatesUniquenessOf("title", { caseSensitive: true });
 
     const t = new Topic({ title: "I'm unique!" });
     expect(await t.save()).toBe(true);
@@ -531,7 +531,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate case sensitive uniqueness with attribute passed as integer", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: true });
+    Topic.validatesUniquenessOf("title", { caseSensitive: true });
     await Topic.createBang({ title: 101 as any });
 
     const t2 = new Topic({ title: 101 as any });
@@ -546,7 +546,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validates uniqueness inside scoping", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
 
     const t1 = new Topic({ title: "I'm unique!", author_name: "Mary" });
     expect(await t1.save()).toBe(true);
@@ -556,7 +556,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness with columns which are sql keywords", async () => {
-    Guid.validatesUniqueness("key");
+    Guid.validatesUniquenessOf("key");
     try {
       const g = new Guid();
       g.writeAttribute("key", "foo");
@@ -620,7 +620,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness with conditions", async () => {
-    Topic.validatesUniqueness("title", {
+    Topic.validatesUniquenessOf("title", {
       conditions: function (this: any) {
         return this.where({ approved: true });
       },
@@ -639,14 +639,14 @@ describe("UniquenessValidationTest", () => {
     // Rails instantiates the validator at declaration time (validates_with),
     // so a non-callable :conditions raises immediately, not at save.
     expect(() =>
-      Topic.validatesUniqueness("title", {
+      Topic.validatesUniquenessOf("title", {
         conditions: Topic.where({ approved: true }) as any,
       }),
     ).toThrow();
   });
 
   it("validate uniqueness with conditions with record arg", async () => {
-    Topic.validatesUniqueness("title", {
+    Topic.validatesUniquenessOf("title", {
       conditions: function (this: any, record: any) {
         return this.where({ author_name: record.readAttribute("author_name") });
       },
@@ -678,7 +678,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness of custom primary key", async () => {
-    Keyboard.validatesUniqueness("key_number");
+    Keyboard.validatesUniquenessOf("key_number");
     try {
       await Keyboard.createBang({ key_number: 10 });
       const key2 = await Keyboard.createBang({ key_number: 11 });
@@ -704,7 +704,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness ignores itself when primary key changed", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
 
     const t = new Topic({ title: "This is a unique title" });
     expect(await t.save()).toBe(true);
@@ -717,7 +717,7 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate uniqueness with after create performing save", async () => {
-    TopicWithAfterCreate.validatesUniqueness("title");
+    TopicWithAfterCreate.validatesUniquenessOf("title");
     try {
       const topic = await TopicWithAfterCreate.createBang({ title: "Title1" });
       expect((topic.readAttribute("author_name") as string).startsWith("Title1")).toBe(true);
@@ -771,7 +771,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("new record", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
 
     const t = new Topic({ title: "abc" });
@@ -781,7 +781,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("changing non unique attribute", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
 
     const t = await Topic.createBang({ title: "abc" });
@@ -792,7 +792,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("changing unique attribute", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
 
     const t = await Topic.createBang({ title: "abc" });
@@ -803,7 +803,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("changing non unique attribute and unique attribute is nil", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
 
     const t = await Topic.createBang({});
@@ -815,7 +815,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("conditions", async () => {
-    Topic.validatesUniqueness("title", {
+    Topic.validatesUniquenessOf("title", {
       conditions: function (this: any) {
         return this.where().not({ author_name: null });
       },
@@ -830,7 +830,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("case sensitive", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: true });
+    Topic.validatesUniquenessOf("title", { caseSensitive: true });
     await Base.connection.addIndex("topics", "title", { unique: true, name: "topics_index" });
 
     const t = await Topic.createBang({ title: "abc" });
@@ -841,7 +841,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   itIfSupports("partial_index", "partial index", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", "title", {
       unique: true,
       where: "approved",
@@ -856,7 +856,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("non unique index", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", "title", { name: "topics_index" });
 
     const t = await Topic.createBang({ title: "abc" });
@@ -867,7 +867,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("scope", async () => {
-    Topic.validatesUniqueness("title", { scope: "author_name" });
+    Topic.validatesUniquenessOf("title", { scope: "author_name" });
     await Base.connection.addIndex("topics", ["author_name", "title"], {
       unique: true,
       name: "topics_index",
@@ -923,7 +923,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("index of sublist of columns", async () => {
-    Topic.validatesUniqueness("title", { scope: "author_name" });
+    Topic.validatesUniquenessOf("title", { scope: "author_name" });
     await Base.connection.addIndex("topics", "author_name", {
       unique: true,
       name: "topics_index",
@@ -942,7 +942,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it("index of columns list and extra columns", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", ["title", "author_name"], {
       unique: true,
       name: "topics_index",
@@ -956,7 +956,7 @@ describe("UniquenessValidationWithIndexTest", () => {
   });
 
   it.skipIf(adapterType !== "postgres")("expression index", async () => {
-    Topic.validatesUniqueness("title");
+    Topic.validatesUniquenessOf("title");
     await Base.connection.addIndex("topics", "LOWER(title)", {
       unique: true,
       name: "topics_index",
@@ -1024,7 +1024,7 @@ class BigIntReverseTest extends Base {
 class TopicWithEvent extends Topic {
   static {
     this.belongsTo("event", { foreignKey: "parent_id" });
-    this.validatesUniqueness("event");
+    this.validatesUniquenessOf("event");
   }
 }
 

--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -28,7 +28,7 @@ describe("UniquenessValidationContextTest", () => {
   });
 
   it("uniqueness honors on: :create context", async () => {
-    Topic.validatesUniqueness("title", { on: "create" });
+    Topic.validatesUniquenessOf("title", { on: "create" });
 
     await Topic.createBang({ title: "ctx-unique" });
 
@@ -46,7 +46,7 @@ describe("UniquenessValidationContextTest", () => {
   });
 
   it("uniqueness honors on: :update context", async () => {
-    Topic.validatesUniqueness("title", { on: "update" });
+    Topic.validatesUniquenessOf("title", { on: "update" });
 
     await Topic.createBang({ title: "upd-unique" });
 
@@ -67,7 +67,7 @@ describe("UniquenessValidationContextTest", () => {
     // errors.add, which raises. In trails, validatesWith's (async-aware) strict
     // wrapper awaits this DB-backed validator and raises StrictValidationFailed
     // when it flags a collision.
-    Topic.validatesUniqueness("title", { strict: true });
+    Topic.validatesUniquenessOf("title", { strict: true });
 
     await Topic.createBang({ title: "strict-dup" });
 
@@ -108,7 +108,7 @@ describe("UniquenessCoveredByUniqueIndexAdapterResolutionTest", () => {
 
   it("skips the existence check for a directly assigned adapter", async () => {
     DirectTopic.clearValidatorsBang();
-    DirectTopic.validatesUniqueness("title");
+    DirectTopic.validatesUniquenessOf("title");
 
     const t = await DirectTopic.createBang({ title: "direct-abc" });
     t.writeAttribute("author_name", "John");

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -11,7 +11,7 @@ import { UnknownPrimaryKey } from "../errors.js";
 import { threadedConnectionFor } from "../connection-handling.js";
 
 /**
- * Shared scope option validation — called eagerly from validatesUniqueness (declaration time)
+ * Shared scope option validation — called eagerly from validatesUniquenessOf (declaration time)
  * and from UniquenessValidator#constructor (instantiation time). Mirrors Rails'
  * ArgumentError raised in UniquenessValidator#initialize for non-symbol :scope values.
  * @internal
@@ -31,46 +31,6 @@ function validateScopeOption(scope: unknown): void {
         "Pass a string or an array of strings instead.",
     );
   }
-}
-
-/**
- * Register a uniqueness validation. Now that the AR/AM validation chain is
- * async (RFC 0063), uniqueness runs inline in `valid?` like any other
- * validator: it registers via `validates_with UniquenessValidator` and the
- * validator's async `validateEach` issues the `SELECT 1 ... WHERE attr = ?`
- * existence check, awaited by the validate callback chain.
- *
- * The declaring class is threaded through as the `:class` option so the
- * validator reproduces Rails' `find_finder_class_for` (the existence query
- * must target the class the validation was declared on — e.g. an abstract STI
- * base — not the leaf subclass of the record being validated).
- *
- * Mirrors: ActiveRecord::Validations::ClassMethods#validates_uniqueness_of
- */
-export function validatesUniqueness(
-  this: {
-    validatesWith(validatorClass: unknown, opts: Record<string, unknown>): void;
-  },
-  attribute: string,
-  options: {
-    scope?: string | string[];
-    message?: string;
-    conditions?: (this: any) => any;
-    caseSensitive?: boolean;
-    allowNil?: boolean;
-    on?: string | string[];
-    if?: unknown;
-    unless?: unknown;
-    strict?: boolean;
-  } = {},
-): void {
-  // Validate options eagerly to match Rails' ArgumentError at declaration time.
-  validateScopeOption(options.scope);
-  this.validatesWith(UniquenessValidator, {
-    ...options,
-    attributes: [attribute],
-    class: this,
-  });
 }
 
 /**
@@ -98,7 +58,7 @@ export function validatesUniquenessOf(
   // (the constructor validates too, but validatesWith reaches it only after
   // bucketing).
   validateScopeOption(merged.scope);
-  this.validatesWith(UniquenessValidator, { ...merged, class: this });
+  this.validatesWith(UniquenessValidator, merged);
 }
 
 export class UniquenessValidator extends EachValidator {

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
-    "novel": 384,
-    "total": 1388
+    "novel": 381,
+    "total": 1384
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
Five RFC 0112 / RFC 0119 convergences, each collapsing a Rails concept that trails spelled twice.

**`Association#checkKlass` → the reflection** (`association.rb:36-38`, `reflection.rb:495-508`)
The method now resolves `this.klass` and nothing else. Gone: the `_reflectOnAssociation` re-resolve off the owner's class, the `NameError`-only rescue around it, and the `camelize(singularize(name))` + `autoloadModel` + `constantize` fallback — the reflection's `compute_class` already raises the faithful `NameError`, and re-raises the "not an ActiveRecord::Base subclass" `ArgumentError`, exactly where Rails' `check_validity!` surfaces both. `deriveClassName` stays for `raiseOnTypeMismatchBang`; the `autoloadModel` / `constantize` / `NameError` imports are dropped.

**`db_warnings_ignore` is a module config** (`active_record.rb:259-263`, `abstract_adapter.rb:1227-1231`)
Moved off `AbstractAdapter` (the last `dbWarnings*` class attribute) onto the `ActiveRecord` namespace object, the sibling of #7055's `db_warnings_action` move. `isWarningIgnored` now mirrors the Ruby arm for arm: Ruby `String#match?` treats a String matcher as a **regexp source**, not a substring, and `warning.code.to_s` stringifies a nil code rather than skipping the code check. `withDbWarningsAction` and the PG warning cases poke the namespace config.

**One uniqueness registrar** (`uniqueness.rb:291-293`)
`validatesUniqueness` — singular-attribute, non-variadic, bypassing `_mergeAttributes`, one validator instance per attribute — is deleted along with its `base.ts` declaration, its `validations.ts` re-exports, and the `dx-tests` assertion. Every call site (test models, encryption helpers, uniqueness/array/uuid/case-sensitivity suites) uses `validatesUniquenessOf`. The explicit `class: this` goes too: `validates_with` already sets `options[:class] = self` (`with.rb:88-90`).

**`SchemaSource` has one arm** (`schema_dumper.rb:113,135,145,158`)
`tables` / `columns` / `indexes` / `fetchTableOptions` and the `schemas` / `extensions` / `types` / `virtualTables` hooks declare `Promise<…>` only. Rails' `@connection` is always the real adapter, and the sync fast path the union existed for died with #7051. The plain-object mock sources in the four dumper test files are `async` to match; no `instanceof Promise` fork remains.

**`ConnectionPool#checkout`: the critical section is unreachable, not backlog** (`connection_pool.rb:550-565`)
Per RFC 0023 intake rule 3, this one closes as a call-site comment rather than machinery. I wrote the concurrency test first: it passes on baseline. The pinned branch has exactly one yield point (`verifyBang`), and everything after it — the `@connections` membership read and the push — runs in a single synchronous continuation, so no second checkout can observe the pool between them. A JS body that mutates only before its first `await`, or only after its last, needs no analogue of the mutex; the `@missingRailsCall lock` reason now says which of those it is instead of appealing to "JS has no threads". Rails' second, in-lock read of `@pinned_connection` (`:552`) collapses to one read for the same reason, which is documented rather than left implicit.

**Gates:** `parity:api:calls` OK (no new rows), `parity:api:calls:args` OK, `parity:api:extra` loses the `validatesUniqueness` novel row on `base.ts` — activerecord novel 384→381, total 1391→1386, marks tightened. AR association / validation / encryption / dumper / pool suites green locally on SQLite.

Closes-story: converge-association-check-klass-onto-reflection-check-validity
Closes-story: db-warnings-ignore-is-an-adapter-class-attribute
Closes-story: drop-validates-uniqueness-for-validates-uniqueness-of
Closes-story: narrow-schema-source-to-its-single-async-arm
Closes-story: connection-pool-checkout-async-critical-section
