### PR TITLE
refactor(activerecord): PG Column ivars, sqlite3 quote_default_expression super, model-layer MySQL concurrency tests, zero-import CollectionProxy load (RFC 0096, RFC 0077, RFC 0119)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
@@ -1,49 +1,40 @@
-import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import {
-  describeIfMysqlAdapter,
-  leaseMysqlAdapter,
-  Mysql2Adapter,
-  MYSQL_TEST_URL,
-} from "./test-helper.js";
+/**
+ * Mirrors Rails
+ * activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
+ */
+import { describe, it, expect } from "vitest";
+import { IsolatedExecutionState } from "@blazetrails/activesupport";
+import { describeIfMysqlAdapter } from "./test-helper.js";
+import { fixtures } from "../../test-fixtures.js";
+import { Bulb } from "../../test-helpers/models/bulb.js";
+import { Author } from "../../test-helpers/models/author.js";
+// Rails' `require "models/car"` (count_deleted_rows_with_lock_test.rb:7) — Bulb
+// `belongs_to :car`, so the constant has to be loaded before Bulb.create.
+import { Car } from "../../test-helpers/models/car.js";
+import { registerModel } from "../../associations.js";
+
+// Rails' `require "models/..."` (count_deleted_rows_with_lock_test.rb:4-7) makes
+// each constant resolvable; the trails equivalent is registering them.
+registerModel([Bulb, Author, Car]);
 
 describeIfMysqlAdapter("Mysql2Adapter", () => {
-  let adapter: Mysql2Adapter;
-  beforeEach(async () => {
-    adapter = await leaseMysqlAdapter();
-  });
-
   describe("CountDeletedRowsWithLockTest", () => {
-    beforeEach(async () => {
-      await adapter.execute("DROP TABLE IF EXISTS `test_bulbs`");
-      await adapter.execute("DROP TABLE IF EXISTS `test_authors`");
-      await adapter.execute(
-        "CREATE TABLE `test_bulbs` (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), color VARCHAR(255))",
-      );
-      await adapter.execute(
-        "CREATE TABLE `test_authors` (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255))",
-      );
-    });
-    afterEach(async () => {
-      await adapter.execute("DROP TABLE IF EXISTS `test_bulbs`").catch(() => {});
-      await adapter.execute("DROP TABLE IF EXISTS `test_authors`").catch(() => {});
-    });
+    fixtures([]);
 
     it("delete and create in different threads synchronize correctly", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `test_bulbs` (name, color) VALUES ('Jimmy', 'blue')",
-      );
+      await Bulb.unscoped().deleteAll();
+      await Bulb.create({ name: "Jimmy", color: "blue" });
 
-      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
-      try {
-        const [deleteResult] = await Promise.all([
-          adapter.executeMutation("DELETE FROM `test_bulbs`"),
-          adapter2.executeMutation("INSERT INTO `test_authors` (name) VALUES ('Tommy')"),
-        ]);
+      // Rails' `Thread.new` (count_deleted_rows_with_lock_test.rb:14-20).
+      // `IsolatedExecutionState.run` is the trails analogue: it opens a fresh
+      // execution context, which is what the connection pool leases per
+      // (connection_pool.rb:711 `connection_lease`).
+      const deleteThread = IsolatedExecutionState.run(async () => Bulb.unscoped().deleteAll());
+      const createThread = IsolatedExecutionState.run(async () => Author.create({ name: "Tommy" }));
 
-        expect(deleteResult).toBe(1);
-      } finally {
-        await adapter2.close();
-      }
+      const [deleteValue] = await Promise.all([deleteThread, createThread]);
+
+      expect(deleteValue).toBe(1);
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/count-deleted-rows-with-lock.test.ts
@@ -3,13 +3,13 @@
  * activerecord/test/cases/adapters/abstract_mysql_adapter/count_deleted_rows_with_lock_test.rb
  */
 import { describe, it, expect } from "vitest";
-import { IsolatedExecutionState } from "@blazetrails/activesupport";
+import { withExecutionContext } from "../../connection-adapters/abstract/connection-pool/execution-context.js";
 import { describeIfMysqlAdapter } from "./test-helper.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Bulb } from "../../test-helpers/models/bulb.js";
 import { Author } from "../../test-helpers/models/author.js";
 // Rails' `require "models/car"` (count_deleted_rows_with_lock_test.rb:7) — Bulb
-// `belongs_to :car`, so the constant has to be loaded before Bulb.create.
+// `belongs_to :car`, so the constant has to be loaded before Bulb.createBang.
 import { Car } from "../../test-helpers/models/car.js";
 import { registerModel } from "../../associations.js";
 
@@ -23,14 +23,18 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("delete and create in different threads synchronize correctly", async () => {
       await Bulb.unscoped().deleteAll();
-      await Bulb.create({ name: "Jimmy", color: "blue" });
+      await Bulb.createBang({ name: "Jimmy", color: "blue" });
 
       // Rails' `Thread.new` (count_deleted_rows_with_lock_test.rb:14-20).
-      // `IsolatedExecutionState.run` is the trails analogue: it opens a fresh
-      // execution context, which is what the connection pool leases per
-      // (connection_pool.rb:711 `connection_lease`).
-      const deleteThread = IsolatedExecutionState.run(async () => Bulb.unscoped().deleteAll());
-      const createThread = IsolatedExecutionState.run(async () => Author.create({ name: "Tommy" }));
+      // `withExecutionContext` is the trails analogue: it sets the id the pool
+      // keys leases on (connection_pool.rb:711 `connection_lease`), which plain
+      // `IsolatedExecutionState.run` leaves unset. Both sides still land on the
+      // one fixture-pinned connection, exactly as they do in Rails — this class
+      // keeps transactional tests on (unlike NestedDeadlockTest), and Rails
+      // shares the pinned connection across threads via `lock_thread`. Sharing
+      // it is the point: the two statements contend on the same connection.
+      const deleteThread = withExecutionContext(async () => Bulb.unscoped().deleteAll());
+      const createThread = withExecutionContext(async () => Author.createBang({ name: "Tommy" }));
 
       const [deleteValue] = await Promise.all([deleteThread, createThread]);
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -8,7 +8,7 @@ import { describeIfMysqlAdapter, leaseMysqlAdapter } from "./test-helper.js";
 import { fixtures } from "../../test-fixtures.js";
 import { registerModel } from "../../associations.js";
 import { Base } from "../../base.js";
-import { Deadlocked, Rollback } from "../../errors.js";
+import { Deadlocked, Rollback, StatementInvalid } from "../../errors.js";
 import { SavepointTransaction } from "../../connection-adapters/abstract/transaction.js";
 
 // Rails' `class Sample < ActiveRecord::Base` (nested_deadlock_test.rb:9-12) —
@@ -47,6 +47,19 @@ async function makeParentTransactionDirty(): Promise<void> {
 async function assertCurrentTransactionIsSavepointTransaction(): Promise<void> {
   const currentTransaction = (await Sample.leaseConnection()).currentTransaction();
   expect(currentTransaction).toBeInstanceOf(SavepointTransaction);
+}
+
+// nested_deadlock_test.rb:64-70 — the savepoint race surfaces as an opaque
+// StatementInvalid, so Rails flunks with a diagnosis rather than re-raising it.
+function flunkOnLostSavepoint(errors: unknown[]): void {
+  const lost = errors.find(
+    (e) =>
+      e instanceof StatementInvalid && /SAVEPOINT active_record_. does not exist/.test(String(e)),
+  );
+  if (lost === undefined) return;
+  expect.fail(
+    `ROLLBACK TO SAVEPOINT query issued for savepoint that no longer exists due to deadlock: ${String(lost)}`,
+  );
 }
 
 describeIfMysqlAdapter("Mysql2Adapter", () => {
@@ -108,6 +121,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
       const outcomes = await Promise.allSettled([thread, main]);
       const errors = outcomes.filter((o) => o.status === "rejected").map((o) => o.reason);
+      flunkOnLostSavepoint(errors);
       expect(errors).toHaveLength(1);
       expect(errors[0]).toBeInstanceOf(Deadlocked);
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -76,6 +76,10 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     afterEach(async () => {
+      // nested_deadlock_test.rb:24 — clear first, so no connection another
+      // execution context still holds is sitting on a `samples` lock when the
+      // drop runs.
+      Base.connectionHandler.clearActiveConnectionsBang("all");
       const connection = await leaseMysqlAdapter();
       await connection.dropTable("samples", { ifExists: true });
     });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/nested-deadlock.test.ts
@@ -1,168 +1,192 @@
+/**
+ * Mirrors Rails
+ * activerecord/test/cases/adapters/abstract_mysql_adapter/nested_deadlock_test.rb
+ */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import {
-  describeIfMysqlAdapter,
-  leaseMysqlAdapter,
-  Mysql2Adapter,
-  MYSQL_TEST_URL,
-} from "./test-helper.js";
+import { withExecutionContext } from "../../connection-adapters/abstract/connection-pool/execution-context.js";
+import { describeIfMysqlAdapter, leaseMysqlAdapter } from "./test-helper.js";
+import { fixtures } from "../../test-fixtures.js";
+import { registerModel } from "../../associations.js";
+import { Base } from "../../base.js";
 import { Deadlocked, Rollback } from "../../errors.js";
 import { SavepointTransaction } from "../../connection-adapters/abstract/transaction.js";
 
-function createBarrier(n: number): { wait: () => Promise<void> } {
+// Rails' `class Sample < ActiveRecord::Base` (nested_deadlock_test.rb:9-12) —
+// an inline model over the table the test creates itself.
+class Sample extends Base {
+  declare id: number;
+  declare value: number | null;
+  static {
+    this.tableName = "samples";
+  }
+}
+registerModel([Sample]);
+
+// `Concurrent::CyclicBarrier.new(2)` (nested_deadlock_test.rb:38).
+function cyclicBarrier(parties: number): { wait: () => Promise<void> } {
   let count = 0;
-  let resolve!: () => void;
-  const promise = new Promise<void>((r) => {
-    resolve = r;
+  let release!: () => void;
+  const gate = new Promise<void>((r) => {
+    release = r;
   });
   return {
     wait: () => {
-      count++;
-      if (count >= n) resolve();
-      return promise;
+      if (++count >= parties) release();
+      return gate;
     },
   };
 }
 
-async function makeParentDirty(a: Mysql2Adapter): Promise<void> {
-  await a.execQuery("SELECT * FROM `samples` LIMIT 1");
+// nested_deadlock_test.rb:177-180 — dirty the parent transaction so the next
+// nested one is a savepoint transaction.
+async function makeParentTransactionDirty(): Promise<void> {
+  await Sample.take();
 }
 
-function assertSavepoint(a: Mysql2Adapter): void {
-  expect(a.currentTransaction()).toBeInstanceOf(SavepointTransaction);
+// nested_deadlock_test.rb:182-187.
+async function assertCurrentTransactionIsSavepointTransaction(): Promise<void> {
+  const currentTransaction = (await Sample.leaseConnection()).currentTransaction();
+  expect(currentTransaction).toBeInstanceOf(SavepointTransaction);
 }
 
 describeIfMysqlAdapter("Mysql2Adapter", () => {
-  let adapter: Mysql2Adapter;
-  beforeEach(async () => {
-    adapter = await leaseMysqlAdapter();
-  });
-
   describe("NestedDeadlockTest", () => {
-    let s1id: number;
-    let s2id: number;
+    fixtures([], { useTransactionalTests: false });
 
     beforeEach(async () => {
-      await adapter.execute("DROP TABLE IF EXISTS `samples`");
-      await adapter.execute(
-        "CREATE TABLE `samples` (id INT AUTO_INCREMENT PRIMARY KEY, value INT)",
-      );
-      await adapter.execute("INSERT INTO `samples` (value) VALUES (1)");
-      await adapter.execute("INSERT INTO `samples` (value) VALUES (2)");
-      const rows = await adapter.execute("SELECT id FROM `samples` ORDER BY id");
-      s1id = Number(rows[0]["id"]);
-      s2id = Number(rows[1]["id"]);
+      const connection = await leaseMysqlAdapter();
+      await connection.clearCache();
+      await connection.createTable("samples", { force: true }, (t) => {
+        t.integer("value");
+      });
+      Sample.resetColumnInformation();
     });
+
     afterEach(async () => {
-      await adapter.execute("DROP TABLE IF EXISTS `samples`").catch(() => {});
+      const connection = await leaseMysqlAdapter();
+      await connection.dropTable("samples", { ifExists: true });
     });
-
-    async function raceNestedTransactions(
-      adapter2: Mysql2Adapter,
-      onDeadlock?: "rollback" | "swallow",
-    ): Promise<{ results: PromiseSettledResult<void>[]; deadlocks: number }> {
-      const barrier = createBarrier(2);
-      let deadlocks = 0;
-
-      const side = async (
-        a: Mysql2Adapter,
-        lockId: number,
-        updateId: number,
-        value: number,
-      ): Promise<void> => {
-        await a.transaction(async () => {
-          await makeParentDirty(a);
-          const nested = a.transaction({ requiresNew: true }, async () => {
-            assertSavepoint(a);
-            await a.execute(`SELECT * FROM \`samples\` WHERE id = ${lockId} FOR UPDATE`);
-            await barrier.wait();
-            try {
-              await a.executeMutation(
-                `UPDATE \`samples\` SET value = ${value} WHERE id = ${updateId}`,
-              );
-            } catch (e) {
-              if (onDeadlock === "rollback" && e instanceof Deadlocked) {
-                deadlocks++;
-                throw new Rollback();
-              }
-              throw e;
-            }
-          });
-          if (onDeadlock === "swallow") {
-            try {
-              await nested;
-            } catch (e) {
-              if (!(e instanceof Deadlocked)) throw e;
-              deadlocks++;
-            }
-          } else {
-            await nested;
-          }
-          if (onDeadlock !== undefined) {
-            await a.executeMutation(`UPDATE \`samples\` SET value = 10 WHERE id = ${updateId}`);
-          }
-        });
-      };
-
-      const results = await Promise.allSettled([
-        side(adapter, s1id, s2id, onDeadlock ? 4 : 1),
-        side(adapter2, s2id, s1id, onDeadlock ? 3 : 2),
-      ]);
-      return { results, deadlocks };
-    }
-
-    async function expectFinalValues(values: number[]): Promise<void> {
-      const finalRows = await adapter.execute("SELECT value FROM `samples` ORDER BY id");
-      expect(finalRows.map((r) => Number(r["value"]))).toEqual(values);
-    }
 
     it("deadlock correctly raises Deadlocked inside nested SavepointTransaction", async () => {
-      // Stays self-built: the second side of the deadlock needs its own
-      // connection (Rails runs it on its own thread).
-      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
-      try {
-        const { results } = await raceNestedTransactions(adapter2);
+      const connection = await Sample.leaseConnection();
+      const barrier = cyclicBarrier(2);
 
-        const errors = results.filter((r) => r.status === "rejected").map((r) => r.reason);
-        expect(errors).toHaveLength(1);
-        expect(errors[0]).toBeInstanceOf(Deadlocked);
+      const s1 = await Sample.create({ value: 1 });
+      const s2 = await Sample.create({ value: 2 });
 
-        expect(await adapter.active()).toBe(true);
-        expect(await adapter2.active()).toBe(true);
-      } finally {
-        await adapter2.close();
-      }
+      // Rails' `Thread.new` (nested_deadlock_test.rb:45). `withExecutionContext`
+      // is the trails analogue for the part that matters here: the pool leases
+      // per execution context (connection_pool.rb:711 `connection_lease`), so
+      // the two sides run on two connections and can really deadlock.
+      const thread = withExecutionContext(async () =>
+        Sample.transaction(async () => {
+          await makeParentTransactionDirty();
+          await Sample.transaction(
+            async () => {
+              await assertCurrentTransactionIsSavepointTransaction();
+              await s1.lockBang();
+              await barrier.wait();
+              await s2.update({ value: 1 });
+            },
+            { requiresNew: true },
+          );
+        }),
+      );
+
+      const main = Sample.transaction(async () => {
+        await makeParentTransactionDirty();
+        await Sample.transaction(
+          async () => {
+            await assertCurrentTransactionIsSavepointTransaction();
+            await s2.lockBang();
+            await barrier.wait();
+            await s1.update({ value: 2 });
+          },
+          { requiresNew: true },
+        );
+      });
+
+      const outcomes = await Promise.allSettled([thread, main]);
+      const errors = outcomes.filter((o) => o.status === "rejected").map((o) => o.reason);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toBeInstanceOf(Deadlocked);
+
+      expect(await connection.active()).toBe(true);
     });
 
     it("rollback exception is swallowed after a rollback", async () => {
-      // Stays self-built: the second side of the deadlock needs its own
-      // connection (Rails runs it on its own thread).
-      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
-      try {
-        const { results, deadlocks } = await raceNestedTransactions(adapter2, "rollback");
+      const barrier = cyclicBarrier(2);
+      let deadlocks = 0;
 
-        expect(results[0].status).toBe("fulfilled");
-        expect(results[1].status).toBe("fulfilled");
-        expect(deadlocks).toBe(1);
-        await expectFinalValues([10, 10]);
-      } finally {
-        await adapter2.close();
-      }
+      const s1 = await Sample.create({ value: 1 });
+      const s2 = await Sample.create({ value: 2 });
+
+      const side = async (locked: Sample, updated: Sample, value: number): Promise<void> =>
+        Sample.transaction(async () => {
+          await makeParentTransactionDirty();
+          await Sample.transaction(
+            async () => {
+              try {
+                await assertCurrentTransactionIsSavepointTransaction();
+                await locked.lockBang();
+                await barrier.wait();
+                await updated.update({ value });
+              } catch (e) {
+                if (!(e instanceof Deadlocked)) throw e;
+                deadlocks += 1;
+                // nested_deadlock_test.rb:99-101: "This rollback is actually
+                // wrong as mysql automatically rollbacks the transaction which
+                // means we have nothing to rollback on the db side but we
+                // expect the framework to handle our mistake gracefully".
+                throw new Rollback();
+              }
+            },
+            { requiresNew: true },
+          );
+          await updated.update({ value: 10 });
+        });
+
+      const thread = withExecutionContext(async () => side(s1, s2, 4));
+      await side(s2, s1, 3);
+      await thread;
+
+      expect(deadlocks).toBe(1);
+      expect(await Sample.pluck("value")).toEqual([10, 10]);
     });
 
     it("deadlock inside nested SavepointTransaction is recoverable", async () => {
-      // Stays self-built: the second side of the deadlock needs its own
-      // connection (Rails runs it on its own thread).
-      const adapter2 = new Mysql2Adapter(MYSQL_TEST_URL);
-      try {
-        const { results, deadlocks } = await raceNestedTransactions(adapter2, "swallow");
+      const barrier = cyclicBarrier(2);
+      let deadlocks = 0;
 
-        expect(results[0].status).toBe("fulfilled");
-        expect(results[1].status).toBe("fulfilled");
-        expect(deadlocks).toBe(1);
-        await expectFinalValues([10, 10]);
-      } finally {
-        await adapter2.close();
-      }
+      const s1 = await Sample.create({ value: 1 });
+      const s2 = await Sample.create({ value: 2 });
+
+      const side = async (locked: Sample, updated: Sample, value: number): Promise<void> =>
+        Sample.transaction(async () => {
+          await makeParentTransactionDirty();
+          try {
+            await Sample.transaction(
+              async () => {
+                await assertCurrentTransactionIsSavepointTransaction();
+                await locked.lockBang();
+                await barrier.wait();
+                await updated.update({ value });
+              },
+              { requiresNew: true },
+            );
+          } catch (e) {
+            if (!(e instanceof Deadlocked)) throw e;
+            deadlocks += 1;
+          }
+          await updated.update({ value: 10 });
+        });
+
+      const thread = withExecutionContext(async () => side(s1, s2, 4));
+      await side(s2, s1, 3);
+      await thread;
+
+      expect(deadlocks).toBe(1);
+      expect(await Sample.pluck("value")).toEqual([10, 10]);
     });
   });
 });

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,11 +1,23 @@
 import type { Base } from "./base.js";
+/**
+ * Force `relation.ts` to be evaluated before anything below reaches
+ * `relation/query-methods.ts` on its own: `relation.ts`'s module body calls
+ * `include(Relation, QueryMethodBangs)` (`relation.rb:68`), so a graph entered
+ * at THIS module that reaches query-methods first observes `QueryMethodBangs`
+ * in TDZ. `relation.ts` already imports this module (relation -> insert-all ->
+ * model-schema -> associations), so this edge closes no NEW cycle, and nothing
+ * here touches `Relation` at module scope. It replaces the side-effect imports
+ * of Relation SUBCLASSES that used to sit here and made entering the graph at
+ * `relation.ts` impossible — those load through the zero-import slots in
+ * `associations/collection-proxy-slot.ts` and `associations/_scope-slots.ts`,
+ * the way Zeitwerk autoloads them in Ruby (CLAUDE.md, "Call-time constant
+ * resolution (Ruby autoload -> the zero-import slot)").
+ */
+import "./relation.js";
 import type { Relation } from "./relation.js";
 import { SpellChecker } from "@blazetrails/did-you-mean";
 import type { CollectionProxy, AssociationProxy } from "./associations/collection-proxy.js";
 import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
-import "./associations/collection-proxy.js";
-import "./association-relation.js";
-import "./associations/disable-joins-association-scope.js";
 import { hasDefaultScopeOverride } from "./scoping/default.js";
 import {
   delegateArrayMethod,

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,17 +1,15 @@
 import type { Base } from "./base.js";
 /**
- * Force `relation.ts` to be evaluated before anything below reaches
- * `relation/query-methods.ts` on its own: `relation.ts`'s module body calls
+ * Evaluate `relation.ts` before anything below reaches
+ * `relation/query-methods.ts` on its own: `relation.ts`'s module body runs
  * `include(Relation, QueryMethodBangs)` (`relation.rb:68`), so a graph entered
- * at THIS module that reaches query-methods first observes `QueryMethodBangs`
- * in TDZ. `relation.ts` already imports this module (relation -> insert-all ->
- * model-schema -> associations), so this edge closes no NEW cycle, and nothing
- * here touches `Relation` at module scope. It replaces the side-effect imports
- * of Relation SUBCLASSES that used to sit here and made entering the graph at
- * `relation.ts` impossible — those load through the zero-import slots in
- * `associations/collection-proxy-slot.ts` and `associations/_scope-slots.ts`,
- * the way Zeitwerk autoloads them in Ruby (CLAUDE.md, "Call-time constant
- * resolution (Ruby autoload -> the zero-import slot)").
+ * at THIS module that reaches query-methods first sees `QueryMethodBangs` in
+ * TDZ. `relation.ts` already imports this module (relation -> insert-all ->
+ * model-schema -> associations), so this closes no NEW cycle, and nothing here
+ * touches `Relation` at module scope. It replaces the side-effect imports of
+ * Relation SUBCLASSES that used to sit here and made entering at `relation.ts`
+ * impossible; those now load through their zero-import slots (CLAUDE.md,
+ * "Call-time constant resolution (Ruby autoload -> the zero-import slot)").
  */
 import "./relation.js";
 import type { Relation } from "./relation.js";

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -10,6 +10,19 @@
 // in activerecord/index.ts) to keep better-sqlite3 a true optional peer for
 // non-test consumers.
 import "../sqlite/better-sqlite3.js";
+// Zeitwerk autoloads `CollectionProxy` when `CollectionAssociation#reader`
+// names it (collection_association.rb `reader` -> `CollectionProxy.create`), so
+// Ruby never needs an explicit require. ESM has no call-time load, and
+// `associations.ts` MUST NOT import it — `collection-proxy.ts` extends
+// `Relation`, which closes the relation<->associations cycle (see CLAUDE.md,
+// "Call-time constant resolution"). The class self-registers into the
+// zero-import slot on load, so it is loaded here — a module outside that cycle
+// — exactly as `index.ts` does for package consumers.
+import "../associations/collection-proxy.js";
+// Same story for the other two `Relation` subclasses `associations.ts` used to
+// force-load: each self-registers into `associations/_scope-slots.ts` on load.
+import "../association-relation.js";
+import "../associations/disable-joins-association-scope.js";
 import { afterAll, afterEach, expect } from "vitest";
 import { Base } from "../base.js";
 import { I18n } from "@blazetrails/activemodel";

--- a/packages/activerecord/src/cases/helper.ts
+++ b/packages/activerecord/src/cases/helper.ts
@@ -10,17 +10,14 @@
 // in activerecord/index.ts) to keep better-sqlite3 a true optional peer for
 // non-test consumers.
 import "../sqlite/better-sqlite3.js";
-// Zeitwerk autoloads `CollectionProxy` when `CollectionAssociation#reader`
-// names it (collection_association.rb `reader` -> `CollectionProxy.create`), so
-// Ruby never needs an explicit require. ESM has no call-time load, and
-// `associations.ts` MUST NOT import it — `collection-proxy.ts` extends
-// `Relation`, which closes the relation<->associations cycle (see CLAUDE.md,
-// "Call-time constant resolution"). The class self-registers into the
-// zero-import slot on load, so it is loaded here — a module outside that cycle
-// — exactly as `index.ts` does for package consumers.
+// Zeitwerk autoloads these three when a method body names them
+// (collection_association.rb `reader` -> `CollectionProxy.create`); ESM has no
+// call-time load, and `associations.ts` cannot import them because each extends
+// `Relation`, closing the relation<->associations cycle. They self-register into
+// their zero-import slots on load, so they are loaded from here — outside that
+// cycle — as `index.ts` does for package consumers (CLAUDE.md, "Call-time
+// constant resolution (Ruby autoload -> the zero-import slot)").
 import "../associations/collection-proxy.js";
-// Same story for the other two `Relation` subclasses `associations.ts` used to
-// force-load: each self-registers into `associations/_scope-slots.ts` on load.
 import "../association-relation.js";
 import "../associations/disable-joins-association-scope.js";
 import { afterAll, afterEach, expect } from "vitest";

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -10,8 +10,8 @@ import { TypeMetadata } from "./type-metadata.js";
 import { isPresent } from "@blazetrails/activesupport";
 
 export class Column extends BaseColumn {
-  serial: boolean;
-  identity: string | null;
+  private _serial: boolean;
+  private _identity: string | null;
   private _generated: string | null;
 
   constructor(
@@ -33,8 +33,8 @@ export class Column extends BaseColumn {
       defaultFunction: options.defaultFunction,
       comment: options.comment,
     });
-    this.serial = options.serial ?? false;
-    this.identity = options.identity ?? null;
+    this._serial = options.serial ?? false;
+    this._identity = options.identity ?? null;
     this._generated = options.generated ?? null;
   }
 
@@ -72,7 +72,7 @@ export class Column extends BaseColumn {
   // PostgreSQLAdapter#newColumnFromField). An explicit
   // `default: -> { "nextval('some_seq')" }` is NOT serial.
   get isSerial(): boolean {
-    return this.serial;
+    return this._serial;
   }
 
   /**
@@ -82,7 +82,7 @@ export class Column extends BaseColumn {
    * key leaves it absent, which `!= null` reads the way Ruby reads nil.
    */
   get isIdentity(): boolean {
-    return this.identity != null;
+    return this._identity != null;
   }
 
   /**
@@ -147,16 +147,16 @@ export class Column extends BaseColumn {
    * and `array` is derived.
    */
   override initWith(coder: ColumnCoder): void {
-    this.serial = (coder["serial"] as boolean) ?? false;
-    this.identity = (coder["identity"] as string | null) ?? null;
+    this._serial = (coder["serial"] as boolean) ?? false;
+    this._identity = (coder["identity"] as string | null) ?? null;
     this._generated = (coder["generated"] as string | null) ?? null;
     super.initWith(coder);
   }
 
   /** @see Column#encodeWith — this subclass' half of the JSON class tag. */
   override encodeWith(coder: ColumnCoder): void {
-    coder["serial"] = this.serial;
-    coder["identity"] = this.identity;
+    coder["serial"] = this._serial;
+    coder["identity"] = this._identity;
     coder["generated"] = this._generated;
     super.encodeWith(coder);
     coder["class"] = "PostgreSQL::Column";

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.trails.test.ts
@@ -5,7 +5,9 @@ import { BinaryData } from "@blazetrails/activemodel";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
-import { type SQLite3Adapter, SQLite3DateTime } from "../sqlite3-adapter.js";
+import { SQLite3Adapter, SQLite3DateTime } from "../sqlite3-adapter.js";
+import { TypeMap } from "../../type/type-map.js";
+import { lookupCastType } from "../abstract/quoting.js";
 import { Date as DateType } from "../../type/date.js";
 import { Time as TimeType } from "../../type/time.js";
 import {
@@ -23,7 +25,16 @@ import {
   typeCast as typeCastFn,
 } from "./quoting.js";
 
+// `quoteDefaultExpression`'s non-Proc arm delegates to the abstract body, which
+// self-sends `lookup_cast_type` (`abstract/quoting.rb:161`); the bare prototype
+// carries no instance config, so wire the SQLite3 type map here.
+const TYPE_MAP = new TypeMap();
+SQLite3Adapter.initializeTypeMap(TYPE_MAP);
+
 const HOST = quotingHost({
+  lookupCastType(sqlType: string | null) {
+    return lookupCastType.call({ typeMap: TYPE_MAP }, sqlType);
+  },
   quotedDate,
   quotedTime,
   quotedBinary,
@@ -232,6 +243,14 @@ describe("SQLite3::Quoting", () => {
       expect(quoteDefaultExpression.call(HOST, () => "CURRENT_TIMESTAMP", {})).toBe(
         "CURRENT_TIMESTAMP",
       );
+    });
+
+    it("serializes a non-Proc default through the column's cast type", () => {
+      // `sqlite3/quoting.rb:107` is `super`, i.e. `abstract/quoting.rb:161`'s
+      // `lookup_cast_type(column.sql_type).serialize(value)` — a structured
+      // `json` default must reach the JSON text, not `String({})`.
+      expect(quoteDefaultExpression.call(HOST, {}, { sqlType: "json" })).toBe("'{}'");
+      expect(quoteDefaultExpression.call(HOST, { a: 1 }, { sqlType: "json" })).toBe("'{\"a\":1}'");
     });
 
     it("quotes a binary default through SQLite's quotedBinary", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -10,6 +10,9 @@
 
 import {
   quote as abstractQuote,
+  quoteDefaultExpression as abstractQuoteDefaultExpression,
+  isSqlLiteral,
+  type QuotingHost,
   quotedDate as abstractQuotedDate,
   typeCast as abstractTypeCast,
   toBytes,
@@ -174,24 +177,29 @@ export function quotedBinary(value: Uint8Array | ArrayBuffer | BinaryData): stri
 }
 
 export function quoteDefaultExpression(
-  this: QuotingDispatchHost,
+  this: QuotingDispatchHost & QuotingHost,
   value: unknown,
-  _column: unknown,
+  column: { sqlType?: string | null },
 ): string {
-  if (value === undefined) return "";
-  if (value === null) return "NULL";
+  // Rails' Proc arm (`sqlite3/quoting.rb:100-105`): call the Proc, and wrap a
+  // bare function call in parentheses for SQLite DDL (`DEFAULT (ABS(RANDOM()))`).
+  // In Ruby `SqlLiteral < String`, so a SqlLiteral result runs through the same
+  // `match?` regex — unwrap it rather than special-casing it.
   if (typeof value === "function") {
     const result = (value as () => unknown)();
-    if (result === undefined) return "";
-    if (result === null) return "NULL";
-    const str = String(result);
-    if (/^\w+\(.*\)$/.test(str)) return `(${str})`;
-    return str;
+    const str = typeof result === "string" ? result : isSqlLiteral(result) ? result.value : null;
+    if (str === null) {
+      throw new TypeError(
+        "quoteDefaultExpression expected function default to return a string or SqlLiteral",
+      );
+    }
+    return /^\w+\(.*\)$/.test(str) ? `(${str})` : str;
   }
-  // Rails: `quote(value)` — self-dispatched, so date/time defaults reach
-  // SQLite's quotedDate / quotedTime overrides and binary defaults its
-  // `x'..'` quotedBinary (the adapter binds `this`).
-  return quote.call(this, value);
+  // Rails: `else super` (`sqlite3/quoting.rb:107`) — the abstract body, which
+  // serializes through the column's cast type (`abstract/quoting.rb:161`) before
+  // quoting. `quote` is self-sent there, so binary / date / time defaults still
+  // reach SQLite's own quotedBinary / quotedDate overrides via this receiver.
+  return abstractQuoteDefaultExpression.call(this, value, column);
 }
 
 export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat = false): unknown {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -349,3 +349,11 @@ export { Resolver as DatabaseSelectorResolver } from "./middleware/database-sele
 export { Session as DatabaseSelectorSession } from "./middleware/database-selector/resolver/session.js";
 export { DatabaseSelector } from "./middleware/database-selector.js";
 export { ShardSelector } from "./middleware/shard-selector.js";
+
+// `DisableJoinsAssociationScope` has no exported name here, but it must still be
+// loaded so it registers its scope builder into `associations/_scope-slots.ts`
+// (Zeitwerk autoloads it in Ruby when `Association#scope` names it).
+// `associations.ts` cannot load it: it extends `Relation`, and that edge closes
+// the relation<->associations cycle. See CLAUDE.md, "Call-time constant
+// resolution (Ruby autoload → the zero-import slot)".
+import "./associations/disable-joins-association-scope.js";

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -350,10 +350,8 @@ export { Session as DatabaseSelectorSession } from "./middleware/database-select
 export { DatabaseSelector } from "./middleware/database-selector.js";
 export { ShardSelector } from "./middleware/shard-selector.js";
 
-// `DisableJoinsAssociationScope` has no exported name here, but it must still be
-// loaded so it registers its scope builder into `associations/_scope-slots.ts`
-// (Zeitwerk autoloads it in Ruby when `Association#scope` names it).
-// `associations.ts` cannot load it: it extends `Relation`, and that edge closes
-// the relation<->associations cycle. See CLAUDE.md, "Call-time constant
-// resolution (Ruby autoload → the zero-import slot)".
+// No exported name, but it must be loaded so it registers its scope builder into
+// `associations/_scope-slots.ts` (Zeitwerk autoloads it when `Association#scope`
+// names it). `associations.ts` cannot load it: it extends `Relation`, closing
+// the relation<->associations cycle. CLAUDE.md, "Call-time constant resolution".
 import "./associations/disable-joins-association-scope.js";

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -409,12 +409,12 @@ describe("PrimaryKeysTest", () => {
     const cols = (await (Base.connection as any).columns("mixed_case_monkeys")) as {
       name: string;
       defaultFunction?: string;
-      serial?: boolean;
+      isSerial?: boolean;
     }[];
     const col = cols.find((c) => c.name === "monkeyID");
     expect(col).toBeDefined();
     expect(col!.defaultFunction).toBe("nextval('\"mixed_case_monkeys_monkeyID_seq\"'::regclass)");
-    expect(col!.serial).toBeTruthy();
+    expect(col!.isSerial).toBeTruthy();
   });
 
   it.skipIf(adapterType !== "postgres")("serial with unquoted sequence name", async () => {
@@ -423,12 +423,12 @@ describe("PrimaryKeysTest", () => {
     const cols = (await (Base.connection as any).columns("topics")) as {
       name: string;
       defaultFunction?: string;
-      serial?: boolean;
+      isSerial?: boolean;
     }[];
     const col = cols.find((c) => c.name === "id");
     expect(col).toBeDefined();
     expect(col!.defaultFunction).toBe("nextval('topics_id_seq'::regclass)");
-    expect(col!.serial).toBeTruthy();
+    expect(col!.isSerial).toBeTruthy();
   });
 });
 

--- a/scripts/test-deps/relation-entry-import-tdz.test.ts
+++ b/scripts/test-deps/relation-entry-import-tdz.test.ts
@@ -1,0 +1,27 @@
+// Regression guard for the relation<->associations circular-init TDZ crash.
+//
+// `associations.ts` used to force-load two `Relation` SUBCLASSES at module
+// scope (`associations/collection-proxy.js`, `association-relation.js`, and the
+// `disable-joins-association-scope.js` that reaches a third). Since
+// `relation.ts` reaches `associations.ts` (relation -> insert-all ->
+// model-schema -> associations), entering the graph at `relation.ts` re-entered
+// it while `Relation` was still in its temporal dead zone, crashing with
+// `ReferenceError: Cannot access 'Relation' before initialization`. Those three
+// now load through the zero-import slots (`associations/collection-proxy-slot.ts`,
+// `associations/_scope-slots.ts`) the way Zeitwerk autoloads them in Ruby — see
+// CLAUDE.md, "Call-time constant resolution (Ruby autoload → the zero-import
+// slot)".
+//
+// Like the adapter-graph guard next door, this lives in the `other` vitest
+// project, which does NOT preload the ActiveRecord graph via setupFiles, so the
+// import below really is the entry module.
+//
+// The import is deliberately the first thing this module touches.
+import { Relation } from "../../packages/activerecord/src/relation.js";
+import { describe, it, expect } from "vitest";
+
+describe("relation entry circular-init", () => {
+  it("imports Relation (value) without a TDZ ReferenceError", () => {
+    expect(typeof Relation).toBe("function");
+  });
+});


### PR DESCRIPTION
* PostgreSQL::Column `serial` / `identity` become private `_serial` /
  `_identity` ivars behind `isSerial` / `isIdentity`, matching
  `postgresql/column.rb:9-22` where neither has an attr_reader. The
  `"serial"` / `"identity"` coder keys are unchanged, so the schema-cache
  round-trip is untouched.

* sqlite3 `quoteDefaultExpression`'s standalone keeps only Rails' Proc arm and
  delegates the `else` to the abstract body (`sqlite3/quoting.rb:107` is
  `super`), so `lookup_cast_type(column.sql_type).serialize`
  (`abstract/quoting.rb:161`) runs for SQLite defaults — a `json` default now
  reaches the JSON text instead of a bare `quote()`.

* The two abstract_mysql_adapter concurrency tests move from raw SQL on two
  adapters to the model layer, as Rails writes them: canonical `Bulb`/`Author`
  for the count test, an inline `Sample` for the deadlock one, with
  `withExecutionContext()` as the `Thread.new` analogue (the pool leases per
  execution context, `connection_pool.rb:711`).

* `associations.ts` no longer force-loads `collection-proxy.ts`,
  `association-relation.ts` or `disable-joins-association-scope.ts` — all three
  extend `Relation`, which made entering the graph at `relation.ts` throw
  `Cannot access 'Relation' before initialization`. They self-register into the
  zero-import slots and are loaded from outside the cycle (`index.ts`,
  `cases/helper.ts`), the way Zeitwerk autoloads them in Ruby.

Closes-story: pg-column-serial-identity-fields-are-public-where-rails-has-ivars
Closes-story: sqlite3-quote-default-expression-standalone-skips-serialize
Closes-story: abstract-mysql-concurrency-tests-model-layer
Closes-story: associations-must-not-force-load-collection-proxy