### PR TITLE
fix(activerecord): CollectionProxy reads its single association seat in _findTargetViaAssociation

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -437,9 +437,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private async _findTargetViaAssociation(queryExecutor?: () => Promise<Base[]>): Promise<Base[]> {
     if (
       !queryExecutor &&
-      !(
-        this._collectionAssociation() as unknown as { findTargetNeeded(): boolean }
-      ).findTargetNeeded()
+      !(this._association as unknown as { findTargetNeeded(): boolean }).findTargetNeeded()
     ) {
       return [];
     }


### PR DESCRIPTION
## Root cause

`#7047` ("one CollectionProxy association seat") replaced the per-call `_collectionAssociation()` helper with the `_association` field and deleted the helper, but one caller — `_findTargetViaAssociation` (`packages/activerecord/src/associations/collection-proxy.ts:441`) — still named it. That line landed on main via #7060 and tsc rejects it:

```
packages/activerecord/src/associations/collection-proxy.ts(441,14): error TS2339: Property '_collectionAssociation' does not exist on type 'CollectionProxy<T>'.
```

which reds `Virtualized DX Type Tests`, `Guides Code Type Check` (`pnpm build`), and `Leaf Tests` (DX type tests).

## Fix

Read `this._association` — the same holder the deleted helper returned (`record.association(assocName)`, set in the constructor) — so `find_target?` (`activerecord/lib/active_record/associations/association.rb:190`) is still asked of the owner's own holder.

`pnpm build` and `pnpm test:types:virtualized` are green locally.

Closes-story: red-0f9245c1