### PR TITLE
refactor(arel): Nodes.buildQuoted re-export, one-Range between/notBetween, Ruby == on the bounds (RFC 0124)

### DIFF
--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -674,6 +674,7 @@ export { currentTime } from "./time-travel.js";
 export { currentTimeInstant } from "./time-travel.js";
 
 export { Range } from "./range-ext.js";
+export { rbEqual } from "./rb-equal.js";
 export { caseEquals, isInclude } from "./core-ext/range/compare-range.js";
 export { overlap, overlaps } from "./core-ext/range/overlap.js";
 // Note: core-ext/range's conversions and each are intentionally kept as subpath

--- a/packages/activesupport/src/rb-equal.ts
+++ b/packages/activesupport/src/rb-equal.ts
@@ -14,5 +14,13 @@ export function rbEqual(a: unknown, b: unknown): boolean {
   if (typeof (a as { equals?: unknown }).equals === "function") {
     return (a as { equals(other: unknown): boolean }).equals(b);
   }
+  // A class whose Ruby `==` is `alias :== :eql?` (Arel::Nodes::Casted,
+  // arel/nodes/casted.rb:33; Arel::Table) has only the `eql` half in TS, so
+  // that IS its `==`. Tried second on purpose: a class carrying both spellings
+  // (Duration, TimeWithZone) means the two by their Ruby names, and `equals`
+  // above is the `==` of the pair.
+  if (typeof (a as { eql?: unknown }).eql === "function") {
+    return (a as { eql(other: unknown): boolean }).eql(b);
+  }
   return false;
 }

--- a/packages/arel/src/attributes/attribute.test.ts
+++ b/packages/arel/src/attributes/attribute.test.ts
@@ -615,7 +615,7 @@ describe("AttributeTest", () => {
   describe("#between", () => {
     it("can be constructed with a standard range", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.between([1, 3]);
+      const node = attribute.between({ begin: 1, end: 3 });
 
       expect(node).toEqual(
         new Nodes.Between(
@@ -627,7 +627,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with a range starting from -Infinity", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.between([-Infinity, 3]);
+      const node = attribute.between({ begin: -Infinity, end: 3 });
 
       expect(node).toEqual(new Nodes.LessThanOrEqual(attribute, new Nodes.Casted(3, attribute)));
     });
@@ -655,7 +655,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with an infinite range", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.between([-Infinity, Infinity]);
+      const node = attribute.between({ begin: -Infinity, end: Infinity });
 
       expect(node).toEqual(new Nodes.NotIn(attribute, []));
     });
@@ -669,7 +669,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with a range ending at Infinity", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.between([0, Infinity]);
+      const node = attribute.between({ begin: 0, end: Infinity });
 
       expect(node).toEqual(new Nodes.GreaterThanOrEqual(attribute, new Nodes.Casted(0, attribute)));
     });
@@ -730,7 +730,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with a range where the begin and end are equal", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.between([1, 1]);
+      const node = attribute.between({ begin: 1, end: 1 });
 
       expect(node).toEqual(new Nodes.Equality(attribute, new Nodes.Casted(1, attribute)));
     });
@@ -739,7 +739,7 @@ describe("AttributeTest", () => {
   describe("#not_between", () => {
     it("can be constructed with a standard range", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.notBetween([1, 3]);
+      const node = attribute.notBetween({ begin: 1, end: 3 });
 
       expect(node).toEqual(
         new Nodes.Grouping(
@@ -753,7 +753,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with a range starting from -Infinity", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.notBetween([-Infinity, 3]);
+      const node = attribute.notBetween({ begin: -Infinity, end: 3 });
 
       expect(node).toEqual(new Nodes.GreaterThan(attribute, new Nodes.Casted(3, attribute)));
     });
@@ -781,7 +781,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with an infinite range", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.notBetween([-Infinity, Infinity]);
+      const node = attribute.notBetween({ begin: -Infinity, end: Infinity });
 
       expect(node).toEqual(new Nodes.In(attribute, []));
     });
@@ -795,7 +795,7 @@ describe("AttributeTest", () => {
 
     it("can be constructed with a range ending at Infinity", () => {
       const attribute = new Attribute(null, null);
-      const node = attribute.notBetween([0, Infinity]);
+      const node = attribute.notBetween({ begin: 0, end: Infinity });
 
       expect(node).toEqual(new Nodes.LessThan(attribute, new Nodes.Casted(0, attribute)));
     });

--- a/packages/arel/src/attributes/attribute.trails.test.ts
+++ b/packages/arel/src/attributes/attribute.trails.test.ts
@@ -95,16 +95,22 @@ describe("AttributeTest (trails)", () => {
   // convenience signature with no Rails-side test.
   describe("two-argument between overload", () => {
     it("between generates BETWEEN", () => {
-      expect(users.project(star()).where(users.get("age").between(18, 65)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE "users"."age" BETWEEN 18 AND 65',
-      );
+      expect(
+        users
+          .project(star())
+          .where(users.get("age").between({ begin: 18, end: 65 }))
+          .toSql(),
+      ).toBe('SELECT * FROM "users" WHERE "users"."age" BETWEEN 18 AND 65');
     });
 
     it("notBetween generates NOT BETWEEN", () => {
       // Mirrors Rails: not_between renders as `(col < begin OR col > end)`.
-      expect(users.project(star()).where(users.get("age").notBetween(18, 65)).toSql()).toBe(
-        'SELECT * FROM "users" WHERE ("users"."age" < 18 OR "users"."age" > 65)',
-      );
+      expect(
+        users
+          .project(star())
+          .where(users.get("age").notBetween({ begin: 18, end: 65 }))
+          .toSql(),
+      ).toBe('SELECT * FROM "users" WHERE ("users"."age" < 18 OR "users"."age" > 65)');
     });
   });
 

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -21,7 +21,7 @@ import {
 } from "../nodes/infix-operation.js";
 import { BitwiseNot } from "../nodes/unary-operation.js";
 import type { NodeOrValue } from "../nodes/binary.js";
-import { Predications } from "../predications.js";
+import { Predications, type RangeLike } from "../predications.js";
 
 /**
  * Attribute — represents a column on a table.
@@ -189,10 +189,6 @@ export class Attribute extends Node {
 // quoted_array / grouping_any / infinity? helpers — comes from the mixin and
 // dispatches back through this class's `quotedNode`, which is the only piece
 // Attribute supplies (the type-casting variant).
-//
-// `between` / `notBetween` are re-declared rather than inherited from
-// `Included<>`: the mixin types them with an overload set, and `Included<>`'s
-// signature inference keeps only the last overload.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Attribute extends Omit<
   Included<typeof Predications>,
@@ -208,12 +204,8 @@ export interface Attribute extends Omit<
   isUnboundable(value: unknown): 1 | -1 | 0;
   /** @internal */
   isOpenEnded(value: unknown): boolean;
-  between(range: readonly [unknown, unknown]): Node;
-  between(rangeObj: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
-  between(begin: unknown, end: unknown, excludeEnd?: boolean): Node;
-  notBetween(range: readonly [unknown, unknown]): Node;
-  notBetween(rangeObj: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
-  notBetween(begin: unknown, end: unknown, excludeEnd?: boolean): Node;
+  between(other: RangeLike): Node;
+  notBetween(other: RangeLike): Node;
 }
 
 include(Attribute, Predications);

--- a/packages/arel/src/nodes/index.ts
+++ b/packages/arel/src/nodes/index.ts
@@ -3,7 +3,7 @@ export { And, Or } from "./nary.js";
 export { Grouping } from "./grouping.js";
 export { SqlLiteral } from "./sql-literal.js";
 export { Fragments } from "./fragments.js";
-export { Quoted, Casted } from "./casted.js";
+export { Quoted, Casted, buildQuoted } from "./casted.js";
 export { Attribute } from "../attributes/attribute.js";
 export { Distinct } from "./terminal.js";
 export { Function, Exists, Sum, Max, Min, Avg } from "./function.js";

--- a/packages/arel/src/predications.test.ts
+++ b/packages/arel/src/predications.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { fakeRecordConnection } from "./test-helpers/connection.js";
+import { Temporal } from "@blazetrails/date";
 import { Table, Nodes, Visitors } from "./index.js";
 
 describe("PredicationsMixin", () => {
@@ -94,6 +95,16 @@ describe("Predications range semantics", () => {
 
     it("range begin == end collapses to Equality", () => {
       const node = id.between({ begin: 5, end: 5 });
+      expect(node).toBeInstanceOf(Nodes.Equality);
+    });
+
+    it("range begin == end collapses to Equality for equal-valued Dates", () => {
+      // predications.rb:56 compares the bounds with Ruby `==`, so two distinct
+      // but equal Date objects collapse — the shape AR's RangeHandler builds.
+      const node = id.between({
+        begin: Temporal.PlainDate.from("2002-03-19"),
+        end: Temporal.PlainDate.from("2002-03-19"),
+      });
       expect(node).toBeInstanceOf(Nodes.Equality);
     });
 

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -19,6 +19,7 @@ import { And, Or } from "./nodes/nary.js";
 import { Grouping } from "./nodes/grouping.js";
 import { Case } from "./nodes/case.js";
 import { Concat, Contains, Overlaps } from "./nodes/infix-operation.js";
+import { rbEqual } from "@blazetrails/activesupport";
 
 /**
  * Stands in for Rails' `when Arel::SelectManager` arm (predications.rb:65-74
@@ -145,34 +146,15 @@ interface UnboundableLike {
 /** The receiver `between` / `notBetween` dispatch their whole tree through. */
 type BetweenHost = Node & PredicationHost & RangePredicates;
 
-/** The `begin` / `end` / `exclude_end?` trio Ruby's Range answers. */
-interface RangeLike {
+/**
+ * The JS analogue of the Ruby Range `between` / `not_between` take
+ * (predications.rb:36, :84): the `begin` / `end` / `exclude_end?` trio, and
+ * nothing else — those bodies read no other member off `other`.
+ */
+export interface RangeLike {
   begin: unknown;
   end: unknown;
-  excludeEnd: boolean;
-}
-
-// Ruby's `between(other)` takes one Range and reads `other.begin` /
-// `other.end` / `other.exclude_end?` off it — a language protocol with no JS
-// equivalent, so the three call shapes trails accepts (`[begin, end]`,
-// `{ begin, end, excludeEnd? }`, `(begin, end, excludeEnd?)`) are normalized
-// to that trio here before the Rails decision tree runs on it.
-function parseRange(beginOrRange: unknown, end: unknown, excludeEnd?: boolean): RangeLike {
-  if (Array.isArray(beginOrRange) && end === undefined) {
-    return { begin: beginOrRange[0], end: beginOrRange[1], excludeEnd: false };
-  }
-  if (
-    typeof beginOrRange === "object" &&
-    beginOrRange !== null &&
-    !(beginOrRange instanceof Node) &&
-    end === undefined &&
-    "begin" in (beginOrRange as Record<string, unknown>) &&
-    "end" in (beginOrRange as Record<string, unknown>)
-  ) {
-    const r = beginOrRange as { begin: unknown; end: unknown; excludeEnd?: boolean };
-    return { begin: r.begin, end: r.end, excludeEnd: r.excludeEnd === true };
-  }
-  return { begin: beginOrRange, end, excludeEnd: excludeEnd === true };
+  excludeEnd?: boolean;
 }
 
 // Build the `expr → Node` callback used by groupingAny / groupingAll.
@@ -271,17 +253,8 @@ export const Predications = {
     return new NotIn(this, this.quotedNode(other));
   },
 
-  // Mirrors Arel::Predications#between (predications.rb:36-61). `other` is a
-  // Ruby Range there; here it is the trio `parseRange` normalizes the three
-  // accepted call shapes onto, and the decision tree below is Rails' own,
-  // branch for branch.
-  between: function (
-    this: BetweenHost,
-    beginOrRange: unknown,
-    end?: unknown,
-    excludeEnd?: boolean,
-  ): Node {
-    const other = parseRange(beginOrRange, end, excludeEnd);
+  // Mirrors Arel::Predications#between (predications.rb:36-61).
+  between(this: BetweenHost, other: RangeLike): Node {
     if (this.isUnboundable(other.begin) === 1 || this.isUnboundable(other.end) === -1) {
       return this.in([]);
     } else if (this.isOpenEnded(other.begin)) {
@@ -300,27 +273,20 @@ export const Predications = {
       return this.gteq(other.begin);
     } else if (other.excludeEnd) {
       return this.gteq(other.begin).and(this.lt(other.end));
-    } else if (other.begin === other.end) {
+    } else if (rbEqual(other.begin, other.end)) {
+      // predications.rb:56 — Ruby `==`, a value comparison: two equal Dates or
+      // two equal bind attributes collapse to `eq` there. `rbEqual` is that
+      // send; JS `===` would only ever cover its identity arm.
       return this.eq(other.begin);
     } else {
       const left = this.quotedNode(other.begin);
       const right = this.quotedNode(other.end);
       return new Between(this, new And([left, right]));
     }
-  } as {
-    (this: BetweenHost, range: readonly [unknown, unknown]): Node;
-    (this: BetweenHost, range: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
-    (this: BetweenHost, begin: unknown, end: unknown, excludeEnd?: boolean): Node;
   },
 
   // Mirrors Arel::Predications#not_between (predications.rb:84-110).
-  notBetween: function (
-    this: BetweenHost,
-    beginOrRange: unknown,
-    end?: unknown,
-    excludeEnd?: boolean,
-  ): Node {
-    const other = parseRange(beginOrRange, end, excludeEnd);
+  notBetween(this: BetweenHost, other: RangeLike): Node {
     if (this.isUnboundable(other.begin) === 1 || this.isUnboundable(other.end) === -1) {
       return this.notIn([]);
     } else if (this.isOpenEnded(other.begin)) {
@@ -342,10 +308,6 @@ export const Predications = {
       const right = other.excludeEnd ? this.gteq(other.end) : this.gt(other.end);
       return left.or(right);
     }
-  } as {
-    (this: BetweenHost, range: readonly [unknown, unknown]): Node;
-    (this: BetweenHost, range: { begin: unknown; end: unknown; excludeEnd?: boolean }): Node;
-    (this: BetweenHost, begin: unknown, end: unknown, excludeEnd?: boolean): Node;
   },
 
   eqAny(

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -274,9 +274,8 @@ export const Predications = {
     } else if (other.excludeEnd) {
       return this.gteq(other.begin).and(this.lt(other.end));
     } else if (rbEqual(other.begin, other.end)) {
-      // predications.rb:56 — Ruby `==`, a value comparison: two equal Dates or
-      // two equal bind attributes collapse to `eq` there. `rbEqual` is that
-      // send; JS `===` would only ever cover its identity arm.
+      // predications.rb:56's `==` is a value comparison; `===` covers only its
+      // identity arm, so two equal Dates would not collapse.
       return this.eq(other.begin);
     } else {
       const left = this.quotedNode(other.begin);

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -356,11 +356,11 @@ describe("SelectManagerTest", () => {
     it("should except two managers", () => {
       const m1 = new SelectManager(users);
       m1.project(star());
-      m1.where(users.get("age").between(18, 60));
+      m1.where(users.get("age").between({ begin: 18, end: 60 }));
 
       const m2 = new SelectManager(users);
       m2.project(star());
-      m2.where(users.get("age").between(40, 99));
+      m2.where(users.get("age").between({ begin: 40, end: 99 }));
 
       const node = m1.except(m2);
       expect(mustBeLike(visitor.compile(node))).toBe(

--- a/packages/arel/src/visitors/mysql.test.ts
+++ b/packages/arel/src/visitors/mysql.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { mustBeLike } from "../test-helpers/must-be-like.js";
-import { buildQuoted } from "../nodes/casted.js";
 import { Table, star, sql, Nodes, Visitors, Collectors } from "../index.js";
 
 describe("MysqlTest", () => {
@@ -26,7 +25,7 @@ describe("MysqlTest", () => {
   it("should escape LIMIT", () => {
     const sc = new Nodes.UpdateStatement();
     sc.relation = new Table("users");
-    sc.limit = new Nodes.Limit(buildQuoted("omg"));
+    sc.limit = new Nodes.Limit(Nodes.buildQuoted("omg"));
     expect(compile(sc)).toBe(`UPDATE "users" LIMIT 'omg'`);
   });
 
@@ -57,7 +56,7 @@ describe("MysqlTest", () => {
 
     it("concats a string", () => {
       const table = new Table("users");
-      const query = table.get("name").concat(buildQuoted("abc"));
+      const query = table.get("name").concat(Nodes.buildQuoted("abc"));
       expect(mustBeLike(compile(query))).toBe(mustBeLike(`CONCAT("users"."name", 'abc')`));
     });
   });
@@ -79,7 +78,7 @@ describe("MysqlTest", () => {
 
     it("should handle nil", () => {
       const table = new Table("users");
-      const val = buildQuoted(null, table.get("active"));
+      const val = Nodes.buildQuoted(null, table.get("active"));
       const compiled = compile(new Nodes.IsNotDistinctFrom(table.get("name"), val));
       expect(mustBeLike(compiled)).toBe(mustBeLike(`"users"."name" <=> NULL`));
     });
@@ -97,7 +96,7 @@ describe("MysqlTest", () => {
 
     it("should handle nil", () => {
       const table = new Table("users");
-      const val = buildQuoted(null, table.get("active"));
+      const val = Nodes.buildQuoted(null, table.get("active"));
       const compiled = compile(new Nodes.IsDistinctFrom(table.get("name"), val));
       expect(mustBeLike(compiled)).toBe(mustBeLike(`NOT "users"."name" <=> NULL`));
     });

--- a/packages/arel/src/visitors/sqlite.test.ts
+++ b/packages/arel/src/visitors/sqlite.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { mustBeLike } from "../test-helpers/must-be-like.js";
-import { buildQuoted } from "../nodes/casted.js";
 import { Table, sql, Nodes, Visitors, Collectors } from "../index.js";
 
 describe("SqliteTest", () => {
@@ -50,7 +49,7 @@ describe("SqliteTest", () => {
 
     it("should handle nil", () => {
       const table = new Table("users");
-      const val = buildQuoted(null, table.get("active"));
+      const val = Nodes.buildQuoted(null, table.get("active"));
       const compiled = compile(new Nodes.IsNotDistinctFrom(table.get("name"), val));
       expect(mustBeLike(compiled)).toBe(mustBeLike(`"users"."name" IS NULL`));
     });
@@ -68,7 +67,7 @@ describe("SqliteTest", () => {
 
     it("should handle nil", () => {
       const table = new Table("users");
-      const val = buildQuoted(null, table.get("active"));
+      const val = Nodes.buildQuoted(null, table.get("active"));
       const compiled = compile(new Nodes.IsDistinctFrom(table.get("name"), val));
       expect(mustBeLike(compiled)).toBe(mustBeLike(`"users"."name" IS NOT NULL`));
     });

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -64,7 +64,7 @@ describe("the to_sql visitor", () => {
     });
 
     it("can handle two dot ranges", () => {
-      const node = attr.notBetween([1, 3]);
+      const node = attr.notBetween({ begin: 1, end: 3 });
       expect(compile(node)).toBe(`("users"."id" < 1 OR "users"."id" > 3)`);
     });
 
@@ -74,16 +74,18 @@ describe("the to_sql visitor", () => {
     });
 
     it("can handle ranges bounded by infinity", () => {
-      expect(mustBeLike(compile(attr.notBetween([1, Infinity])))).toBe(
+      expect(mustBeLike(compile(attr.notBetween({ begin: 1, end: Infinity })))).toBe(
         mustBeLike(`"users"."id" < 1`),
       );
-      expect(mustBeLike(compile(attr.notBetween([-Infinity, 3])))).toBe(
+      expect(mustBeLike(compile(attr.notBetween({ begin: -Infinity, end: 3 })))).toBe(
         mustBeLike(`"users"."id" > 3`),
       );
       expect(
         mustBeLike(compile(attr.notBetween({ begin: -Infinity, end: 3, excludeEnd: true }))),
       ).toBe(mustBeLike(`"users"."id" >= 3`));
-      expect(mustBeLike(compile(attr.notBetween([-Infinity, Infinity])))).toBe(mustBeLike("1=0"));
+      expect(mustBeLike(compile(attr.notBetween({ begin: -Infinity, end: Infinity })))).toBe(
+        mustBeLike("1=0"),
+      );
     });
 
     it("is not preparable when an array", () => {
@@ -327,7 +329,7 @@ describe("the to_sql visitor", () => {
       new Visitors.ToSql(fakeRecordConnection).compile(n);
 
     it("can handle two dot ranges", () => {
-      const node = users.get("id").between([1, 3]);
+      const node = users.get("id").between({ begin: 1, end: 3 });
       expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" BETWEEN 1 AND 3'));
     });
 
@@ -339,13 +341,13 @@ describe("the to_sql visitor", () => {
     });
 
     it("can handle ranges bounded by infinity", () => {
-      let node = users.get("id").between([1, Infinity]);
+      let node = users.get("id").between({ begin: 1, end: Infinity });
       expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" >= 1'));
-      node = users.get("id").between([-Infinity, 3]);
+      node = users.get("id").between({ begin: -Infinity, end: 3 });
       expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" <= 3'));
       node = users.get("id").between({ begin: -Infinity, end: 3, excludeEnd: true });
       expect(mustBeLike(compileNode(node))).toBe(mustBeLike('"users"."id" < 3'));
-      node = users.get("id").between([-Infinity, Infinity]);
+      node = users.get("id").between({ begin: -Infinity, end: Infinity });
       expect(mustBeLike(compileNode(node))).toBe(mustBeLike("1=1"));
     });
   });
@@ -1092,7 +1094,7 @@ describe("the to_sql visitor", () => {
     });
 
     it("can handle two dot ranges", () => {
-      const node = attr.between([1, 3]);
+      const node = attr.between({ begin: 1, end: 3 });
       expect(mustBeLike(compile(node))).toBe(mustBeLike(`"users"."id" BETWEEN 1 AND 3`));
     });
 
@@ -1102,16 +1104,18 @@ describe("the to_sql visitor", () => {
     });
 
     it("can handle ranges bounded by infinity", () => {
-      expect(mustBeLike(compile(attr.between([1, Infinity])))).toBe(
+      expect(mustBeLike(compile(attr.between({ begin: 1, end: Infinity })))).toBe(
         mustBeLike(`"users"."id" >= 1`),
       );
-      expect(mustBeLike(compile(attr.between([-Infinity, 3])))).toBe(
+      expect(mustBeLike(compile(attr.between({ begin: -Infinity, end: 3 })))).toBe(
         mustBeLike(`"users"."id" <= 3`),
       );
       expect(
         mustBeLike(compile(attr.between({ begin: -Infinity, end: 3, excludeEnd: true }))),
       ).toBe(mustBeLike(`"users"."id" < 3`));
-      expect(mustBeLike(compile(attr.between([-Infinity, Infinity])))).toBe(mustBeLike("1=1"));
+      expect(mustBeLike(compile(attr.between({ begin: -Infinity, end: Infinity })))).toBe(
+        mustBeLike("1=1"),
+      );
     });
 
     it("can handle subqueries", () => {

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
-    "novel": 381,
-    "total": 1379
+    "novel": 377,
+    "total": 1331
   },
   "arel": {
     "novel": 0,

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1590,6 +1590,9 @@ function buildPackageReport(
     }
   }
 
+  const rubyFileByTsFile = new Map<string, string>();
+  for (const rf of rubyFileNames) rubyFileByTsFile.set(rubyFileToTs(rf, pkg), rf);
+
   const scoreTargets: { tsFile: string; rubyFile: string | null }[] = [
     ...[...rubyFileNames].map((rubyFile) => ({
       tsFile: rubyFileToTs(rubyFile, pkg),
@@ -1631,6 +1634,33 @@ function buildPackageReport(
             Object.keys(rubyPkg.fileConstants?.[rubyFile] ?? {}),
             rubyFile,
           );
+
+    // A NAMED re-export (`export { buildQuoted } from "./casted.js"`) is a
+    // re-export site, not a port location (compare.ts:2346). When the barrel
+    // itself has no Rails counterpart — `nodes/index.ts` mirrors `arel/nodes.rb`,
+    // which declares nothing — the name is still Rails': `Arel::Nodes.build_quoted`
+    // lives in `arel/nodes/casted.rb` (casted.rb:47-58), which `nodes/casted.ts`
+    // already matches. Score it there, so passing it through a barrel does not
+    // re-charge it as extra surface.
+    if (rubyFile === null) {
+      for (const fn of fileFns ?? []) {
+        if (fn.reExportedFrom === undefined) continue;
+        const sourceTs = fn.reExportedFrom.slice(0, fn.reExportedFrom.lastIndexOf(":"));
+        const sourceRuby = rubyFileByTsFile.get(sourceTs);
+        if (sourceRuby === undefined) continue;
+        const sourceAllowed = collectAllowedNames(
+          rubyFiles.get(sourceRuby) ?? [],
+          pkg,
+          rubyPkg.modules,
+          moduleFqnByShort,
+          crossPackageModules,
+          crossPackagePkgByFqn,
+          Object.keys(rubyPkg.fileConstants?.[sourceRuby] ?? {}),
+          sourceRuby,
+        );
+        if (sourceAllowed.has(fn.name)) allowed.add(fn.name);
+      }
+    }
 
     // `compare_range.rb` declares `CompareWithRange`: the container synthesized
     // from the FILENAME is a name nobody wrote (see `synthesizedFileModule`).

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -927,6 +927,26 @@ export function extractFromProgram(
             d.getSourceFile() === sourceFile &&
             d.parent.parent.moduleSpecifier !== undefined,
         );
+        // Where that named re-export points, as a `<file>:<name>` key. The
+        // barrel is a re-export site, not a port location, so extra-surface
+        // scores the name against the DECLARING file's Rails counterpart.
+        const reExportSpecifier = sym.declarations?.find(
+          (d): d is ts.ExportSpecifier =>
+            ts.isExportSpecifier(d) &&
+            d.getSourceFile() === sourceFile &&
+            d.parent.parent.moduleSpecifier !== undefined,
+        );
+        let reExportedFrom: string | undefined;
+        if (reExportSpecifier !== undefined) {
+          const spec = reExportSpecifier.parent.parent.moduleSpecifier;
+          const targetRel =
+            spec !== undefined && ts.isStringLiteral(spec)
+              ? resolveRelModule(relPath, spec.text)
+              : null;
+          if (targetRel) {
+            reExportedFrom = `${targetRel}:${(reExportSpecifier.propertyName ?? reExportSpecifier.name).text}`;
+          }
+        }
         if (decl && (decl.getSourceFile() === sourceFile || namedReExport === true)) {
           let params: ParamInfo[] = [];
           let isFunctionLike = false;
@@ -998,6 +1018,7 @@ export function extractFromProgram(
               line,
               file: relPath,
               ...(internal ? { internal: true } : {}),
+              ...(reExportedFrom !== undefined ? { reExportedFrom } : {}),
               ...(noRailsEquivalent !== undefined ? { noRailsEquivalent } : {}),
               ...(calls !== undefined ? { calls } : {}),
               ...(callSeq !== undefined ? { callSeq } : {}),
@@ -1029,7 +1050,11 @@ export function extractFromProgram(
     // Only count public functions: a file with only non-exported helpers
     // (all `internal: true`) shouldn't fabricate a module — there's no
     // public surface for the module to represent.
-    const hasPublicFn = fileFunctions.some((fn) => !fn.internal);
+    // A function that only passes THROUGH this file (`export { buildQuoted }
+    // from "./casted.js"`) is not a declaration here, so it cannot conjure a
+    // module named after the barrel's filename — `nodes/index.ts` would
+    // fabricate `Index`, a name nobody wrote and Rails does not have.
+    const hasPublicFn = fileFunctions.some((fn) => !fn.internal && !fn.reExportedFrom);
     if (!fileHasClassOrModule && hasPublicFn) {
       const baseName = path.basename(relPath, ".ts");
       const moduleName = baseName

--- a/scripts/api-compare/extractor-schema.ts
+++ b/scripts/api-compare/extractor-schema.ts
@@ -87,6 +87,7 @@ export const EXTRACTOR_OUTPUT_FIELDS = [
   "missingRailsArgsReasons",
   "recv",
   "writer",
+  "reExportedFrom",
 ] as const;
 
 /**

--- a/scripts/parity/types.ts
+++ b/scripts/parity/types.ts
@@ -239,6 +239,14 @@ export interface MethodInfo {
    * other). See extract-ts-api.ts `delegationTargetName`.
    */
   delegatesTo?: string;
+  /**
+   * TS-side only: for a top-level function that reaches this file through a
+   * NAMED re-export (`export { buildQuoted } from "./casted.js"`), the
+   * `<file>:<name>` key of the declaration site. A barrel is a re-export site,
+   * never a port location (compare.ts:2346), so extra-surface scores such a
+   * name where it is DECLARED when the barrel itself has no Rails counterpart.
+   */
+  reExportedFrom?: string;
 }
 
 export interface ClassInfo {


### PR DESCRIPTION
Three RFC 0124 deviation-convergence stories over arel's predications and the
`Nodes` namespace.

## `Nodes.buildQuoted` (nodes-build-quoted-missing-from-nodes-namespace)

`build_quoted` is a module function on `Arel::Nodes`
(`arel/nodes/casted.rb:47-58`), and Rails' own arel tests call it that way —
`mysql_test.rb:31`, `sqlite_test.rb:50`. trails defined `buildQuoted` in
`nodes/casted.ts` but never re-exported it, so every call site deep-imported the
module instead.

The re-export was attempted in #7016 and reverted: it moved arel's
extra-surface measurement from novel 0 / total 63 to novel 1 / total 65. The
cause was in the extractor, not the name. A barrel is a re-export site, never a
port location (`compare.ts:2346`), but `nodes/index.ts` has no Rails
counterpart (`arel/nodes.rb` is `require`s only), so:

- the passed-through `buildQuoted` was charged to the barrel with an empty
  allow-set, and
- the barrel, now holding a "public function", synthesized a module named after
  its own filename — `Index`, a name nobody wrote — which scored novel.

Both are fixed at the source. A named re-export now records its declaration site
(`MethodInfo.reExportedFrom`); when the re-exporting file has no Rails
counterpart, extra-surface scores the name against the DECLARING file's Rails
match, and a file no longer synthesizes a filename module out of functions it
does not declare. arel's mark is unchanged at novel 0 / total 62; activerecord's
narrows (novel 381 → 377, total 1379 → 1331) as 48 barrel re-exports get
credited where they are written.

## One Range argument (predications-between-accepts-three-call-shapes)

`between` / `not_between` (`predications.rb:36`, `:84`) take one Ruby Range and
read `begin` / `end` / `exclude_end?` off it. trails accepted three call shapes,
which cost a `parseRange` normalizer with no Rails counterpart, a three-overload
cast on each method, and the same overload set re-declared on `Attribute`
(because `Included<>` keeps only the last overload). All of it is gone: one
`RangeLike` argument — the shape AR's `RangeHandler` already threads
(`range-handler.ts:30`). Call sites in the suites move from the array and
positional forms to it.

## Ruby `==` on the bounds (predications-between-bound-equality-is-reference-equality)

`predications.rb:56`'s degenerate-range arm is `other.begin == other.end` —
value equality, so two equal `Date`s or two equal bind attributes collapse to
`eq`. The port used `===`, which only ever covers the identity arm, so
`between(someDate, sameDate)` built a `Between(And(Casted, Casted))` where Rails
builds an `Equality`.

It now uses `rbEqual`, activesupport's existing `rb_equal` port
(`rb-equal.ts`, already the `==` send behind `Range#==` and `Duration#==`),
rather than a bespoke deep-equal in `predications.ts`. `rbEqual` gains one arm:
a class whose Ruby `==` is `alias :== :eql?` (`casted.rb:33`) has only the `eql`
half in TS, so that IS its `==`. It is tried after `equals` on purpose — a class
carrying both spellings (`Duration`, `TimeWithZone`) means them by their Ruby
names.

Regression: `predications.test.ts`'s new "range begin == end collapses to
Equality for equal-valued Dates" fails on the `===` baseline (verified) and
passes here.

## Verification

- `pnpm vitest run packages/arel` — 88 files / 1470 tests green.
- AR `where` / `where-clause` / PG `oid/range` / predicate-builder suites green.
- `pnpm parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate` all
  OK; no new arity-exclude row for `between` / `not_between`.
- `pnpm vitest run scripts/api-compare/` — 41 files / 1379 tests green.
- `pnpm lint` clean.

Closes-story: nodes-build-quoted-missing-from-nodes-namespace
Closes-story: predications-between-accepts-three-call-shapes
Closes-story: predications-between-bound-equality-is-reference-equality
