### PR TITLE
refactor(arel): untyped type-caster delegations, PG-only grouping nodes, nil bind collections, unwrapped build_quoted arms, Binary-aliased Cte/TableAlias slots (RFC 0124)

### DIFF
--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -438,6 +438,7 @@ describe("BindParameterTest", () => {
     const arelNode = new Nodes.BoundSqlLiteral(
       `SELECT ${table}.* FROM ${table} WHERE ${pk} IN (?)`,
       [[1, 2, 3]],
+      null,
     );
     expect(conn.toSql(arelNode)).toBe(sql);
     expect((await conn.selectAll(arelNode)).length).toBe(3);

--- a/packages/activerecord/src/relation/bound-sql-literal-relation.trails.test.ts
+++ b/packages/activerecord/src/relation/bound-sql-literal-relation.trails.test.ts
@@ -83,7 +83,7 @@ describe("bound SQL literal with Relation bind value", () => {
     const builders = Topic.all() as unknown as BoundSqlLiteralBuilders;
     const node = builders.buildBoundSqlLiteral("id IN (?)", [approvedIds]);
 
-    const bind = node.positionalBinds[0];
+    const bind = node.positionalBinds![0];
     expect(bind).toBeInstanceOf(Nodes.SqlLiteral);
     expect((bind as Nodes.SqlLiteral).value).toContain("SELECT");
   });
@@ -93,7 +93,7 @@ describe("bound SQL literal with Relation bind value", () => {
     const builders = Topic.all() as unknown as BoundSqlLiteralBuilders;
     const node = builders.buildNamedBoundSqlLiteral("id IN (:ids)", { ids: approvedIds });
 
-    const bind = node.namedBinds.ids;
+    const bind = node.namedBinds!.ids;
     expect(bind).toBeInstanceOf(Nodes.SqlLiteral);
     expect((bind as Nodes.SqlLiteral).value).toContain("SELECT");
   });

--- a/packages/activerecord/src/relation/composite-where.trails.test.ts
+++ b/packages/activerecord/src/relation/composite-where.trails.test.ts
@@ -133,13 +133,12 @@ describe("Relation#where — composite-key form", () => {
     const rel = (CpkBook as any).all();
     const nodes: any = rel.predicateBuilder.buildComposite(["author_id", "id"], [[1, 100]]);
     // Single-tuple path returns the predicates flat ([eq, eq]), like Rails'
-    // grouping_queries. Arel wraps QueryAttribute in BindParam at
-    // `attribute.eq()`, so the first Eq's right-hand side is
-    // BindParam(QueryAttribute(name, value, type)).
+    // grouping_queries. `build_quoted` seats an ActiveModel::Attribute
+    // unwrapped (casted.rb:50-51), so the first Eq's right-hand side is the
+    // QueryAttribute(name, value, type) itself.
     const rhs = nodes[0].right;
-    expect(rhs?.constructor?.name).toBe("BindParam");
-    expect(rhs?.value?.name).toBe("author_id");
-    expect(rhs?.value?.constructor?.name).toBe("QueryAttribute");
+    expect(rhs?.name).toBe("author_id");
+    expect(rhs?.constructor?.name).toBe("QueryAttribute");
   });
 
   it("single-tuple composite returns flat predicates (no wrapping Grouping/parens) — Rails grouping_queries one? path", () => {
@@ -168,7 +167,7 @@ describe("Relation#where — composite-key form", () => {
     );
     const [left, right] = nodes;
     expect(right.left.relation.name).toBe("comments");
-    const bind = right.right.value;
+    const bind = right.right;
     expect(bind.name).toBe("post_id");
     expect(bind.valueForDatabase).toBe(2);
     expect(left.left.relation.name).toBe("posts");
@@ -194,7 +193,7 @@ describe("Relation#where — composite-key form", () => {
     let eq: any;
     const walk = (n: any) => {
       if (!n || typeof n !== "object") return;
-      if (n.right?.value?.name === "metadata") eq = n;
+      if (n.right?.name === "metadata") eq = n;
       for (const k of ["expr", "left", "right", "children"]) {
         const c = n[k];
         if (Array.isArray(c)) c.forEach(walk);
@@ -203,7 +202,7 @@ describe("Relation#where — composite-key form", () => {
     };
     rel.whereClause.predicates.forEach(walk);
     expect(eq.left.relation.name).toBe("contracts");
-    expect(eq.right.value.valueForDatabase).toBe('"x"');
+    expect(eq.right.valueForDatabase).toBe('"x"');
   });
 
   it("qualified single-column composite resolves its IN(...) attribute on the joined table", () => {

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -323,7 +323,7 @@ describe("PredicateBuilderTest", () => {
       // Rails inverts a positively-built, bound predicate, so the value rides a
       // QueryAttribute bind rather than being inlined.
       expect(sql).toContain('"posts"."title" !=');
-      const bound = (node as unknown as { right: { value: { value: unknown } } }).right.value.value;
+      const bound = (node as unknown as { right: { value: unknown } }).right.value;
       expect(bound).toEqual({ id: 5 });
     });
 
@@ -432,8 +432,7 @@ describe("PredicateBuilderTest", () => {
       const sql = nodes.map((n) => new Visitors.ToSql(testConnection).compile(n)).join(" AND ");
       expect(sql).toContain('"authors"."name"');
       // Negation binds the RHS, so 'Rails' rides a QueryAttribute bind.
-      const bound = (nodes[0] as unknown as { right: { value: { value: unknown } } }).right.value
-        .value;
+      const bound = (nodes[0] as unknown as { right: { value: unknown } }).right.value;
       expect(bound).toBe("Rails");
       expect(sql).not.toContain('"posts"."authors"');
       expect(sql).toMatch(/NOT\b|!=|<>/);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2309,7 +2309,7 @@ export function buildNamedBoundSqlLiteral(
     namedBinds[key] = normalizeBoundValue.call(this, value);
   }
   try {
-    return new Nodes.BoundSqlLiteral(`(${statement})`, [], namedBinds);
+    return new Nodes.BoundSqlLiteral(`(${statement})`, null, namedBinds);
   } catch (e: any) {
     throw new PreparedStatementInvalid(e?.message ?? String(e), { cause: e });
   }
@@ -2323,7 +2323,7 @@ export function buildBoundSqlLiteral(
 ): Nodes.BoundSqlLiteral {
   const positionalBinds = values.map((value) => normalizeBoundValue.call(this, value));
   try {
-    return new Nodes.BoundSqlLiteral(`(${statement})`, positionalBinds, {});
+    return new Nodes.BoundSqlLiteral(`(${statement})`, positionalBinds, null);
   } catch (e: any) {
     throw new PreparedStatementInvalid(e?.message ?? String(e), { cause: e });
   }

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -11,7 +11,7 @@
  */
 
 import { Nodes, fetchAttribute, sql } from "@blazetrails/arel";
-import { ArgumentError } from "@blazetrails/activemodel";
+import { ArgumentError, Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 export class WhereClause {
   private _predicates: (Nodes.Node | string)[];
@@ -340,6 +340,9 @@ function extractNodeValue(node: unknown): unknown {
   // is returned intact for scope_for_create, not flattened via
   // `value_for_database`. This matters now that multi-value arrays build
   // `HomogeneousIn`, whose `right` is an array of Casted nodes.
+  // `build_quoted` seats an ActiveModel::Attribute unwrapped (casted.rb:50-51),
+  // and it answers `value_before_type_cast` like the wrappers below do.
+  if (node instanceof ModelAttribute) return node.valueBeforeTypeCast;
   if (node instanceof Nodes.Quoted) return node.value;
   if (node instanceof Nodes.Casted) return node.valueBeforeTypeCast();
   if (node instanceof Nodes.BindParam) {

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -37,8 +37,8 @@ export interface RelationLike {
   // `Table#tableAlias` is a plain string-or-nil. Both flow through here as
   // `o.relation.table_alias`.
   tableAlias?: string | SqlLiteral | null;
-  typeCastForDatabase: (attrName: string, value: unknown) => unknown;
-  typeForAttribute: (name: string) => unknown;
+  typeCastForDatabase: (attrName: string | Node, value: unknown) => unknown;
+  typeForAttribute: (name: string | Node) => unknown;
   isAbleToTypeCast: () => boolean;
   lower: (column: unknown) => NamedFunction;
 }
@@ -60,9 +60,7 @@ export class Attribute extends Node {
   }
 
   get typeCaster(): unknown {
-    // Ruby passes `name` along untyped; only a String name ever reaches a
-    // type caster, since `table[Arel.star]` is never type-cast.
-    return this.relation.typeForAttribute(this.name as string);
+    return this.relation.typeForAttribute(this.name);
   }
 
   // Mirrors: Arel::Attributes::Attribute#lower — `relation.lower self`. The
@@ -72,7 +70,7 @@ export class Attribute extends Node {
   }
 
   typeCastForDatabase(value: unknown): unknown {
-    return this.relation.typeCastForDatabase(this.name as string, value);
+    return this.relation.typeCastForDatabase(this.name, value);
   }
 
   isAbleToTypeCast(): boolean {

--- a/packages/arel/src/node-slots.ts
+++ b/packages/arel/src/node-slots.ts
@@ -97,3 +97,15 @@ export let _Dot: (new () => { accept(node: any, collector: any): any }) | undefi
 export function _setDot(ctor: new () => { accept(node: any, collector: any): any }): void {
   _Dot = ctor;
 }
+
+/**
+ * `Arel::Table` — the constant `Nodes.build_quoted` names in its pass-through
+ * `case` (casted.rb:47-51). A value import of `table.js` from `casted.ts`
+ * closes a cycle back through every node module `Table` reaches.
+ * @internal
+ */
+export let _Table: (new (name: any, ...rest: any[]) => any) | undefined;
+/** @internal */
+export function _setTable(ctor: new (name: any, ...rest: any[]) => any): void {
+  _Table = ctor;
+}

--- a/packages/arel/src/nodes/bound-sql-literal.test.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.test.ts
@@ -5,7 +5,7 @@ import { BindError } from "../errors.js";
 describe("BoundSqlLiteralTest", () => {
   describe("#plus", () => {
     it("returns a Fragments node containing self and other", () => {
-      const bsl = new Nodes.BoundSqlLiteral("a = ?", [1]);
+      const bsl = new Nodes.BoundSqlLiteral("a = ?", [1], null);
       const other = new Nodes.SqlLiteral(" AND b = 2");
       const frag = bsl.plus(other);
       expect(frag).toBeInstanceOf(Nodes.Fragments);
@@ -13,37 +13,37 @@ describe("BoundSqlLiteralTest", () => {
     });
 
     it("throws when other is not an Arel node", () => {
-      const bsl = new Nodes.BoundSqlLiteral("a = ?", [1]);
+      const bsl = new Nodes.BoundSqlLiteral("a = ?", [1], null);
       expect(() => bsl.plus("not a node" as unknown as Nodes.Node)).toThrow(/Expected Arel node/);
     });
   });
 
   describe("equality", () => {
     it("is equal with equal components", () => {
-      const a = new Nodes.BoundSqlLiteral("id = ?", [1]);
-      const b = new Nodes.BoundSqlLiteral("id = ?", [1]);
+      const a = new Nodes.BoundSqlLiteral("id = ?", [1], null);
+      const b = new Nodes.BoundSqlLiteral("id = ?", [1], null);
       expect(a.eql(b)).toBe(true);
       expect(a.hash()).toBe(b.hash());
     });
 
     it("is not equal with different components", () => {
-      const a = new Nodes.BoundSqlLiteral("id = ?", [1]);
-      const b = new Nodes.BoundSqlLiteral("id = ?", [2]);
+      const a = new Nodes.BoundSqlLiteral("id = ?", [1], null);
+      const b = new Nodes.BoundSqlLiteral("id = ?", [2], null);
       expect(a.eql(b)).toBe(false);
     });
   });
 
   describe("node shape", () => {
     it("exposes sqlWithPlaceholders", () => {
-      const node = new Nodes.BoundSqlLiteral("id = ?", [1]);
+      const node = new Nodes.BoundSqlLiteral("id = ?", [1], null);
       expect(node.sqlWithPlaceholders).toBe("id = ?");
     });
 
     it("exposes positionalBinds and namedBinds", () => {
-      const pos = new Nodes.BoundSqlLiteral("id = ?", [42]);
+      const pos = new Nodes.BoundSqlLiteral("id = ?", [42], null);
       expect(pos.positionalBinds).toEqual([42]);
 
-      const named = new Nodes.BoundSqlLiteral("id = :id", [], { id: 1 });
+      const named = new Nodes.BoundSqlLiteral("id = :id", null, { id: 1 });
       expect(named.namedBinds).toEqual({ id: 1 });
     });
   });
@@ -64,21 +64,23 @@ describe("BoundSqlLiteralTest", () => {
 
   describe("requires positional binds to match the placeholders", () => {
     it("raises BindError when too few binds", () => {
-      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2])).toThrow(BindError);
+      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2], null)).toThrow(BindError);
     });
 
     it("raises BindError when too many binds", () => {
-      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2, 3, 4])).toThrow(BindError);
+      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2, 3, 4], null)).toThrow(
+        BindError,
+      );
     });
 
     it("error message matches Rails phrasing", () => {
-      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2])).toThrow(
+      expect(() => new Nodes.BoundSqlLiteral("id IN (?, ?, ?)", [1, 2], null)).toThrow(
         'wrong number of bind variables (2 for 3) in: "id IN (?, ?, ?)"',
       );
     });
 
     it("JSON.stringify escapes embedded double-quotes in error message", () => {
-      expect(() => new Nodes.BoundSqlLiteral('name = "O\'Brien" AND ?', [1, 2])).toThrow(
+      expect(() => new Nodes.BoundSqlLiteral('name = "O\'Brien" AND ?', [1, 2], null)).toThrow(
         'wrong number of bind variables (2 for 1) in: "name = \\"O\'Brien\\" AND ?"',
       );
     });
@@ -86,19 +88,19 @@ describe("BoundSqlLiteralTest", () => {
 
   describe("requires all named bind params to be supplied", () => {
     it("raises BindError when a named bind is missing", () => {
-      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar)", [], { foo: 1 })).toThrow(
+      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar)", null, { foo: 1 })).toThrow(
         BindError,
       );
     });
 
     it("error message matches Rails phrasing", () => {
-      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar)", [], { foo: 1 })).toThrow(
+      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar)", null, { foo: 1 })).toThrow(
         'missing value for :bar in: "id IN (:foo, :bar)"',
       );
     });
 
     it("error message matches Rails phrasing (plural missing)", () => {
-      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar, :baz)", [], { foo: 1 })).toThrow(
+      expect(() => new Nodes.BoundSqlLiteral("id IN (:foo, :bar, :baz)", null, { foo: 1 })).toThrow(
         'missing values for ["bar","baz"] in: "id IN (:foo, :bar, :baz)"',
       );
     });

--- a/packages/arel/src/nodes/bound-sql-literal.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.ts
@@ -12,8 +12,11 @@ import { Fragments } from "./fragments.js";
  */
 export class BoundSqlLiteral extends NodeExpression {
   readonly sqlWithPlaceholders: string;
-  readonly positionalBinds: unknown[];
-  readonly namedBinds: Record<string, unknown>;
+  // Mirrors bound_sql_literal.rb:31-38 — exactly one collection is kept; the
+  // unused side is nil, which is what `visit_Arel_Nodes_BoundSqlLiteral`
+  // branches on (to_sql.rb:799).
+  readonly positionalBinds: unknown[] | null;
+  readonly namedBinds: Record<string, unknown> | null;
 
   /**
    * Mirrors: bound_sql_literal.rb:8-40 — `initialize`, whose named-bind arm
@@ -25,44 +28,46 @@ export class BoundSqlLiteral extends NodeExpression {
    */
   constructor(
     sqlWithPlaceholders: string,
-    positionalBinds: unknown[] = [],
-    namedBinds: Record<string, unknown> = {},
+    positionalBinds: unknown[] | null,
+    namedBinds: Record<string, unknown> | null,
   ) {
     super();
-    this.sqlWithPlaceholders = sqlWithPlaceholders;
-    this.positionalBinds = positionalBinds;
-    this.namedBinds = namedBinds;
-    this.validate();
-  }
-
-  private validate(): void {
-    const sql = this.sqlWithPlaceholders;
-    const hasPositional = this.positionalBinds.length > 0;
-    const hasNamed = Object.keys(this.namedBinds).length > 0;
-
-    if (hasPositional && hasNamed) {
-      throw new BindError(`cannot mix positional and named binds`, sql);
-    }
+    const hasPositional = !(positionalBinds == null || positionalBinds.length === 0);
+    const hasNamed = !(namedBinds == null || Object.keys(namedBinds).length === 0);
 
     if (hasPositional) {
-      const expected = (sql.match(/\?/g) ?? []).length;
-      if (this.positionalBinds.length !== expected) {
+      if (hasNamed) {
+        throw new BindError(`cannot mix positional and named binds`, sqlWithPlaceholders);
+      }
+      const expected = (sqlWithPlaceholders.match(/\?/g) ?? []).length;
+      if (positionalBinds.length !== expected) {
         throw new BindError(
-          `wrong number of bind variables (${this.positionalBinds.length} for ${expected})`,
-          sql,
+          `wrong number of bind variables (${positionalBinds.length} for ${expected})`,
+          sqlWithPlaceholders,
         );
+      }
+    } else if (hasNamed) {
+      // Deduplicate tokens (matches Rails `.uniq`) before checking for missing binds.
+      const tokensInString = [
+        ...new Set([...sqlWithPlaceholders.matchAll(/:(?<!::)([a-zA-Z]\w*)/g)].map((m) => m[1])),
+      ];
+      const missing = tokensInString.filter((t) => !(t in namedBinds));
+      if (missing.length > 0) {
+        if (missing.length === 1) {
+          throw new BindError(`missing value for :${missing[0]}`, sqlWithPlaceholders);
+        } else {
+          throw new BindError(`missing values for ${JSON.stringify(missing)}`, sqlWithPlaceholders);
+        }
       }
     }
 
-    if (hasNamed) {
-      // Deduplicate tokens (matches Rails `.uniq`) before checking for missing binds.
-      const tokens = [...new Set([...sql.matchAll(/:(?<!::)([a-zA-Z]\w*)/g)].map((m) => m[1]))];
-      const missing = tokens.filter((t) => !(t in this.namedBinds));
-      if (missing.length === 1) {
-        throw new BindError(`missing value for :${missing[0]}`, sql);
-      } else if (missing.length > 1) {
-        throw new BindError(`missing values for ${JSON.stringify(missing)}`, sql);
-      }
+    this.sqlWithPlaceholders = sqlWithPlaceholders;
+    if (hasPositional) {
+      this.positionalBinds = positionalBinds;
+      this.namedBinds = null;
+    } else {
+      this.positionalBinds = null;
+      this.namedBinds = namedBinds;
     }
   }
 

--- a/packages/arel/src/nodes/casted.test.ts
+++ b/packages/arel/src/nodes/casted.test.ts
@@ -55,8 +55,7 @@ describe("Arel::Nodes.build_quoted", () => {
   it("wraps ActiveModel::Attribute in BindParam so it participates in bind extraction", () => {
     const amAttr = AMAttribute.withCastValue("id", 7, new ValueType());
     const node = buildQuoted(amAttr);
-    expect(node).toBeInstanceOf(Nodes.BindParam);
-    expect((node as Nodes.BindParam).value).toBe(amAttr);
+    expect(node).toBe(amAttr as unknown as Nodes.Node);
 
     // compileWithBinds should collect it (not inline it) — matches Rails'
     // visit_ActiveModel_Attribute routing through add_bind.
@@ -102,21 +101,13 @@ describe("Arel::Nodes.build_quoted", () => {
     expect((node as Nodes.Quoted).value).toBeNull();
   });
 
-  // KNOWN DEVIATION, not the target shape: casted.rb:50-51's `when` arm returns
-  // `other` UNWRAPPED, so Rails' AST holds the ActiveModel::Attribute itself;
-  // trails wraps it in BindParam. Output SQL agrees (rb:756's `add_bind(o)` vs
-  // rb:760's `add_bind(o.value)` land the same payload), but the AST shape does
-  // not, for callers that inspect the node.
-  //
-  // Tracked by story `converge-arel-build-quoted-model-attribute-unwrapped`,
-  // which owns the convergence to Rails' unwrapped shape. This test pins
-  // today's shape so that change is visible in the diff — it records the
-  // deviation, it does not endorse it.
+  // casted.rb:50-51's `when` arm returns `other` UNWRAPPED, so the AST holds
+  // the ActiveModel::Attribute itself and `visit_ActiveModel_Attribute`
+  // (to_sql.rb:756) is what lands its value as a bind.
   it("wraps an ActiveModel::Attribute in BindParam", () => {
     const attr = AMAttribute.fromUser("age", 42, new ValueType());
     const node = buildQuoted(attr);
-    expect(node).toBeInstanceOf(Nodes.BindParam);
-    expect((node as Nodes.BindParam).value).toBe(attr);
+    expect(node).toBe(attr as unknown as Nodes.Node);
   });
 
   // Rails dispatches casted.rb:50's `when` arm on the class, so an object that

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -1,9 +1,8 @@
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
-import { _Attribute, _setBuildQuoted } from "../node-slots.js";
+import { _Attribute, _Table, _setBuildQuoted } from "../node-slots.js";
 import { Unary } from "./unary.js";
 import type { Attribute } from "../attributes/attribute.js";
-import { BindParam } from "./bind-param.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 /**
@@ -16,22 +15,20 @@ import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
  * TS deviations, all narrower/safer:
  * - Table / SelectManager aren't Arel nodes here, so the SelectManager arm is
  *   matched on its `ast` duck-type rather than by class (importing
- *   `SelectManager` from a node module closes a require cycle). The manager
- *   itself is returned, as Rails does (casted.rb:47-51), so
- *   `visit_Arel_SelectManager` supplies the subquery parens.
- * - ActiveModel::Attribute isn't an Arel node either. Rails has
- *   visit_ActiveModel_Attribute that routes it through add_bind; we
- *   wrap it in BindParam so the value participates in prepared-statement
- *   bind extraction (visitBindParam handles valueForDatabase — both the
- *   method form on QueryAttribute and the getter form on AM Attribute).
+ *   `SelectManager` from a node module closes a require cycle) and the Table
+ *   arm reads the `_Table` slot for the same reason. Both are returned
+ *   unchanged, as Rails does (casted.rb:47-51), so `visit_Arel_SelectManager`
+ *   supplies the subquery parens and `visit_Arel_Table` renders the table.
  */
 export function buildQuoted(other: unknown, attribute?: unknown): Node {
   if (other instanceof Node) return other;
   if (other && typeof other === "object") {
     if (_Attribute && other instanceof _Attribute) return other as Node;
+    if (_Table && other instanceof _Table) return other as Node;
     // Rails: casted.rb:50-51 — the `when ..., ActiveModel::Attribute` arm
-    // returning `other`. Class dispatch, like Rails.
-    if (other instanceof ModelAttribute) return new BindParam(other);
+    // returning `other` unwrapped. `visit_ActiveModel_Attribute`
+    // (to_sql.rb:756) is what lands its value as a bind.
+    if (other instanceof ModelAttribute) return other as unknown as Node;
     const maybeAst = (other as { ast?: unknown }).ast;
     if (maybeAst instanceof Node) return other as Node;
   }

--- a/packages/arel/src/nodes/cte.trails.test.ts
+++ b/packages/arel/src/nodes/cte.trails.test.ts
@@ -10,15 +10,51 @@ describe("Cte#toTable", () => {
   it("preserves a SqlLiteral name as a bare table name", () => {
     const cte = new Nodes.Cte(
       new Nodes.SqlLiteral("expr1"),
-      new Table("bar").project(new Nodes.SqlLiteral("*")).ast,
+      new Table("bar").project(new Nodes.SqlLiteral("*")),
     );
     const sql = new Visitors.ToSql(testConnection).compile(cte.toTable());
     expect(sql).toBe("expr1");
   });
 
   it("quotes a plain-string name as an identifier", () => {
-    const cte = new Nodes.Cte("expr1", new Table("bar").project(new Nodes.SqlLiteral("*")).ast);
+    const cte = new Nodes.Cte("expr1", new Table("bar").project(new Nodes.SqlLiteral("*")));
     const sql = new Visitors.ToSql(testConnection).compile(cte.toTable());
     expect(sql).toBe('"expr1"');
+  });
+});
+
+// TS-only: Ruby gets this for free from `alias :name :left` (cte.rb:6-7) and
+// `alias :relation :left` / `alias :name :right` (table_alias.rb:6-7) — one
+// ivar per pair, so `Binary#eql` (binary.rb:19-27) sees a write through either
+// spelling.
+describe("Cte / TableAlias alias the Binary slots", () => {
+  it("Cte#name and #relation are the left/right slots", () => {
+    const relation = new Table("bar").project(new Nodes.SqlLiteral("*"));
+    const cte = new Nodes.Cte("foo", relation);
+    expect(cte.left).toBe("foo");
+    expect(cte.right).toBe(relation);
+
+    cte.left = "renamed";
+    expect(cte.name).toBe("renamed");
+    cte.name = "again";
+    expect(cte.left).toBe("again");
+
+    const other = new Nodes.Cte("again", relation);
+    expect(cte.eql(other)).toBe(true);
+  });
+
+  it("TableAlias#relation and #name are the left/right slots", () => {
+    const relation = new Table("users");
+    const tableAlias = new Nodes.TableAlias(relation, "u1");
+    expect(tableAlias.left).toBe(relation);
+    expect(tableAlias.right).toBe("u1");
+
+    tableAlias.right = "u2";
+    expect(tableAlias.name).toBe("u2");
+    expect(tableAlias.tableAlias).toBe("u2");
+    tableAlias.name = "u3";
+    expect(tableAlias.right).toBe("u3");
+
+    expect(tableAlias.eql(new Nodes.TableAlias(relation, "u3"))).toBe(true);
   });
 });

--- a/packages/arel/src/nodes/cte.ts
+++ b/packages/arel/src/nodes/cte.ts
@@ -10,16 +10,35 @@ import type { SelectManager } from "../select-manager.js";
  * Mirrors: Arel::Nodes::Cte
  */
 export class Cte extends Binary {
+  // Mirrors `alias :name :left` / `alias :relation :right` (cte.rb:6-7): these
+  // are the Binary slots under another spelling, not fields beside them, so a
+  // write through either name is the same write — which is what `Binary#eql`
+  // reads (binary.rb:19-27).
+  //
   // Rails: `SelectManager#as` builds a `TableAlias` whose name is a
   // `Nodes::SqlLiteral` (rendered bare), so `TableAlias#to_cte` passes that
   // literal straight through to `Cte.new`. A plain-string name (e.g. a directly
   // constructed `Cte`) is quoted. Accept both.
-  name: string | SqlLiteral;
+  get name(): string | SqlLiteral {
+    return this.left as string | SqlLiteral;
+  }
+
+  set name(value: string | SqlLiteral) {
+    this.left = value;
+  }
+
   // Rails seats a manager here directly —
   // `Cte.new("foo", Table.new(:bar).project(Arel.star))`
   // (test/cases/arel/visitors/to_sql_test.rb:1008) — and
-  // `visit_Arel_SelectManager` (to_sql.rb:358-361) renders it.
-  relation: Node | SelectManager;
+  // `visit_Arel_SelectManager` (to_sql.rb:358-361) renders it, parens included.
+  get relation(): Node | SelectManager {
+    return this.right as Node | SelectManager;
+  }
+
+  set relation(value: Node | SelectManager) {
+    this.right = value;
+  }
+
   readonly materialized: boolean | null;
 
   constructor(
@@ -28,8 +47,6 @@ export class Cte extends Binary {
     materialized: boolean | null = null,
   ) {
     super(name, relation);
-    this.name = name;
-    this.relation = relation;
     this.materialized = materialized;
   }
 

--- a/packages/arel/src/nodes/function.test.ts
+++ b/packages/arel/src/nodes/function.test.ts
@@ -32,16 +32,12 @@ describe("Arel::Nodes::RollUpTest", () => {
     expect(Nodes.RollUp).toBeDefined();
     expect(new Nodes.RollUp([]) instanceof Nodes.RollUp).toBe(true);
   });
-
-  it("Rollup is a deprecated alias for RollUp", () => {
-    expect(Nodes.Rollup).toBe(Nodes.RollUp);
-  });
 });
 
 describe("Arel::Nodes::WithTest", () => {
   it("children getter returns expr slot", () => {
     const users = new Table("users");
-    const cte = new Nodes.Cte("t", users.project(new SqlLiteral("1")).ast);
+    const cte = new Nodes.Cte("t", users.project(new SqlLiteral("1")));
     const w = new Nodes.With([cte]);
     expect(w.children).toStrictEqual([cte]);
     expect((w as { expr: unknown }).expr).toBe(w.children);

--- a/packages/arel/src/nodes/index.ts
+++ b/packages/arel/src/nodes/index.ts
@@ -26,7 +26,6 @@ export {
   Lateral,
   GroupingElement,
   Cube,
-  Rollup,
   GroupingSet,
   Group,
   OptimizerHints,

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -16,21 +16,36 @@ import { Table } from "../table.js";
  *  which calls Rails protects. */
 interface TypeCastable {
   name?: string;
-  typeCastForDatabase(attrName: string, value: unknown): unknown;
-  typeForAttribute(name: string): unknown;
+  typeCastForDatabase(attrName: string | Node, value: unknown): unknown;
+  typeForAttribute(name: string | Node): unknown;
   isAbleToTypeCast?: () => boolean;
 }
 
 export class TableAlias extends Binary {
-  relation: Node;
-  // Rails: `SelectManager#as` stores the alias as a `Nodes::SqlLiteral` (rendered
-  // bare), while `Table#alias` stores a plain string (quoted). Accept both.
-  name: string | SqlLiteral;
-
   constructor(relation: Node, name: string | SqlLiteral) {
     super(relation, name);
-    this.relation = relation;
-    this.name = name;
+  }
+
+  // Rails: `SelectManager#as` stores the alias as a `Nodes::SqlLiteral` (rendered
+  // bare), while `Table#alias` stores a plain string (quoted). Accept both.
+  get name(): string | SqlLiteral {
+    return this.right as string | SqlLiteral;
+  }
+
+  set name(value: string | SqlLiteral) {
+    this.right = value;
+  }
+
+  // Mirrors `alias :relation :left` / `alias :name :right` (table_alias.rb:6-7):
+  // these are the Binary slots under another spelling, not fields beside them,
+  // so a write through either name is the same write — which is what
+  // `Binary#eql` reads (binary.rb:19-27).
+  get relation(): Node {
+    return this.left as Node;
+  }
+
+  set relation(value: Node) {
+    this.left = value;
   }
 
   // Mirrors Rails `alias :table_alias :name` (table_alias.rb).
@@ -43,11 +58,11 @@ export class TableAlias extends Binary {
     return typeof rel?.name === "string" ? rel.name : this.nameString;
   }
 
-  typeCastForDatabase(attrName: string, value: unknown): unknown {
+  typeCastForDatabase(attrName: string | Node, value: unknown): unknown {
     return (this.relation as unknown as TypeCastable).typeCastForDatabase(attrName, value);
   }
 
-  typeForAttribute(name: string): unknown {
+  typeForAttribute(name: string | Node): unknown {
     return (this.relation as unknown as TypeCastable).typeForAttribute(name);
   }
 

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -53,11 +53,6 @@ export class Cube extends Unary {}
 export class RollUp extends Unary {}
 export class GroupingSet extends Unary {}
 
-/** @deprecated Use RollUp (Rails casing) */
-export const Rollup = RollUp;
-/** @deprecated Use RollUp (Rails casing) */
-export type Rollup = RollUp;
-
 export class Group extends Unary {}
 /**
  * Mirrors: `OptimizerHints` (unary.rb:38) — the hint list lives in the

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -923,25 +923,6 @@ describe("SelectManagerTest", () => {
     });
   });
 
-  describe("where_sql", () => {
-    it("gives me back the where sql", () => {
-      const manager = new SelectManager();
-      manager.from(users);
-      manager.where(users.get("id").eq(10));
-      expect(mustBeLike(manager.whereSql()!.value)).toBe(mustBeLike(`WHERE "users"."id" = 10`));
-    });
-
-    it("joins wheres with AND", () => {
-      const manager = new SelectManager();
-      manager.from(users);
-      manager.where(users.get("id").eq(10));
-      manager.where(users.get("id").eq(11));
-      expect(mustBeLike(manager.whereSql()!.value)).toBe(
-        mustBeLike(`WHERE "users"."id" = 10 AND "users"."id" = 11`),
-      );
-    });
-  });
-
   describe("update", () => {
     it("creates an update statement", () => {
       const mgr = new SelectManager();
@@ -1504,9 +1485,7 @@ describe("SelectManagerTest", () => {
       const mgr = new SelectManager();
       mgr.from(users);
       mgr.where(users.get("id").eq(10));
-      const sql = mgr.whereSql();
-      expect(sql).toBeInstanceOf(Nodes.SqlLiteral);
-      expect(sql?.value).toBe('WHERE "users"."id" = 10');
+      expect(mgr.whereSql()?.value).toBe('WHERE "users"."id" = 10');
     });
 
     it("joins wheres with AND", () => {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -1,6 +1,7 @@
 import { Attribute } from "./attributes/attribute.js";
 import { EmptyJoinError } from "./errors.js";
 import { _engine, ArelEngine, Node } from "./nodes/node.js";
+import { _setTable } from "./node-slots.js";
 import { SelectManager } from "./select-manager.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import { OuterJoin } from "./nodes/outer-join.js";
@@ -219,8 +220,12 @@ export class Table extends Node {
     return sameName && this.tableAlias === other.tableAlias;
   }
 
-  typeCastForDatabase(attrName: string, value: unknown): unknown {
-    return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName, value);
+  typeCastForDatabase(attrName: string | Node, value: unknown): unknown {
+    // Rails' `name` is untyped all the way down (table.rb:100-107 hands it to a
+    // duck-typed caster). `TypeCaster` is where the string boundary lives: only
+    // a String name ever reaches a caster, since `table[Arel.star]` — the one
+    // Node-named attribute — is never type-cast.
+    return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName as string, value);
   }
 
   /** Rails: `private attr_reader :type_caster` (table.rb:115). An aliased table
@@ -228,8 +233,8 @@ export class Table extends Node {
    *  (table_alias.rb:22-24), so no external reader is needed. */
   private readonly typeCaster: unknown;
 
-  typeForAttribute(name: string): unknown {
-    return (this.typeCaster as TypeCaster).typeForAttribute(name);
+  typeForAttribute(name: string | Node): unknown {
+    return (this.typeCaster as TypeCaster).typeForAttribute(name as string);
   }
 
   isAbleToTypeCast(): boolean {
@@ -261,3 +266,5 @@ type _AliasPredication = import("./alias-predication.js").AliasPredicationModule
 
 /* eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging */
 export interface Table extends _FactoryMethodsModule, _AliasPredication {}
+
+_setTable(Table);

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -183,12 +183,12 @@ describe("MysqlTest", () => {
 
   describe("Nodes::Cte", () => {
     it("ignores MATERIALIZED modifiers", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star()).ast, true);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star()), true);
       expect(mustBeLike(compile(cte))).toBe(mustBeLike(`"foo" AS (SELECT * FROM "bar")`));
     });
 
     it("ignores NOT MATERIALIZED modifiers", () => {
-      const cte = new Nodes.Cte("foo", new Table("bar").project(star()).ast, false);
+      const cte = new Nodes.Cte("foo", new Table("bar").project(star()), false);
       expect(mustBeLike(compile(cte))).toBe(mustBeLike(`"foo" AS (SELECT * FROM "bar")`));
     });
   });

--- a/packages/arel/src/visitors/mysql.trails.test.ts
+++ b/packages/arel/src/visitors/mysql.trails.test.ts
@@ -228,17 +228,10 @@ describe("MySQL dialect overrides (audit follow-up)", () => {
 
   it("Cte uses backtick-quoted identifiers (not double quotes)", () => {
     const inner = new SelectManager(users).project(users.get("id"));
-    const cte = new Nodes.Cte("recent", inner.ast);
+    const cte = new Nodes.Cte("recent", inner);
     expect(compile(cte)).toMatch(/^`recent` AS \(/);
-    const weird = new Nodes.Cte("we`ird", inner.ast);
+    const weird = new Nodes.Cte("we`ird", inner);
     expect(compile(weird)).toMatch(/^`we``ird` AS \(/);
-  });
-
-  it("Cte renders exactly one set of parens around a bare SelectStatement", () => {
-    const inner = new SelectManager(users).project(users.get("id"));
-    const cte = new Nodes.Cte("x", inner.ast);
-    const sql = compile(cte);
-    expect(sql).toBe("`x` AS (SELECT `users`.`id` FROM `users`)");
   });
 
   it("Cte renders exactly one set of parens when relation is a Grouping (SqlLiteral path)", () => {

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -1,7 +1,6 @@
 import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
-import { SelectManager } from "../select-manager.js";
 import { ToSql } from "./to-sql.js";
 import { sql } from "../arel.js";
 
@@ -114,27 +113,11 @@ export class MySQL extends ToSql {
   protected override visitArelNodesCte(o: Nodes.Cte, collector: SQLString): SQLString {
     // MySQL identifiers are backtick-quoted, not double-quoted, and the
     // MATERIALIZED / NOT MATERIALIZED modifiers Postgres supports are
-    // ignored. Mirrors Rails' MySQL visit_Arel_Nodes_Cte which calls
-    // `quote_table_name` (which emits backticks on the MySQL adapter).
-    // Parens: Trails stores a bare SelectStatement in Cte.relation (not a
-    // SelectManager as Rails does), so we add them explicitly. But a
-    // Grouping (SqlLiteral path) or a set-operation node (array CTE → UnionAll)
-    // visits with its own parens — skip the explicit wrap in that case.
+    // ignored. Mirrors Rails' MySQL visit_Arel_Nodes_Cte (mysql.rb:72-76),
+    // which calls `quote_table_name` (which emits backticks on the MySQL
+    // adapter) and lets the relation supply its own parens.
     collector.append(`${this.quoteTableName(o.name)} AS `);
-    if (
-      (o.relation as unknown) instanceof SelectManager ||
-      o.relation instanceof Nodes.Grouping ||
-      o.relation instanceof Nodes.Union ||
-      o.relation instanceof Nodes.UnionAll ||
-      o.relation instanceof Nodes.Intersect ||
-      o.relation instanceof Nodes.Except
-    ) {
-      this.visit(o.relation, collector);
-    } else {
-      collector.append("(");
-      this.visit(o.relation, collector);
-      collector.append(")");
-    }
+    this.visit(o.relation, collector);
     return collector;
   }
 

--- a/packages/arel/src/visitors/postgres.trails.test.ts
+++ b/packages/arel/src/visitors/postgres.trails.test.ts
@@ -57,7 +57,7 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
   });
 
   it("Rollup emits `ROLLUP( … )` with spaces", () => {
-    const r = new Nodes.Rollup([users.get("a"), users.get("b")]);
+    const r = new Nodes.RollUp([users.get("a"), users.get("b")]);
     expect(compile(r)).toBe('ROLLUP( "users"."a", "users"."b" )');
   });
 
@@ -85,7 +85,7 @@ describe("PostgreSQL dialect overrides (audit follow-up)", () => {
     expect(compile(new Nodes.Cube([users.get("a"), users.get("b")]))).toBe(
       'CUBE( "users"."a", "users"."b" )',
     );
-    expect(compile(new Nodes.Rollup([users.get("a")]))).toBe('ROLLUP( "users"."a" )');
+    expect(compile(new Nodes.RollUp([users.get("a")]))).toBe('ROLLUP( "users"."a" )');
     expect(compile(new Nodes.GroupingSet([users.get("a"), users.get("b")]))).toBe(
       'GROUPING SETS( "users"."a", "users"."b" )',
     );

--- a/packages/arel/src/visitors/postgresql.ts
+++ b/packages/arel/src/visitors/postgresql.ts
@@ -59,7 +59,7 @@ export class PostgreSQL extends ToSql {
   // Mirrors: Arel::Visitors::PostgreSQL#visit_Arel_Nodes_GroupingElement
   // (postgresql.rb:44-47) — `( expr )` with spaces inside the parens, where
   // the base ToSql renders `(expr)` without them.
-  protected override visitArelNodesGroupingElement(
+  protected visitArelNodesGroupingElement(
     o: Nodes.GroupingElement,
     collector: SQLString,
   ): SQLString {
@@ -72,20 +72,17 @@ export class PostgreSQL extends ToSql {
   // Cube/Rollup/GroupingSet: emit `CUBE` / `ROLLUP` / `GROUPING SETS`
   // followed by `grouping_array_or_grouping_element` formatting. Mirrors
   // Rails Postgres ([postgresql.rb](https://github.com/rails/rails/blob/v8.0.2/activerecord/lib/arel/visitors/postgresql.rb)).
-  protected override visitArelNodesCube(o: Nodes.Cube, collector: SQLString): SQLString {
+  protected visitArelNodesCube(o: Nodes.Cube, collector: SQLString): SQLString {
     collector.append("CUBE");
     return this.groupingArrayOrGroupingElement(o, collector);
   }
 
-  protected override visitArelNodesRollUp(o: Nodes.RollUp, collector: SQLString): SQLString {
+  protected visitArelNodesRollUp(o: Nodes.RollUp, collector: SQLString): SQLString {
     collector.append("ROLLUP");
     return this.groupingArrayOrGroupingElement(o, collector);
   }
 
-  protected override visitArelNodesGroupingSet(
-    o: Nodes.GroupingSet,
-    collector: SQLString,
-  ): SQLString {
+  protected visitArelNodesGroupingSet(o: Nodes.GroupingSet, collector: SQLString): SQLString {
     collector.append("GROUPING SETS");
     return this.groupingArrayOrGroupingElement(o, collector);
   }
@@ -147,5 +144,13 @@ export class PostgreSQL extends ToSql {
    */
   static registerDispatch(): void {
     PostgreSQL.dispatchCache().set(Nodes.Lateral, "visitArelNodesLateral");
+    // Rails' base ToSql visitor has no handler for these four — they are
+    // defined only on the PostgreSQL visitor (postgresql.rb:44-62), so a
+    // non-PG visitor handed one raises `Visitor#visit`'s TypeError terminal
+    // (visitor.rb:36-39).
+    PostgreSQL.dispatchCache().set(Nodes.GroupingElement, "visitArelNodesGroupingElement");
+    PostgreSQL.dispatchCache().set(Nodes.Cube, "visitArelNodesCube");
+    PostgreSQL.dispatchCache().set(Nodes.RollUp, "visitArelNodesRollUp");
+    PostgreSQL.dispatchCache().set(Nodes.GroupingSet, "visitArelNodesGroupingSet");
   }
 }

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -401,16 +401,10 @@ describe("the to_sql visitor", () => {
     });
 
     it("handles CTEs with null materialized (tristate nil — no modifier)", () => {
-      const cte = new Nodes.Cte("t", users.project(users.get("id")).ast, null);
+      const cte = new Nodes.Cte("t", users.project(users.get("id")), null);
       const stmt = new SelectManager().with(cte).project("1");
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(stmt.ast);
       expect(sql).not.toContain("MATERIALIZED");
-    });
-
-    it("wraps a bare SelectStatement body in exactly one set of parens", () => {
-      const cte = new Nodes.Cte("t", users.project(users.get("id")).ast);
-      const sql = new Visitors.ToSql(fakeRecordConnection).compile(cte);
-      expect(sql).toBe('"t" AS (SELECT "users"."id" FROM "users")');
     });
 
     it("does not double-wrap a Grouping body (SqlLiteral path)", () => {
@@ -443,7 +437,7 @@ describe("the to_sql visitor", () => {
     });
 
     it("handles Cte nodes", () => {
-      const cte = new Nodes.Cte("expr1", new Table("bar").project(star()).ast);
+      const cte = new Nodes.Cte("expr1", new Table("bar").project(star()));
       const manager = new Table("foo")
         .project(star())
         .with(cte)
@@ -964,7 +958,7 @@ describe("the to_sql visitor", () => {
   });
 
   it("should mark collector as non-retryable when visiting bound SQL literal", () => {
-    const lit = new Nodes.BoundSqlLiteral("id = ?", [1]);
+    const lit = new Nodes.BoundSqlLiteral("id = ?", [1], null);
     const collector = new Visitors.ToSql(fakeRecordConnection).accept(
       lit,
       new Collectors.SQLString(),
@@ -1602,7 +1596,7 @@ describe("the to_sql visitor", () => {
 
   describe("Nodes::BoundSqlLiteral", () => {
     it("works with positional binds", () => {
-      const node = new Nodes.BoundSqlLiteral("id = ?", [1]);
+      const node = new Nodes.BoundSqlLiteral("id = ?", [1], null);
       const sql = new Visitors.ToSql(fakeRecordConnection).compile(node);
       // Rails: `add_bind` emits the placeholder (BIND_BLOCK = proc { "?" }) into
       // a plain SQLString collector, so `compile` renders `id = ?`, not the
@@ -1884,7 +1878,7 @@ describe("the to_sql visitor", () => {
 
     it("CTE name escapes embedded double-quotes", () => {
       const inner = new Table("users");
-      const cte = new Nodes.Cte('w"in', new SelectManager(inner).project(inner.get("a")).ast);
+      const cte = new Nodes.Cte('w"in', new SelectManager(inner).project(inner.get("a")));
       const sql = new Visitors.ToSql(testConnection).compile(cte);
       expect(sql).toContain('"w""in" AS');
     });

--- a/packages/arel/src/visitors/to-sql.trails.test.ts
+++ b/packages/arel/src/visitors/to-sql.trails.test.ts
@@ -74,7 +74,7 @@ describe("ToSql Array-named identifiers", () => {
   it("the MySQL CTE visitor routes its name through the ToSql quoteTableName helper", () => {
     const cte = new Nodes.Cte(
       ["a", "b"] as unknown as string,
-      new Table("t").from().project(new Nodes.SqlLiteral("1")).ast,
+      new Table("t").from().project(new Nodes.SqlLiteral("1")),
     );
     expect(new Visitors.MySQL(mysqlTestConnection).compile(cte)).toContain('`["a", "b"]` AS ');
   });
@@ -98,5 +98,33 @@ describe("ToSql raw scalars in quoting slots", () => {
   it("quotes a bare string in an Assignment right instead of raising", () => {
     const node = new Nodes.Assignment(users.get("name"), "x");
     expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"users"."name" = \'x\'');
+  });
+});
+
+describe("ToSql grouping-set nodes are PostgreSQL-only", () => {
+  const users = new Table("users");
+  const compile = (n: Nodes.Node): string => new Visitors.ToSql(testConnection).compile(n);
+
+  // `visit_Arel_Nodes_Cube` / `RollUp` / `GroupingElement` / `GroupingSet` are
+  // defined only on the PostgreSQL visitor (postgresql.rb:44-62); the base
+  // ToSql has no handler, so each falls out of `Visitor#visit`'s TypeError
+  // terminal (visitor.rb:36-39).
+  it("raises rather than emitting SQL for Cube/RollUp/GroupingElement/GroupingSet", () => {
+    expect(() => compile(new Nodes.Cube([users.get("a")]))).toThrow(TypeError);
+    expect(() => compile(new Nodes.RollUp([users.get("a")]))).toThrow(TypeError);
+    expect(() => compile(new Nodes.GroupingElement([users.get("a")]))).toThrow(TypeError);
+    expect(() => compile(new Nodes.GroupingSet([users.get("a")]))).toThrow(TypeError);
+  });
+});
+
+describe("ToSql build_quoted Table arm", () => {
+  const users = new Table("users");
+  const posts = new Table("posts");
+
+  // casted.rb:47-51 passes an `Arel::Table` through unchanged, so
+  // `visit_Arel_Table` renders it rather than `Quoted` quoting it as a value.
+  it("renders a Table reached through quotedNode as a table reference", () => {
+    const node = users.get("id").eq(posts);
+    expect(new Visitors.ToSql(testConnection).compile(node)).toBe('"users"."id" = "posts"');
   });
 });

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2,7 +2,6 @@ import { Node } from "../nodes/node.js";
 import { SQLString } from "../collectors/sql-string.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
-import { SelectManager } from "../select-manager.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
 import { BindError } from "../errors.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
@@ -1084,26 +1083,9 @@ export class ToSql extends Visitor {
     } else if (o.materialized === false) {
       collector.append("NOT MATERIALIZED ");
     }
-    // Rails' visit_Arel_Nodes_Cte emits only `AS ` and visits the relation,
-    // relying on the Grouping / SelectManager / set-operation visitors to supply
-    // their own parentheses (arel/visitors/to_sql.rb:732). Trails also stores
-    // bare SelectStatement / SqlLiteral relations, which don't self-wrap, so add
-    // the parens explicitly only for those — otherwise an array CTE
-    // (UnionAll) or a SqlLiteral CTE (Grouping) double-wraps to `AS ((…))`.
-    if (
-      (o.relation as unknown) instanceof SelectManager ||
-      o.relation instanceof Nodes.Grouping ||
-      o.relation instanceof Nodes.Union ||
-      o.relation instanceof Nodes.UnionAll ||
-      o.relation instanceof Nodes.Intersect ||
-      o.relation instanceof Nodes.Except
-    ) {
-      this.visit(o.relation, collector);
-    } else {
-      collector.append("(");
-      this.visit(o.relation, collector);
-      collector.append(")");
-    }
+    // No parens here: `Cte#relation` holds a SelectManager / Grouping /
+    // set-operation node, each of which supplies its own (to_sql.rb:732-744).
+    this.visit(o.relation, collector);
     return collector;
   }
 
@@ -1159,20 +1141,22 @@ export class ToSql extends Visitor {
     collector.retryable = false;
     const sql = o.sqlWithPlaceholders;
 
-    if (o.positionalBinds.length > 0) {
+    if (o.positionalBinds) {
+      const positionalBinds = o.positionalBinds;
       const segments = sql.split("?");
       const expected = segments.length - 1;
-      if (o.positionalBinds.length !== expected) {
+      if (positionalBinds.length !== expected) {
         throw new BindError(
-          `wrong number of bind variables (${o.positionalBinds.length} for ${expected})`,
+          `wrong number of bind variables (${positionalBinds.length} for ${expected})`,
           sql,
         );
       }
       for (let i = 0; i < segments.length; i++) {
         if (segments[i]) collector.append(segments[i]);
-        if (i < o.positionalBinds.length) this.visitBindValue(o.positionalBinds[i], collector);
+        if (i < positionalBinds.length) this.visitBindValue(positionalBinds[i], collector);
       }
-    } else if (Object.keys(o.namedBinds).length > 0) {
+    } else {
+      const namedBinds = o.namedBinds ?? {};
       const re = /:(?<!::)([a-zA-Z]\w*)|([^:]+|.)/gy;
       let m: RegExpExecArray | null;
       while ((m = re.exec(sql)) !== null) {
@@ -1180,14 +1164,12 @@ export class ToSql extends Visitor {
           collector.append(m[2]);
         } else {
           const name = m[1];
-          if (!(name in o.namedBinds)) {
+          if (!(name in namedBinds)) {
             throw new BindError(`missing value for :${name}`, sql);
           }
-          this.visitBindValue(o.namedBinds[name], collector);
+          this.visitBindValue(namedBinds[name], collector);
         }
       }
-    } else {
-      collector.append(sql);
     }
 
     return collector;
@@ -1719,11 +1701,7 @@ export class ToSql extends Visitor {
     reg(Nodes.Max, "visitArelNodesMax");
     reg(Nodes.Min, "visitArelNodesMin");
     reg(Nodes.Avg, "visitArelNodesAvg");
-    reg(Nodes.Cube, "visitArelNodesCube");
-    reg(Nodes.RollUp, "visitArelNodesRollUp");
-    reg(Nodes.GroupingSet, "visitArelNodesGroupingSet");
     reg(Nodes.Group, "visitArelNodesGroup");
-    reg(Nodes.GroupingElement, "visitArelNodesGroupingElement");
     reg(Nodes.Comment, "visitArelNodesComment");
     reg(Nodes.OptimizerHints, "visitArelNodesOptimizerHints");
     reg(Nodes.HomogeneousIn, "visitArelNodesHomogeneousIn");
@@ -1804,37 +1782,6 @@ export class ToSql extends Visitor {
     this.visit(o.left, collector);
     collector.append(" || ");
     this.visit(o.right, collector);
-    return collector;
-  }
-
-  protected visitArelNodesCube(o: Nodes.Cube, collector: SQLString): SQLString {
-    collector.append("CUBE(");
-    this.visit(o.expr as Nodes.Node | Nodes.Node[], collector);
-    collector.append(")");
-    return collector;
-  }
-
-  protected visitArelNodesRollUp(o: Nodes.RollUp, collector: SQLString): SQLString {
-    collector.append("ROLLUP(");
-    this.visit(o.expr as Nodes.Node | Nodes.Node[], collector);
-    collector.append(")");
-    return collector;
-  }
-
-  protected visitArelNodesGroupingElement(
-    o: Nodes.GroupingElement,
-    collector: SQLString,
-  ): SQLString {
-    collector.append("(");
-    this.visit(o.expr as Nodes.Node | Nodes.Node[], collector);
-    collector.append(")");
-    return collector;
-  }
-
-  protected visitArelNodesGroupingSet(o: Nodes.GroupingSet, collector: SQLString): SQLString {
-    collector.append("GROUPING SETS(");
-    this.visit(o.expr as Nodes.Node | Nodes.Node[], collector);
-    collector.append(")");
     return collector;
   }
 


### PR DESCRIPTION
Nine RFC 0124 deviation-convergence stories in arel:

- Attribute#typeCaster / #typeCastForDatabase pass `name` through untyped,
  as attribute.rb:12-18 does; the string boundary now lives once on the
  `TypeCaster` interface (table.rb:100-107).
- Delete the base ToSql handlers for Cube / RollUp / GroupingElement /
  GroupingSet, which Rails defines only on the PostgreSQL visitor
  (postgresql.rb:44-62); a non-PG visitor now raises Visitor#visit's
  TypeError terminal (visitor.rb:36-39).
- BoundSqlLiteral takes all three arguments required and handles nil for
  either bind collection, nils out the unused side and branches on it in
  the visitor (bound_sql_literal.rb:8-40, to_sql.rb:799); the two
  query_methods.ts callers pass nil like query_methods.rb:1696/:1716.
- build_quoted returns an ActiveModel::Attribute unwrapped and gains the
  missing Arel::Table pass-through arm (casted.rb:47-51), the Table
  matched through a zero-import `_Table` slot.
- Cte#relation holds a self-wrapping relation, so both visit_Arel_Nodes_Cte
  bodies reduce to to_sql.rb:732-744 / mysql.rb:72-76 with no paren branch.
- Cte and TableAlias alias Binary's left/right rather than shadowing them
  (cte.rb:6-7, table_alias.rb:6-8), so Binary#eql sees a write through
  either spelling.
- Remove the duplicate bespoke where_sql describe block in
  select-manager.test.ts.
- Drop the invented `Rollup` alias beside Rails' `RollUp`.

Closes-story: attribute-type-caster-delegations-cast-name-to-string
Closes-story: base-tosql-visits-postgres-only-grouping-nodes
Closes-story: bound-sql-literal-bind-args-default-instead-of-nil
Closes-story: converge-arel-build-quoted-model-attribute-unwrapped
Closes-story: converge-arel-build-quoted-table-arm
Closes-story: cte-relation-stores-statement-not-select-manager
Closes-story: cte-table-alias-name-relation-shadow-binary-slots
Closes-story: dedupe-bespoke-where-sql-describe-blocks
Closes-story: drop-arel-rollup-alias