### PR TITLE
refactor(activerecord,trailties): name the StatementPool type, four insert_all guards, single-arm SchemaDumper.dump, retire PG clear_cache! override (RFC 0112)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -207,36 +207,6 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(pool.length).toBe(0);
     });
 
-    it("tags the released client and runs DEALLOCATE ALL on its next checkout", async () => {
-      await adapter.beginDbTransaction();
-      await adapter.execute("SELECT $1::int", [1]);
-      await adapter.rollback();
-      await adapter.reconnect();
-      await adapter.beginDbTransaction();
-      await adapter.execute("SELECT $1::int", [2]);
-      await adapter.rollback();
-      const conn = adapter._rawConnectionForTest();
-      adapter._rawConnection = null;
-      await adapter.clearCacheBang();
-      expect(adapter._needsDeallocateAllForTest()).toBe(true);
-      adapter._rawConnection = conn;
-      expect(conn).not.toBeNull();
-      const observed: string[] = [];
-      const live = conn!;
-      const origQuery = live.query.bind(live);
-      // pg's `query` is overloaded with a void-returning callback form, so the
-      // mock's Promise return trips checksVoidReturn; the Promise form is the one
-      // exercised here (execute awaits it), so the return is intentional.
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      vi.spyOn(live, "query").mockImplementation(((sql: unknown, ...rest: unknown[]) => {
-        if (typeof sql === "string") observed.push(sql);
-        return (origQuery as (...a: unknown[]) => unknown)(sql, ...rest);
-      }) as typeof live.query);
-      await adapter.execute("SELECT 1");
-      expect(observed[0]).toBe("DEALLOCATE ALL");
-      expect(adapter._needsDeallocateAllForTest()).toBe(false);
-    });
-
     it("clearCacheBang resets the released-client pool even when a new txn is in progress", async () => {
       await adapter.beginDbTransaction();
       await adapter.execute("SELECT $1::int", [1]);

--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -121,19 +121,6 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
   }
 
   /**
-   * Find the first record matching the current scope, or build one (unsaved).
-   * Routes build through the association so the FK and polymorphic type are
-   * set even when the owner is unsaved (no FK in the where clause).
-   *
-   * Mirrors: ActiveRecord::AssociationRelation#first_or_initialize
-   */
-  async firstOrInitialize(extra?: Record<string, unknown>): Promise<T> {
-    const records = await this.limit(1);
-    if (records.length > 0) return records[0];
-    return this.build(extra ?? {});
-  }
-
-  /**
    * Mirrors: ActiveRecord::AssociationRelation#_new (association_relation.rb:31-33).
    * The `scoping {}` wrap lives in `Relation#build` (relation.rb:125-132), so
    * `Association#scope` sees this relation as the current scope while the

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -125,6 +125,7 @@ import type {
   CheckConstraintDefinition,
 } from "./abstract/schema-definitions.js";
 import type { SchemaCreation } from "./abstract/schema-creation.js";
+import type { StatementPool } from "./statement-pool.js";
 import type { Column } from "./column.js";
 import { TypeMap } from "../type/type-map.js";
 import {
@@ -926,7 +927,7 @@ export class AbstractAdapter implements Quoting {
    *
    * @internal
    */
-  _statements?: { reset(): void; clear(): void | Promise<void> } | null;
+  _statements?: StatementPool | null;
   /** Stable per-instance hex slot + monotonic source for {@link inspect}. @internal */
   private _inspectId?: number;
   private static _inspectSeq?: number;

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -9,6 +9,7 @@ import type mysql from "mysql2/promise";
 import { Result, type ColumnTypes } from "../../result.js";
 import { combineMultiStatements, type MaxAllowedPacketHost } from "../mysql/database-statements.js";
 import { lastInsertedId as abstractLastInsertedId } from "../abstract/database-statements.js";
+import type { StatementPool } from "../statement-pool.js";
 
 export interface DatabaseStatementsHost {
   execQuery(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
@@ -113,7 +114,8 @@ export function buildColumnTypes(
 interface PerformQueryHost {
   _affectedRowsBeforeWarnings?: number;
   _lastId?: number;
-  _statements?: { delete(key: string): unknown } | null;
+  /** Rails' `@statements` (abstract_adapter.rb:156). */
+  _statements?: StatementPool | null;
   handleWarnings?(sql: string): void | Promise<void>;
   verified?(): void;
   preparedStatements?: boolean;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -534,7 +534,6 @@ export class PostgreSQLAdapter
   // names `@statements`.
   /** @internal */
   declare _statements: StatementPool;
-  private _needsDeallocateAll = false;
   private _closed = false;
   private _closingDriver: Promise<void> | null = null;
   // Per-acquire generation. Each _doAcquire captures the current value; a
@@ -1296,7 +1295,7 @@ export class PostgreSQLAdapter
     if (this._closed || this._pgClientOptions == null) {
       throw new Error("PostgreSQLAdapter: connection is closed");
     }
-    if (this._rawConnection && this._connectionConfigured && !this._needsDeallocateAll) {
+    if (this._rawConnection && this._connectionConfigured) {
       return this._rawConnection;
     }
     if (!this._acquiring || this._acquiringGen !== this._acquireGeneration) {
@@ -1360,10 +1359,6 @@ export class PostgreSQLAdapter
       if (this._closed || this._rawConnection !== client) {
         throw new Error("PostgreSQLAdapter: connection is closed");
       }
-      await this._maybeDrainOrphanedPreparedStatements(client);
-      if (this._closed || this._rawConnection !== client) {
-        throw new Error("PostgreSQLAdapter: connection is closed");
-      }
     } catch (error) {
       if (this._rawConnection === client) {
         this._rawConnection = null;
@@ -1395,18 +1390,6 @@ export class PostgreSQLAdapter
   }
 
   /**
-   * If the connection was tagged for `DEALLOCATE ALL` (by the
-   * `clearCacheBang` reset branch on the prior session), drain its
-   * server-side prepared statements before handing it to user code.
-   */
-  private async _maybeDrainOrphanedPreparedStatements(client: pg.Client): Promise<void> {
-    if (!this._needsDeallocateAll) return;
-    this._needsDeallocateAll = false;
-    this._commandSettled = false;
-    await client.query("DEALLOCATE ALL");
-  }
-
-  /**
    * Re-open / drain the connection before the base `withRawConnection` loop
    * yields `this._connection`. Serialization against `resetBang` is NOT this
    * hook's job: the reset body runs under the same `@lock` the loop already
@@ -1422,8 +1405,6 @@ export class PostgreSQLAdapter
     if (!this._closed && this._rawConnection === null && this._pgClientOptions !== null) {
       await this.connect();
     }
-    const client = this._rawConnection;
-    if (client && !this._closed) await this._maybeDrainOrphanedPreparedStatements(client);
   }
 
   /**
@@ -2416,7 +2397,6 @@ export class PostgreSQLAdapter
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
     this._statements.reset();
-    this._needsDeallocateAll = false;
     this._inTransaction = false;
     this._closed = false;
     conn?.end().catch(() => {});
@@ -2631,7 +2611,6 @@ export class PostgreSQLAdapter
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
     this._statements.reset();
-    this._needsDeallocateAll = false;
     this._inTransaction = false;
     // Rails' disconnect! is NOT terminal: with_raw_connection's
     // `connect! if @raw_connection.nil?` (abstract_adapter.rb:985) lazily
@@ -2683,7 +2662,6 @@ export class PostgreSQLAdapter
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
     this._statements.reset();
-    this._needsDeallocateAll = false;
     this._inTransaction = false;
     this._closed = true;
     if (this._acquiring) this._discardedAcquireGenerations.add(this._acquireGeneration);
@@ -2699,46 +2677,6 @@ export class PostgreSQLAdapter
   /** @internal — the currently-held txn client (always _rawConnection while in TX). */
   _currentClientForTest(): pg.Client | null {
     return this._client;
-  }
-
-  /** @internal — whether the next acquire will run DEALLOCATE ALL. */
-  _needsDeallocateAllForTest(): boolean {
-    return this._needsDeallocateAll;
-  }
-
-  /**
-   * Clear cached prepared statements. Mirrors Rails'
-   * `PostgreSQLAdapter#clear_cache!` which sends DEALLOCATE for each
-   * cached entry on the adapter's sole PG::Connection. With the
-   * single-client design we always own the session, so a full
-   * `clear()` always applies (it fires DEALLOCATE per entry via the
-   * PG-specific dealloc override). If the connection has been torn
-   * down (post-disconnect/reconnect failure window) we mark
-   * `_needsDeallocateAll` so the next acquire drains the server side.
-   * Returns the pool's chained DEALLOCATEs so the caller can await them before
-   * putting its own query on the socket; Rails' `clear_cache!` blocks on them.
-   */
-  override clearCacheBang({
-    newConnection = false,
-  }: { newConnection?: boolean } = {}): void | Promise<void> {
-    // No `super` call: this body replaces `abstract_adapter.rb:739-748`'s
-    // single `@lock.synchronize` block rather than running after it. The
-    // precondition `dealloc` states outright is that "the statement pool is
-    // only accessed while holding the connection's lock"
-    // (postgresql_adapter.rb:308-310).
-    return this.lock.synchronize(() => {
-      if (newConnection) {
-        // Rails' `new_connection: true` branch (statement_pool.rb:44-46) drops the
-        // map without DEALLOCATE: the session that owned those statement names is
-        // gone, so naming them again is an error, not a cleanup.
-        this._statements.reset();
-      } else if (this._rawConnection) {
-        return this._statements.clear();
-      } else {
-        this._statements.reset();
-        this._needsDeallocateAll = true;
-      }
-    });
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/database-statements.ts
@@ -12,6 +12,7 @@ import { PreparedStatementCacheExpired, type SQLWarning } from "../../errors.js"
 import { Result } from "../../result.js";
 import { combineMultiStatements, type ExplainOption } from "../abstract/database-statements.js";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
+import type { StatementPool } from "../statement-pool.js";
 
 // Mirrors: PostgreSQL::DatabaseStatements::READ_QUERY (database_statements.rb:19-21)
 // Mirrors Rails' build_read_query_regexp which combines the default read list
@@ -120,7 +121,7 @@ export interface PerformQueryHost extends HandleWarningsHost {
   inTransaction: boolean;
   sqlKey(sql: string): string;
   /** Rails' `@statements` (abstract_adapter.rb:156). */
-  _statements: { delete(key: string): unknown };
+  _statements: StatementPool;
   verifiedBang(): void;
   /** @internal */
   handleWarnings(sql: unknown): void;

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -1186,9 +1186,14 @@ describe("InsertAllTest", () => {
   it.skipIf(supportsInsertConflictTarget)(
     "upsert all with unique by fails cleanly for adapters not supporting insert conflict target",
     async () => {
-      await expect(
-        Book.upsertAll([{ name: "Rework", author_id: 1 }], { uniqueBy: "isbn" }),
-      ).rejects.toThrow(/does not support :uniqueBy/);
+      const connection = await Base.leaseConnection();
+      const error = await Book.upsertAll([{ name: "Rework", author_id: 1 }], {
+        uniqueBy: "isbn",
+      }).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(ArgumentError);
+      expect((error as Error).message).toContain(
+        `${connection.constructor.name} does not support :unique_by`,
+      );
     },
   );
 

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -53,6 +53,8 @@ export interface InsertAllOptions {
  */
 interface ResolvedConnectionFacts {
   supportsInsertReturning: boolean;
+  supportsInsertOnDuplicateSkip: boolean;
+  supportsInsertOnDuplicateUpdate: boolean;
   supportsInsertConflictTarget: boolean;
   primaryKeys: string[];
   indexes: (tableName: string) => unknown[];
@@ -78,6 +80,14 @@ async function resolveConnectionFacts(
     typeof connection.supportsInsertReturning === "function"
       ? await connection.supportsInsertReturning()
       : false;
+  const supportsInsertOnDuplicateSkip =
+    typeof connection.supportsInsertOnDuplicateSkip === "function"
+      ? await connection.supportsInsertOnDuplicateSkip()
+      : false;
+  const supportsInsertOnDuplicateUpdate =
+    typeof connection.supportsInsertOnDuplicateUpdate === "function"
+      ? await connection.supportsInsertOnDuplicateUpdate()
+      : false;
   const supportsInsertConflictTarget =
     typeof connection.supportsInsertConflictTarget === "function"
       ? await connection.supportsInsertConflictTarget()
@@ -90,6 +100,8 @@ async function resolveConnectionFacts(
   const indexes: unknown[] = cache ? await cache.indexes(model.tableName) : [];
   return {
     supportsInsertReturning,
+    supportsInsertOnDuplicateSkip,
+    supportsInsertOnDuplicateUpdate,
     supportsInsertConflictTarget,
     primaryKeys,
     indexes: (name: string) => (name === model.tableName ? indexes : []),
@@ -379,11 +391,29 @@ export class InsertAll {
     return Array.isArray(this.uniqueBy.columns) ? this.uniqueBy.columns : [this.uniqueBy.columns];
   }
 
-  /** @internal */
+  /** @internal Mirrors: ActiveRecord::InsertAll#ensure_valid_options_for_connection! */
   private ensureValidOptionsForConnectionBang(): void {
     if (this.returning && !this._facts.supportsInsertReturning) {
-      throw new Error(
-        `${(this.connection as any).constructor?.name ?? "Adapter"} does not support INSERT...RETURNING`,
+      throw new ArgumentError(
+        `${(this.connection as any).constructor?.name ?? "Adapter"} does not support :returning`,
+      );
+    }
+
+    if (this.skipDuplicates() && !this._facts.supportsInsertOnDuplicateSkip) {
+      throw new ArgumentError(
+        `${(this.connection as any).constructor?.name ?? "Adapter"} does not support skipping duplicates`,
+      );
+    }
+
+    if (this.updateDuplicates() && !this._facts.supportsInsertOnDuplicateUpdate) {
+      throw new ArgumentError(
+        `${(this.connection as any).constructor?.name ?? "Adapter"} does not support upsert`,
+      );
+    }
+
+    if (this.uniqueBy && !this._facts.supportsInsertConflictTarget) {
+      throw new ArgumentError(
+        `${(this.connection as any).constructor?.name ?? "Adapter"} does not support :unique_by`,
       );
     }
   }
@@ -454,7 +484,7 @@ export class InsertAll {
       // unsupported (plain insertAll on MySQL); a given unique_by raises.
       if (uniqueBy == null) return undefined;
       throw new ArgumentError(
-        `${(conn as any).constructor?.name ?? "Adapter"} does not support :uniqueBy`,
+        `${(conn as any).constructor?.name ?? "Adapter"} does not support :unique_by`,
       );
     }
     // Rails: `name_or_columns = unique_by || model.primary_key`. The match runs

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -557,7 +557,7 @@ export abstract class SchemaDumper {
     pool: ConnectionPoolLike | SchemaSource | DatabaseAdapter = baseClass().connectionPool(),
     stream: string[] = [],
     config: SchemaDumperConfig = baseClass(),
-  ): string[] | Promise<string[]> {
+  ): Promise<string[]> {
     const options = this.generateOptions(config);
     // Adapter check runs FIRST because concrete DatabaseAdapters
     // (PostgreSQLAdapter, SQLite3Adapter) implement `tables()` /

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -16,7 +16,7 @@ import { fixtures } from "./test-fixtures.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import { WrongReply } from "./test-helpers/models/reply.js";
 import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "./test-helpers/models/cpk.js";
-import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
 
@@ -113,19 +113,10 @@ describe("TransactionTest", () => {
     // mocks into later tests.
     //
     // `after_failure_actions` dispatches on the connection instance
-    // (`transaction.rb:1221`, `@connection.clear_cache!`), so the spy must sit
-    // on the prototype that OWNS clearCacheBang for the live adapter class:
-    // PostgreSQLAdapter overrides it, while sqlite3 and mysql2 inherit
-    // AbstractAdapter's (abstract_adapter.rb:739-748). Spying the owner rather
-    // than an instance still catches any pool slot.
-    function clearCacheBangOwner(conn: DatabaseAdapter): Required<DatabaseAdapter> {
-      let proto: object | null = Object.getPrototypeOf(conn) as object | null;
-      while (proto && !Object.prototype.hasOwnProperty.call(proto, "clearCacheBang")) {
-        proto = Object.getPrototypeOf(proto) as object | null;
-      }
-      if (!proto) throw new Error("no clearCacheBang on the connection's prototype chain");
-      return proto as Required<DatabaseAdapter>;
-    }
+    // (`transaction.rb:1221`, `@connection.clear_cache!`), so the spy sits on
+    // AbstractAdapter's prototype: Rails has no adapter override of
+    // `clear_cache!` (abstract_adapter.rb:739-748) and neither does trails, so
+    // every adapter dispatches to that one body.
 
     afterEach(() => {
       vi.restoreAllMocks();
@@ -133,7 +124,7 @@ describe("TransactionTest", () => {
 
     it("calls clearCacheBang and re-raises when the body throws the expired error", async () => {
       const { PreparedStatementCacheExpired } = await import("./errors.js");
-      const spy = vi.spyOn(clearCacheBangOwner(CanonicalTopic.connection), "clearCacheBang");
+      const spy = vi.spyOn(AbstractAdapter.prototype, "clearCacheBang");
       await expect(
         transaction(CanonicalTopic, async () => {
           throw new PreparedStatementCacheExpired("cached plan expired");
@@ -143,7 +134,7 @@ describe("TransactionTest", () => {
     });
 
     it("does not call clearCacheBang for unrelated errors", async () => {
-      const spy = vi.spyOn(clearCacheBangOwner(CanonicalTopic.connection), "clearCacheBang");
+      const spy = vi.spyOn(AbstractAdapter.prototype, "clearCacheBang");
       await expect(
         transaction(CanonicalTopic, async () => {
           throw new Error("unrelated");

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -122,7 +122,14 @@ interface DatabaseEntry {
  * `DatabaseTasks.forEach` (`tasks/database_tasks.rb:141-154`), which is what
  * `databases.rake:35,54,105,120` uses to generate the namespaced
  * `db:<task>:<name>` tasks — so replicas and `databaseTasks: false` configs
- * are skipped here for exactly the reason they get no rake task there.
+ * are skipped here for exactly the reason they get no rake task there
+ * (`database_tasks.rb:150`).
+ *
+ * `for_each` yields nothing for a single-database application
+ * (`database_tasks.rb:147`): there are no namespaced tasks to generate, and the
+ * un-namespaced command is that application's only task. Rails reaches that
+ * lone config through `each_current_configuration`, which applies the same
+ * `database_tasks?` filter — hence the second arm.
  */
 async function taskableDatabaseEntries(
   opts: DatabaseOpts,
@@ -158,11 +165,6 @@ async function taskableDatabaseEntries(
       );
     },
   );
-  // `for_each` yields nothing for a single-database application
-  // (database_tasks.rb:147) — there are no namespaced tasks to generate, and
-  // the un-namespaced command is that application's only task. Rails reaches
-  // that lone config through `each_current_configuration`, which applies the
-  // same `database_tasks?` filter `for_each` does (database_tasks.rb:150).
   const taskable =
     namespacedNames.size > 0
       ? all.filter((c) => namespacedNames.has(c.name))

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -118,9 +118,11 @@ interface DatabaseEntry {
 
 /**
  * Every named config in the current env, optionally filtered to one name
- * via `--database`. Builds HashConfigs first so we can filter by
- * databaseTasks() — replicas and configs with `databaseTasks: false` are
- * skipped, matching Rails' `configsFor(includeHidden: false)`.
+ * via `--database`. The set of per-database names is chosen by
+ * `DatabaseTasks.forEach` (`tasks/database_tasks.rb:141-154`), which is what
+ * `databases.rake:35,54,105,120` uses to generate the namespaced
+ * `db:<task>:<name>` tasks — so replicas and `databaseTasks: false` configs
+ * are skipped here for exactly the reason they get no rake task there.
  */
 async function taskableDatabaseEntries(
   opts: DatabaseOpts,
@@ -143,7 +145,28 @@ async function taskableDatabaseEntries(
       };
     }),
   );
-  const taskable = all.filter((c) => c.hashConfig.databaseTasks());
+  const namespacedNames = new Set<string>();
+  await withRegisteredConfigurations(
+    all.map((c) => c.hashConfig),
+    envName,
+    async () => {
+      DatabaseTasks.forEach(
+        { [envName]: Object.fromEntries(all.map((c) => [c.name, c.raw])) },
+        (name) => {
+          namespacedNames.add(name);
+        },
+      );
+    },
+  );
+  // `for_each` yields nothing for a single-database application
+  // (database_tasks.rb:147) — there are no namespaced tasks to generate, and
+  // the un-namespaced command is that application's only task. Rails reaches
+  // that lone config through `each_current_configuration`, which applies the
+  // same `database_tasks?` filter `for_each` does (database_tasks.rb:150).
+  const taskable =
+    namespacedNames.size > 0
+      ? all.filter((c) => namespacedNames.has(c.name))
+      : all.filter((c) => c.hashConfig.databaseTasks());
   const filtered = dbName ? taskable.filter((c) => c.name === dbName) : taskable;
   if (filtered.length === 0 && dbName) {
     const available = taskable.map((c) => c.name).join(", ");
@@ -156,11 +179,10 @@ async function taskableDatabaseEntries(
 }
 
 /**
- * Iterate every named database config in the current env, optionally
- * filtered to a single name via `--database`. Mirrors Rails'
- * `DatabaseTasks.for_each(databases) { |name| ... }` which generates
- * per-name rake tasks. Commander can't generate dynamic subcommands,
- * so we use a `--database` flag instead.
+ * Adds the adapter checkout `DatabaseTasks.forEach` has no counterpart for:
+ * the name fan-out itself lives in `taskableDatabaseEntries`, which runs
+ * `forEach`. Commander can't generate dynamic subcommands, so the namespaced
+ * `db:<task>:<name>` task is spelled as a `--database` flag instead.
  *
  * For each config: connects an adapter, runs `fn`, closes the adapter.
  * `fn` receives the adapter, the raw config, the HashConfig, and the
@@ -192,6 +214,7 @@ async function forEachDatabase(
 /**
  * Like forEachDatabase but doesn't connect an adapter — for commands
  * like `create` and `drop` that need to operate BEFORE the DB exists.
+ * Same `taskableDatabaseEntries` / `DatabaseTasks.forEach` fan-out.
  */
 async function forEachDatabaseConfig(
   opts: DatabaseOpts,

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
     "novel": 381,
-    "total": 1384
+    "total": 1379
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
Six RFC 0112 "one Rails thing, N trails things" convergences.

### 1. `AbstractAdapter._statements` names `StatementPool`
Rails' `@statements` is a `ConnectionAdapters::StatementPool` (`abstract_adapter.rb:156`). The base field was typed structurally (`{ reset(); clear() }`), and the same duck-type was repeated in mysql2's and PostgreSQL's `PerformQueryHost`. All three now name the class. `statement-pool.ts` has no runtime imports, so the import closes no cycle; the base signature already covers all three adapters' narrowings (mysql2's `Mysql2StatementPool | null`, sqlite3's non-nullable, PG's `declare`d).

### 2. `AssociationRelation#firstOrInitialize` deleted
Rails' `AssociationRelation` has no such override — `first_or_initialize` lives once on `Relation` (`relation.rb:186-188`). The trails override diverged three ways (`limit(1)` + index instead of `first`, no block parameter, `extra` renamed from `attributes`). #7053 removed its reason to exist: `_new` delegates to the association and `Relation#build` wraps it in `scoping`.

### 3. trailties fan-out routes through `DatabaseTasks.forEach`
`DatabaseTasks.forEach` (`database_tasks.rb:141-154`) had zero callers while `db.ts` hand-rolled its own multi-DB fan-out. `taskableDatabaseEntries` now selects the per-database names through `forEach`, passing the raw configuration hash the way `databases.rake:35,54,105,120` does, so `databaseTasks()`-disabled and replica configs are skipped at `:150`. `for_each` yields nothing for a single-database application (`:147`) — there are no namespaced tasks to generate — so that arm keeps the same `database_tasks?` filter Rails' `each_current_configuration` applies. `forEachDatabase` / `forEachDatabaseConfig` are reduced to the adapter-checkout and log-prefix concerns `forEach` has no counterpart for.

### 4. `InsertAll#ensure_valid_options_for_connection!` — all four guards
Only 1 of `insert_all.rb:173-188`'s 4 guards was ported, and that one threw a plain `Error` with an invented `"does not support INSERT...RETURNING"` message. All four are now present in Rails' order, each raising `ArgumentError` with Rails' exact string. `ResolvedConnectionFacts` grows `supportsInsertOnDuplicateSkip` / `supportsInsertOnDuplicateUpdate`, resolved in `resolveConnectionFacts`; all three adapters already implement the predicates. Drive-by: `find_unique_index_for`'s message said `:uniqueBy` where Rails says `:unique_by` (`insert_all.rb:155`), and `upsert all with unique by fails cleanly for adapters not supporting insert conflict target` now asserts what Rails' `assert_raises ArgumentError` + `assert_match "#{ActiveRecord::Base.lease_connection.class} does not support :unique_by"` does (`insert_all_test.rb:826-833`) instead of a loose regex on the old spelling.

### 5. `SchemaDumper.dump` is single-arm
Rails' `SchemaDumper.dump` (`schema_dumper.rb:43-48`) has one return; the TS declared `string[] | Promise<string[]>`. Narrowed to `Promise<string[]>` — all three branches already returned a promise and every caller already awaited, so no `instanceof Promise` fork was introduced and no subclass overrides the static. The remaining `T | Promise<T>` in that file is `ConnectionPoolLike.withConnection`'s callback parameter — Ruby's `with_connection { }` block, not a `dump` arm.

### 6. PostgreSQL's `clear_cache!` override retired
Rails has no adapter override of `clear_cache!`; the whole body is `abstract_adapter.rb:739-748`. #7050 converged mysql2 and sqlite3; PG still overrode it for `_rawConnection` and `_needsDeallocateAll`.

`_needsDeallocateAll` is shown unnecessary rather than relocated: the PG `StatementPool` already holds the adapter and re-reads `_rawConnection` inside `dealloc`, skipping a dead handle exactly as `postgresql_adapter.rb:308-314` does — so the decision is already made in the pool. And the flag could only ever be set with `_rawConnection` already null, which means one of `_discardRawConnection` / `disconnectBang` / `discardBang` had run, each of which reset it to false on the same line it reset the pool. It, its drain hook, its `_acquireFreshClient` guard and its test accessor are gone.

`clearCacheBangOwner` in `transactions.trails.test.ts` collapses to a plain `AbstractAdapter.prototype` spy, and the PG statement-pool test that asserted the removed `DEALLOCATE ALL`-on-next-checkout tagging is deleted.

### Verification
`pnpm typecheck` clean; `pnpm lint` clean; `parity:api:calls`, `parity:api:calls:args` and `parity:api:extra:gate` all OK (the extra-surface total mark narrowed 1384 → 1379 via `parity:api:extra:tighten`, no new novel names). Green locally: `insert-all.test.ts`, `schema-dumper.test.ts`, `schema-dumper.trails.test.ts`, `transactions.trails.test.ts`, `has-many-associations.test.ts`, `relation/delegation.test.ts`, trailties `db.test.ts`. The PG statement-pool suite needs a server this host has no credentials for — CI's PG lane covers it.

Closes-story: abstract-statements-field-typed-structurally
Closes-story: association-relation-first-or-initialize-override-is-invented
Closes-story: database-tasks-for-each-has-no-callers
Closes-story: insert-all-ensure-valid-options-missing-three-arms
Closes-story: narrow-schema-dumper-dump-to-its-single-async-arm
Closes-story: retire-pg-clear-cache-adapter-override
