### PR TITLE
refactor(activerecord,trailties): inline-holder find_target? gate, Column/SqlTypeMetadata deduplication, ConnectionDescriptor primary-class name, privates-manifest entities, trailties private-jsdoc (RFC 0112, RFC 0119, RFC 0121)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -357,6 +357,7 @@ export default defineConfig(
       "packages/globalid/src/**/*.ts",
       "packages/i18n/src/**/*.ts",
       "packages/did-you-mean/src/**/*.ts",
+      "packages/trailties/src/**/*.ts",
     ],
     ignores: ["**/*.test.ts"],
     rules: {

--- a/eslint/rails-private-jsdoc.config.mjs
+++ b/eslint/rails-private-jsdoc.config.mjs
@@ -41,6 +41,7 @@ export default [
       "packages/globalid/src/**/*.ts",
       "packages/i18n/src/**/*.ts",
       "packages/did-you-mean/src/**/*.ts",
+      "packages/trailties/src/**/*.ts",
     ],
     ignores: ["**/*.test.ts"],
     languageOptions: {

--- a/packages/activerecord/src/cases/writing-pool-census.trails.test.ts
+++ b/packages/activerecord/src/cases/writing-pool-census.trails.test.ts
@@ -26,7 +26,7 @@ describe("writing pool census", () => {
     try {
       await Base.establishConnection({ adapter: "sqlite3", database: "db/primary.sqlite3" });
       expect(writingPoolsLeakedSinceBaseline()).toEqual(
-        expect.arrayContaining([expect.stringMatching(/^Base \(/)]),
+        expect.arrayContaining([expect.stringMatching(/^ActiveRecord::Base \(/)]),
       );
     } finally {
       await restoreWorkerConnection();

--- a/packages/activerecord/src/connection-adapters/abstract/connection-descriptor.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-descriptor.ts
@@ -21,10 +21,15 @@ export class ConnectionDescriptor {
   }
 
   /** Mirrors: ConnectionHandler::ConnectionDescriptor#name
-   *  (`abstract/connection_handler.rb:63`) — `primary_class? ? "ActiveRecord::Base" : @name`;
-   *  trails spells `ActiveRecord::Base` as `Base`. */
+   *  (`abstract/connection_handler.rb:63`) — `primary_class? ? "ActiveRecord::Base" : @name`,
+   *  the literal Rails hardcodes there. It is also what Rails'
+   *  `connection_specification_name` answers for a primary class (`Base.name`,
+   *  `connection_handling.rb:316-320`), which is why the pool key a descriptor
+   *  names and the one a model looks a pool up by are the same string — so
+   *  trails spells both with the Rails literal rather than with its own
+   *  `Base.name`. */
   get name(): string {
-    return this.primaryClassQ() ? "Base" : this._name;
+    return this.primaryClassQ() ? "ActiveRecord::Base" : this._name;
   }
 
   /** Mirrors: ConnectionHandler::ConnectionDescriptor#primary_class?

--- a/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-handler.ts
@@ -337,7 +337,7 @@ export class ConnectionHandler {
       if (shard !== "default") parts.push(`'${shard}' shard`);
       if (role !== "writing") parts.push(`'${role}' role`);
       const selector = parts.join(" and ");
-      const prefix = connectionName !== "Base" ? connectionName : "";
+      const prefix = connectionName !== "ActiveRecord::Base" ? connectionName : "";
       const full = [prefix, selector].filter(Boolean).join(" with ");
       const suffix = full ? ` for ${full}` : "";
       const message = `No database connection defined${suffix}.`;

--- a/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/column-equality.trails.test.ts
@@ -121,6 +121,15 @@ describe("ColumnDeduplicationTrails", () => {
     expect(plain.deduplicate()).not.toBe(serial.deduplicate());
   });
 
+  it("interns the sqlTypeMetadata onto the shared canonical instance", () => {
+    const canonical = meta({ sqlType: "bigint" }).deduplicate();
+    const own = meta({ sqlType: "bigint" });
+    expect(own).not.toBe(canonical);
+    const column = new Column("dedup_interned", null, own, false).deduplicate();
+    expect(column.sqlTypeMetadata).toBe(canonical);
+    expect(Object.isFrozen(canonical)).toBe(true);
+  });
+
   it("folds the SQLite3 rowid flag into the key, which its equality ignores", () => {
     const opts = { sqlType: "integer", type: "integer" };
     const plain = new SQLite3Column("dedup_sqlite", null, opts, false);

--- a/packages/activerecord/src/connection-adapters/column.ts
+++ b/packages/activerecord/src/connection-adapters/column.ts
@@ -233,7 +233,7 @@ export class Column implements Deduplicable {
    */
   deduplicated(): this {
     if (this.sqlTypeMetadata) {
-      this.sqlTypeMetadata.deduplicate();
+      this.sqlTypeMetadata = this.sqlTypeMetadata.deduplicate();
     }
     return Object.freeze(this);
   }

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -100,12 +100,12 @@ describe("ConnectionHandlerTest", () => {
       database: "test/db/primary.sqlite3",
     });
     localHandler.establishConnection(config, {
-      ownerName: "Base",
+      ownerName: "ActiveRecord::Base",
       role: "also_writing",
       shard: "default",
     });
     localHandler.establishConnection(config, {
-      ownerName: "Base",
+      ownerName: "ActiveRecord::Base",
       role: "also_writing",
       shard: "one",
     });
@@ -118,12 +118,12 @@ describe("ConnectionHandlerTest", () => {
       adapter: "sqlite3",
       database: "test/db/primary.sqlite3",
     });
-    localHandler.establishConnection(config, { ownerName: "Base", role: "writing" });
-    localHandler.establishConnection(config, { ownerName: "Base", role: "reading" });
+    localHandler.establishConnection(config, { ownerName: "ActiveRecord::Base", role: "writing" });
+    localHandler.establishConnection(config, { ownerName: "ActiveRecord::Base", role: "reading" });
     expect(() => setupSharedConnectionPool(localHandler)).not.toThrow();
     // After shared-pool setup reading pool IS the writing pool — same connection leased.
-    const rwPool = localHandler.retrieveConnectionPool("Base", { role: "writing" })!;
-    const roPool = localHandler.retrieveConnectionPool("Base", { role: "reading" })!;
+    const rwPool = localHandler.retrieveConnectionPool("ActiveRecord::Base", { role: "writing" })!;
+    const roPool = localHandler.retrieveConnectionPool("ActiveRecord::Base", { role: "reading" })!;
     expect(roPool).toBe(rwPool);
   });
 
@@ -137,12 +137,12 @@ describe("ConnectionHandlerTest", () => {
         database: "test/db/primary.sqlite3",
       });
       localHandler.establishConnection(config, {
-        ownerName: "Base",
+        ownerName: "ActiveRecord::Base",
         role: "also_writing",
         shard: "default",
       });
       localHandler.establishConnection(config, {
-        ownerName: "Base",
+        ownerName: "ActiveRecord::Base",
         role: "also_writing",
         shard: "one",
       });
@@ -295,7 +295,7 @@ describe("ConnectionHandlerTest", () => {
       const ownConfig = new HashConfig("development", "Klass2", ambientPoolConfiguration());
 
       const basePool = freshHandler.establishConnection(baseConfig, {
-        ownerName: "Base",
+        ownerName: "ActiveRecord::Base",
         role: "writing",
       });
 

--- a/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-multi-db.test.ts
@@ -12,7 +12,7 @@ describe("ConnectionHandlersMultiDbTest", () => {
   let handler: ConnectionHandler;
   let rwPool: any;
   let roPool: any;
-  const connectionName = "Base";
+  const connectionName = "ActiveRecord::Base";
 
   const DB_NAMES = ["primary", "readonly", "animals"] as const;
   type DbName = (typeof DB_NAMES)[number];
@@ -153,11 +153,11 @@ describe("ConnectionHandlersMultiDbTest", () => {
       () => {
         Base.connectsTo({ database: { writing: "default", reading: "readonly" } });
 
-        const writingPool = Base.connectionHandler.retrieveConnectionPool("Base");
+        const writingPool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
         expect(writingPool).not.toBeNull();
         expect(writingPool!.dbConfig.name).toBe("default");
 
-        const readingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+        const readingPool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", {
           role: "reading",
         });
         expect(readingPool).not.toBeNull();
@@ -178,13 +178,13 @@ describe("ConnectionHandlersMultiDbTest", () => {
       () => {
         Base.connectsTo({ database: { default: "primary", readonly: "readonly" } });
 
-        const defaultPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+        const defaultPool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", {
           role: "default",
         });
         expect(defaultPool).not.toBeNull();
         expect(defaultPool!.dbConfig.name).toBe("primary");
 
-        const readonlyPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+        const readonlyPool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", {
           role: "readonly",
         });
         expect(readonlyPool).not.toBeNull();
@@ -199,7 +199,7 @@ describe("ConnectionHandlersMultiDbTest", () => {
       Base.connectsTo({ database: { writing: "postgresql://localhost/bar" } });
       expect(currentRole.call(Base as any)).toBe("writing");
       expect(Base.connectedToQ({ role: "writing" })).toBe(true);
-      const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+      const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
       expect(pool).not.toBeNull();
       expect(pool!.dbConfig.adapter).toMatch(/postgr/i);
     });
@@ -210,7 +210,7 @@ describe("ConnectionHandlersMultiDbTest", () => {
       Base.connectsTo({ database: { writing: sqliteDb("readonly") } });
       expect(currentRole.call(Base as any)).toBe("writing");
       expect(Base.connectedToQ({ role: "writing" })).toBe(true);
-      expect(Base.connectionHandler.retrieveConnectionPool("Base")).not.toBeNull();
+      expect(Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base")).not.toBeNull();
     });
   });
 
@@ -230,7 +230,7 @@ describe("ConnectionHandlersMultiDbTest", () => {
         Base.connectsTo({ database: { writing: "animals" } });
         expect(currentRole.call(Base as any)).toBe("writing");
         expect(Base.connectedToQ({ role: "writing" })).toBe(true);
-        expect(Base.connectionHandler.retrieveConnectionPool("Base")).not.toBeNull();
+        expect(Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base")).not.toBeNull();
       },
       { defaultEnv: "default_env" },
     );
@@ -253,7 +253,7 @@ describe("ConnectionHandlersMultiDbTest", () => {
         const handler = Base.connectionHandler;
         expect(Base.connectionHandler).toBe(handler);
 
-        const pool = handler.retrieveConnectionPool("Base");
+        const pool = handler.retrieveConnectionPool("ActiveRecord::Base");
         expect(pool).not.toBeNull();
         expect(pool!.dbConfig.name).toBe("primary");
         expect(pool!.dbConfig.configurationHash).toEqual(config.default_env.primary);
@@ -281,7 +281,9 @@ describe("ConnectionHandlersMultiDbTest", () => {
       },
       () => {
         Base.connectsTo({ database: { writing: "development", reading: "development_readonly" } });
-        const pool = Base.connectionHandler.retrieveConnectionPool("Base", { role: "reading" });
+        const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", {
+          role: "reading",
+        });
         expect(pool).not.toBeNull();
       },
     );
@@ -298,8 +300,8 @@ describe("ConnectionHandlersMultiDbTest", () => {
           database: { writing: "development", reading: "development_readonly" },
         });
         expect(result).toEqual([
-          Base.connectionHandler.retrieveConnectionPool("Base"),
-          Base.connectionHandler.retrieveConnectionPool("Base", { role: "reading" }),
+          Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base"),
+          Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", { role: "reading" }),
         ]);
       },
     );

--- a/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handlers-sharding-db.test.ts
@@ -78,7 +78,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
           expect(Array.isArray(rows)).toBe(true);
           await conn.executeMutation(`DROP TABLE IF EXISTS "people"`);
 
-          const pm = (Base.connectionHandler as any).getPoolManager("Base");
+          const pm = (Base.connectionHandler as any).getPoolManager("ActiveRecord::Base");
           expect([...pm.shardNames].sort()).toEqual(["default", "shard_one"]);
         });
       },
@@ -103,20 +103,19 @@ describe("ConnectionHandlersShardingDbTest", () => {
           },
         });
 
-        const basePool = Base.connectionHandler.retrieveConnectionPool("Base");
-        const defaultPool = Base.connectionHandler.retrieveConnectionPool("Base", {
+        const basePool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
+        const defaultPool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", {
           shard: "default",
         });
 
-        expect((Base.connectionHandler as any).getPoolManager("Base")!.shardNames).toEqual([
-          "default",
-          "shard_one",
-        ]);
+        expect(
+          (Base.connectionHandler as any).getPoolManager("ActiveRecord::Base")!.shardNames,
+        ).toEqual(["default", "shard_one"]);
         expect(basePool).toBe(defaultPool);
         expect(defaultPool!.dbConfig.database).toBe(primary);
         expect(defaultPool!.dbConfig.name).toBe("primary");
 
-        const shardOnePool = Base.connectionHandler.retrieveConnectionPool("Base", {
+        const shardOnePool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", {
           shard: "shard_one",
         });
         expect(shardOnePool).not.toBeUndefined();
@@ -150,36 +149,51 @@ describe("ConnectionHandlersShardingDbTest", () => {
           },
         });
 
-        const defaultWritingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
-          shard: "default",
-        });
-        const baseWritingPool = Base.connectionHandler.retrieveConnectionPool("Base");
+        const defaultWritingPool = Base.connectionHandler.retrieveConnectionPool(
+          "ActiveRecord::Base",
+          {
+            shard: "default",
+          },
+        );
+        const baseWritingPool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
         expect(baseWritingPool).toBe(defaultWritingPool);
         expect(defaultWritingPool!.dbConfig.database).toBe(primary);
         expect(defaultWritingPool!.dbConfig.name).toBe("primary");
 
-        const defaultReadingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
-          role: "reading",
-          shard: "default",
-        });
-        const baseReadingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
-          role: "reading",
-        });
+        const defaultReadingPool = Base.connectionHandler.retrieveConnectionPool(
+          "ActiveRecord::Base",
+          {
+            role: "reading",
+            shard: "default",
+          },
+        );
+        const baseReadingPool = Base.connectionHandler.retrieveConnectionPool(
+          "ActiveRecord::Base",
+          {
+            role: "reading",
+          },
+        );
         expect(baseReadingPool).toBe(defaultReadingPool);
         expect(defaultReadingPool!.dbConfig.database).toBe(primary);
         expect(defaultReadingPool!.dbConfig.name).toBe("primary_replica");
 
-        const shardOneWritingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
-          shard: "shard_one",
-        });
+        const shardOneWritingPool = Base.connectionHandler.retrieveConnectionPool(
+          "ActiveRecord::Base",
+          {
+            shard: "shard_one",
+          },
+        );
         expect(shardOneWritingPool).not.toBeUndefined();
         expect(shardOneWritingPool!.dbConfig.database).toBe(primaryShardOne);
         expect(shardOneWritingPool!.dbConfig.name).toBe("primary_shard_one");
 
-        const shardOneReadingPool = Base.connectionHandler.retrieveConnectionPool("Base", {
-          role: "reading",
-          shard: "shard_one",
-        });
+        const shardOneReadingPool = Base.connectionHandler.retrieveConnectionPool(
+          "ActiveRecord::Base",
+          {
+            role: "reading",
+            shard: "shard_one",
+          },
+        );
         expect(shardOneReadingPool).not.toBeUndefined();
         expect(shardOneReadingPool!.dbConfig.database).toBe(primaryShardOne);
         expect(shardOneReadingPool!.dbConfig.name).toBe("primary_shard_one_replica");
@@ -204,7 +218,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
           database: databases[name],
           ...(replica ? { replica: true } : {}),
         }),
-        { ownerName: "Base", role, shard },
+        { ownerName: "ActiveRecord::Base", role, shard },
       );
 
     try {
@@ -311,10 +325,12 @@ describe("ConnectionHandlersShardingDbTest", () => {
   it("retrieve connection pool with invalid shard", async () => {
     Base.connectionHandler.establishConnection(
       new HashConfig("test", "Base", { adapter: "sqlite3", database: dbPath("arunit.sqlite3") }),
-      { ownerName: "Base" },
+      { ownerName: "ActiveRecord::Base" },
     );
-    expect(Base.connectionHandler.retrieveConnectionPool("Base")).not.toBeUndefined();
-    expect(Base.connectionHandler.retrieveConnectionPool("Base", { shard: "foo" })).toBeUndefined();
+    expect(Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base")).not.toBeUndefined();
+    expect(
+      Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base", { shard: "foo" }),
+    ).toBeUndefined();
   });
 
   it("calling connected to on a non existent shard raises", async () => {
@@ -334,7 +350,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
         expect(error.message).toBe(
           "No database connection defined for 'foo' shard and 'reading' role.",
         );
-        expect(error.connectionName).toBe("Base");
+        expect(error.connectionName).toBe("ActiveRecord::Base");
         expect(error.shard).toBe("foo");
         expect(error.role).toBe("reading");
       },
@@ -363,7 +379,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
         expect(error.message).toBe(
           "No database connection defined for 'shard_one' shard and 'non_existent' role.",
         );
-        expect(error.connectionName).toBe("Base");
+        expect(error.connectionName).toBe("ActiveRecord::Base");
         expect(error.shard).toBe("shard_one");
         expect(error.role).toBe("non_existent");
       },
@@ -385,7 +401,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
         }
         expect(error).toBeDefined();
         expect(error.message).toBe("No database connection defined for 'foo' shard.");
-        expect(error.connectionName).toBe("Base");
+        expect(error.connectionName).toBe("ActiveRecord::Base");
         expect(error.shard).toBe("foo");
         expect(error.role).toBe("writing");
       },
@@ -401,7 +417,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
     const makePool = (shard: string) =>
       Base.connectionHandler.establishConnection(
         new HashConfig("test", shard, { adapter: "sqlite3", database: databases[shard] }),
-        { ownerName: "Base", role: "writing", shard },
+        { ownerName: "ActiveRecord::Base", role: "writing", shard },
       );
     try {
       makePool("default");
@@ -419,7 +435,7 @@ describe("ConnectionHandlersShardingDbTest", () => {
   it("can swap roles while shard swapping is prohibited", async () => {
     Base.connectionHandler.establishConnection(
       new HashConfig("test", "Base", { adapter: "sqlite3", database: dbPath("primary.sqlite3") }),
-      { ownerName: "Base", role: "reading", shard: "default" },
+      { ownerName: "ActiveRecord::Base", role: "reading", shard: "default" },
     );
     expect(() => {
       Base.prohibitShardSwapping(() => {

--- a/packages/activerecord/src/connection-adapters/pool-config.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.trails.test.ts
@@ -58,7 +58,7 @@ describe("PoolConfig", () => {
     it("wraps primary class owners correctly", () => {
       config.connectionDescriptor = { name: "Base", primaryClassQ: () => true };
       expect(config.connectionDescriptor.primaryClassQ()).toBe(true);
-      expect(config.connectionDescriptor.name).toBe("Base");
+      expect(config.connectionDescriptor.name).toBe("ActiveRecord::Base");
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -98,9 +98,13 @@ export class SqlTypeMetadata implements Deduplicable {
     return deduplicate(this);
   }
 
-  /** @internal */
+  /**
+   * `SqlTypeMetadata` adds nothing to `Deduplicable#deduplicated`, which is
+   * `freeze` (`deduplicable.rb:26`).
+   * @internal
+   */
   deduplicated(): this {
-    return this;
+    return Object.freeze(this);
   }
 }
 

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -247,7 +247,7 @@ describe("ConnectionHandlingTest", () => {
   });
 
   it("connection_specification_name defaults to Base", async () => {
-    expect(Base.connectionSpecificationName).toBe("Base");
+    expect(Base.connectionSpecificationName).toBe("ActiveRecord::Base");
   });
 
   it("connection_specification_name returns 'Base' for a primary class even before connectsTo plants it", async () => {
@@ -262,7 +262,7 @@ describe("ConnectionHandlingTest", () => {
       expect(Object.prototype.hasOwnProperty.call(AppRecord, "_connectionSpecificationName")).toBe(
         false,
       );
-      expect(AppRecord.connectionSpecificationName).toBe("Base");
+      expect(AppRecord.connectionSpecificationName).toBe("ActiveRecord::Base");
     } finally {
       __resetPrimaryAbstractClass();
     }
@@ -825,7 +825,7 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
       // resolveConfigForConnection side effect (planting
       // _connectionSpecificationName) is covered end-to-end.
       AppRecord.connectsTo({ database: { writing: "primary" } });
-      expect((AppRecord as any)._connectionSpecificationName).toBe("Base");
+      expect((AppRecord as any)._connectionSpecificationName).toBe("ActiveRecord::Base");
 
       SecondaryAbstract.connectsTo({ database: { writing: "primary" } });
       expect((SecondaryAbstract as any)._connectionSpecificationName).toBe("SecondaryAbstract");

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -525,20 +525,22 @@ export function connectionSpecificationName(this: typeof Base): string {
 
   // Branch 2: explicitly cleared → parent walk (Base terminates).
   if (ownHas) {
-    if (this.name === "Base") return "Base";
+    if (this.name === "Base") return "ActiveRecord::Base";
     const parent = Object.getPrototypeOf(this);
     if (parent && typeof parent === "function" && parent !== this) {
       return connectionSpecificationName.call(parent as typeof Base);
     }
-    return "Base";
+    return "ActiveRecord::Base";
   }
 
   // Branch 3: no own property — derive from class shape.
-  // Base is always its own terminal; primary classes (ApplicationRecord) store
-  // their pool under "Base" per ConnectionDescriptor#name (connection_handler.rb:63).
-  if (this.name === "Base") return "Base";
+  // Base is always its own terminal (Rails' `Base.name`); primary classes
+  // (ApplicationRecord) store their pool under that same name, which is the
+  // string `ConnectionDescriptor#name` answers for them
+  // (connection_handler.rb:63).
+  if (this.name === "Base") return "ActiveRecord::Base";
   if (typeof (this as any).primaryClassQ === "function" && (this as any).primaryClassQ()) {
-    return "Base";
+    return "ActiveRecord::Base";
   }
   // connectionClass = true means establish_connection or connectsTo was called
   // and planted a pool under this class's name without setting the ivar explicitly.
@@ -549,7 +551,7 @@ export function connectionSpecificationName(this: typeof Base): string {
   if (parent && typeof parent === "function" && parent !== this) {
     return connectionSpecificationName.call(parent as typeof Base);
   }
-  return "Base";
+  return "ActiveRecord::Base";
 }
 
 export function schemaCache(this: typeof Base) {
@@ -887,7 +889,7 @@ async function establishWithConfig(
   // class so it gets an independent pool entry under its own name instead of
   // inheriting the Base pool. Without this Tag.establishConnection and
   // Tag2.establishConnection both resolve connectionClassForSelf() → Base and
-  // register under the same "Base" pool key, defeating cross-connection
+  // register under the same primary-class pool key, defeating cross-connection
   // isolation tests.
   modelClass.connectionClass = true;
 
@@ -971,12 +973,14 @@ export function resolveConfigForConnection(
   if (!this.name) throw new Error("Anonymous class is not allowed.");
   // Mirrors Rails: connection_name = primary_class? ? Base.name : name, then
   // self.connection_specification_name = connection_name. The primary class
-  // (Base/ApplicationRecord) stores its pool under "Base" — matching
-  // ConnectionDescriptor#name's primary-class normalization — so
+  // (Base/ApplicationRecord) stores its pool under `Base.name` — the same
+  // string ConnectionDescriptor#name answers (connection_handler.rb:63) — so
   // subsequent connectionPool() lookups hit the right key. The reader uses
   // an own-property check so writing here doesn't bleed through JS static
   // inheritance into unrelated subclasses.
-  (this as any)._connectionSpecificationName = isPrimaryClass.call(this) ? "Base" : this.name;
+  (this as any)._connectionSpecificationName = isPrimaryClass.call(this)
+    ? "ActiveRecord::Base"
+    : this.name;
   // Rails: `Base.configurations.resolve(config_or_env)` — the `Base` constant
   // literally (connection_handling.rb:385-391), never `self`, so a model-local
   // `configurations` cannot redirect resolution.

--- a/packages/activerecord/src/establish-connection.trails.test.ts
+++ b/packages/activerecord/src/establish-connection.trails.test.ts
@@ -19,38 +19,38 @@ describe("Base.establishConnection", () => {
 
   it("creates a PostgresAdapter from a postgres:// URL", async () => {
     await Base.establishConnection("postgres://localhost:5432/testdb");
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(pool).toBeDefined();
     expect(await pool!.checkout()).toBeInstanceOf(PostgreSQLAdapter);
   });
 
   it("creates a PostgresAdapter from a postgresql:// URL", async () => {
     await Base.establishConnection("postgresql://localhost:5432/testdb");
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(PostgreSQLAdapter);
   });
 
   it("creates a MysqlAdapter from a mysql:// URL", async () => {
     await Base.establishConnection("mysql://localhost:3306/testdb");
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(Mysql2Adapter);
   });
 
   it("creates a SqliteAdapter from a :memory: URL", async () => {
     await Base.establishConnection("sqlite3::memory:");
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(BetterSQLite3Adapter);
   });
 
   it("creates a SqliteAdapter from a .sqlite3 file path", async () => {
     await Base.establishConnection(`sqlite3:${join(tmpdir(), "test.sqlite3")}`);
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(BetterSQLite3Adapter);
   });
 
   it("accepts a config object with adapter name", async () => {
     await Base.establishConnection({ adapter: "sqlite", database: ":memory:" });
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(BetterSQLite3Adapter);
   });
 
@@ -73,25 +73,25 @@ describe("Base.establishConnection", () => {
 
   it("accepts sqlite3 as an adapter name alias", async () => {
     await Base.establishConnection({ adapter: "sqlite3", database: ":memory:" });
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(BetterSQLite3Adapter);
   });
 
   it("accepts postgres as an adapter name alias", async () => {
     await Base.establishConnection({ adapter: "postgres", url: "postgres://localhost/db" });
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(PostgreSQLAdapter);
   });
 
   it("accepts mysql2 as an adapter name alias", async () => {
     await Base.establishConnection({ adapter: "mysql2", url: "mysql://localhost/db" });
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(Mysql2Adapter);
   });
 
   it("parses sqlite:// URLs into file paths", async () => {
     await Base.establishConnection("sqlite3:///tmp/test.sqlite3");
-    const pool = Base.connectionHandler.retrieveConnectionPool("Base");
+    const pool = Base.connectionHandler.retrieveConnectionPool("ActiveRecord::Base");
     expect(await pool!.checkout()).toBeInstanceOf(BetterSQLite3Adapter);
   });
 });

--- a/packages/activerecord/src/multi-db-migrator.test.ts
+++ b/packages/activerecord/src/multi-db-migrator.test.ts
@@ -118,7 +118,7 @@ describe("MultiDbMigratorTest", () => {
   it("schema migration is different for different connections", () => {
     expect(schemaMigrationA).not.toBe(schemaMigrationB);
     expect(adapterA).not.toBe(adapterB);
-    expect(Base.connectionPool().poolConfig.connectionDescriptor.name).toBe("Base");
+    expect(Base.connectionPool().poolConfig.connectionDescriptor.name).toBe("ActiveRecord::Base");
     expect(ARUnit2Model.connectionPool().poolConfig.connectionDescriptor.name).toBe("ARUnit2Model");
   });
 

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -59,7 +59,7 @@ describe("MultipleDbTest", () => {
 
   it("swapping the connection", async () => {
     const oldSpecName = Course.connectionSpecificationName;
-    Course.connectionSpecificationName = "Base";
+    Course.connectionSpecificationName = "ActiveRecord::Base";
     try {
       expect(await Entrant.leaseConnection()).toBe(await Course.leaseConnection());
     } finally {

--- a/packages/activerecord/src/shard-selector.test.ts
+++ b/packages/activerecord/src/shard-selector.test.ts
@@ -7,7 +7,7 @@ import { ambientPoolConfiguration } from "./test-adapter.js";
 describe("ShardSelectorTest", () => {
   afterEach(async () => {
     await Base.connectionHandler.clearAllConnectionsBang();
-    Base.connectionHandler.removeConnectionPool("Base", { shard: "shard_one" });
+    Base.connectionHandler.removeConnectionPool("ActiveRecord::Base", { shard: "shard_one" });
   });
 
   function setupShards() {
@@ -16,7 +16,7 @@ describe("ShardSelectorTest", () => {
     // database of its own.
     const dbConfig = new HashConfig("test", "Base", ambientPoolConfiguration());
     Base.connectionHandler.establishConnection(dbConfig, {
-      ownerName: "Base",
+      ownerName: "ActiveRecord::Base",
       role: "writing",
       shard: "shard_one",
     });

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -87,6 +87,23 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     ).resolves.toEqual([]);
   });
 
+  // The inline-options shape — a `name` the owner never declared — used to skip
+  // `find_target?` entirely, because a reflection-less holder answered
+  // `klass === undefined` and the gate ends in `&& klass`
+  // (`association.rb:320-321`). Its ad hoc reflection now resolves `klass`, so
+  // the new-record-without-FK arm suppresses the query here too.
+  it("suppresses the query for an inline options set the owner never declared", async () => {
+    const developer = new Developer({ name: "New Dev" });
+    developer.strictLoadingBang();
+    expect(developer.isNewRecord()).toBe(true);
+    await expect(
+      findHasManyTarget(developer, "inline_audit_logs", {
+        className: "AuditLog",
+        foreignKey: "developer_id",
+      }),
+    ).resolves.toEqual([]);
+  });
+
   it("does not raise on lazy loading a has_one on a new strict-loading owner without the foreign key", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -87,11 +87,6 @@ describe("StrictLoadingNewRecordFindTargetTest", () => {
     ).resolves.toEqual([]);
   });
 
-  // The inline-options shape — a `name` the owner never declared — used to skip
-  // `find_target?` entirely, because a reflection-less holder answered
-  // `klass === undefined` and the gate ends in `&& klass`
-  // (`association.rb:320-321`). Its ad hoc reflection now resolves `klass`, so
-  // the new-record-without-FK arm suppresses the query here too.
   it("suppresses the query for an inline options set the owner never declared", async () => {
     const developer = new Developer({ name: "New Dev" });
     developer.strictLoadingBang();

--- a/packages/activerecord/src/test-helpers/find-collection-target.ts
+++ b/packages/activerecord/src/test-helpers/find-collection-target.ts
@@ -15,10 +15,10 @@ import { camelize, singularize } from "@blazetrails/activesupport";
  * inverse wiring the load must not disturb) while the load runs on a holder
  * built fresh, which is what these tests want when they drive the loader
  * directly. A `name` the owner never declared has no such holder, so the gate
- * is read off the fresh one instead — its ad hoc reflection resolves `klass`
- * from `className` the way the loaders do (`resolveAssocClass`,
- * `associations.ts`), so `find_target?`'s trailing `&& klass`
- * (`association.rb:320-321`) is answerable there too rather than being skipped.
+ * is read off the fresh one instead: its reflection resolves `klass` from
+ * `className` the way the loaders do (`resolveAssocClass`, `associations.ts`),
+ * so `find_target?`'s trailing `&& klass` (`association.rb:320-321`) is
+ * answerable on every path rather than skipped for that shape.
  *
  * Test-only sugar: every call site would otherwise repeat the same cast.
  * `async` so `check_validity!` — run when
@@ -46,21 +46,12 @@ export async function findCollectionTarget(
   } else if (scope !== null) {
     options = scope;
   }
-  const declared = (
-    record.constructor as unknown as {
-      _reflectOnAssociation?: (n: string) => unknown;
-    }
-  )._reflectOnAssociation?.(name);
   const assoc = _buildAssociationInstance.call(record, {
     name,
     type: "hasMany",
     scope: positionalScope,
     options,
-    ...(declared
-      ? {}
-      : {
-          klass: resolveAssocClass(record, name, options.className ?? camelize(singularize(name))),
-        }),
+    klass: resolveAssocClass(record, name, options.className ?? camelize(singularize(name))),
   } as never);
   const holder =
     (

--- a/packages/activerecord/src/test-helpers/find-collection-target.ts
+++ b/packages/activerecord/src/test-helpers/find-collection-target.ts
@@ -1,6 +1,8 @@
 import type { Base } from "../base.js";
 import type { AssociationDefinition, AssociationOptions } from "../associations.js";
 import { _buildAssociationInstance } from "../associations/instance-methods.js";
+import { resolveAssocClass } from "../associations.js";
+import { camelize, singularize } from "@blazetrails/activesupport";
 
 /**
  * Runs a has_many load the way `CollectionProxy` does — `find_target?`
@@ -9,13 +11,14 @@ import { _buildAssociationInstance } from "../associations/instance-methods.js";
  * necessarily the declared one.
  *
  * As in `CollectionProxy._findTargetViaAssociation`, the gate is read off the
- * owner's own holder (whose reflection answers `klass` and
- * `active_record_primary_key`) while the load runs on a holder built fresh, so
- * it leaves the record's real holder — its loadedness, its writeback
- * suppression, its inverse wiring — untouched, which is what these tests want
- * when they drive the loader directly. A `name` the owner never declared has no
- * real holder and so no `find_target?` to consult: Rails has no association
- * without a reflection, and that inline-fallback shape is trails-only.
+ * holder the record itself keeps (whose loadedness, writeback suppression and
+ * inverse wiring the load must not disturb) while the load runs on a holder
+ * built fresh, which is what these tests want when they drive the loader
+ * directly. A `name` the owner never declared has no such holder, so the gate
+ * is read off the fresh one instead — its ad hoc reflection resolves `klass`
+ * from `className` the way the loaders do (`resolveAssocClass`,
+ * `associations.ts`), so `find_target?`'s trailing `&& klass`
+ * (`association.rb:320-321`) is answerable there too rather than being skipped.
  *
  * Test-only sugar: every call site would otherwise repeat the same cast.
  * `async` so `check_validity!` — run when
@@ -48,22 +51,27 @@ export async function findCollectionTarget(
       _reflectOnAssociation?: (n: string) => unknown;
     }
   )._reflectOnAssociation?.(name);
-  if (declared) {
-    const holder = (
-      record as unknown as {
-        association(n: string): { findTargetNeeded(): boolean; target: Base[] };
-      }
-    ).association(name);
-    // `load_target` answers `target` whether or not `find_target?` sent it to
-    // the database (association.rb:189-195), so an already-loaded holder
-    // reports what it holds rather than an empty list.
-    if (!holder.findTargetNeeded()) return holder.target ?? [];
-  }
   const assoc = _buildAssociationInstance.call(record, {
     name,
     type: "hasMany",
     scope: positionalScope,
     options,
-  });
+    ...(declared
+      ? {}
+      : {
+          klass: resolveAssocClass(record, name, options.className ?? camelize(singularize(name))),
+        }),
+  } as never);
+  const holder =
+    (
+      record as unknown as {
+        _associationInstances: Map<string, { findTargetNeeded(): boolean; target: Base[] }>;
+      }
+    )._associationInstances.get(name) ??
+    (assoc as unknown as { findTargetNeeded(): boolean; target: Base[] });
+  // `load_target` answers `target` whether or not `find_target?` sent it to
+  // the database (association.rb:189-195), so an already-loaded holder
+  // reports what it holds rather than an empty list.
+  if (!holder.findTargetNeeded()) return holder.target ?? [];
   return (assoc as unknown as { findTarget(): Promise<Base[]> }).findTarget();
 }

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -172,7 +172,11 @@ export class Application extends Engine {
     return (this._app = stack.build(this.endpoint()));
   }
 
-  /** Rails: `alias :build_middleware_stack :app` (`application.rb:558`). */
+  /**
+   * Rails: `alias :build_middleware_stack :app` (`application.rb:558`).
+   *
+   * @internal
+   */
   buildMiddlewareStack(): RackApp {
     return this.app();
   }
@@ -190,7 +194,10 @@ export class Application extends Engine {
 
   /** Mirrors `Application#default_middleware_stack` (`application.rb:626-629`).
    * Rails passes `paths`; `Engine#paths()` is async in trails (it resolves the
-   * root first), so the sync `config.paths()` it delegates to is passed here. */
+   * root first), so the sync `config.paths()` it delegates to is passed here.
+   *
+   * @internal
+   */
   defaultMiddlewareStack(): MiddlewareStack {
     const defaultStack = new DefaultMiddlewareStack(this, this.config, this.config.paths());
     return defaultStack.buildStack();
@@ -204,6 +211,8 @@ export class Application extends Engine {
    * `Path#existent` is async in trails (`paths.ts:147`) while initializers run
    * synchronously (`Initializable#runInitializers`), so the declared paths are
    * unshifted unfiltered — see the `generator-templates-existent-paths` story.
+   *
+   * @internal
    */
   ensureGeneratorTemplatesAdded(): void {
     const configuredPaths = this.config.generators().templates as string[];

--- a/packages/trailties/src/code-statistics-calculator.ts
+++ b/packages/trailties/src/code-statistics-calculator.ts
@@ -113,6 +113,7 @@ export class CodeStatisticsCalculator {
   }
 }
 
+/** @internal */
 export function fileType(filePath: string): FileType | undefined {
   if (filePath.endsWith("_test.rb")) return "minitest";
   const m = /\.([^.]+)$/.exec(filePath);

--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -82,7 +82,7 @@ async function establishMigrationConnection(
   // `connection.pool.db_config`, migration.rb:1512-1516).
   await pool.leaseConnection();
   onTestFinished(() => {
-    Base.connectionHandler.removeConnection("Base");
+    Base.connectionHandler.removeConnection("ActiveRecord::Base");
   });
 }
 
@@ -1461,7 +1461,7 @@ export class CreatePosts extends Migration {
     // removing the connection disconnects the pool, whose `disconnect` does
     // `conn.steal!; checkin conn` (connection_pool.rb:456-459), and `checkin`
     // expires the connection.
-    Base.connectionHandler.removeConnection("Base");
+    Base.connectionHandler.removeConnection("ActiveRecord::Base");
     await establishMigrationConnection(adapter, database, { useMetadataTable: false });
   }
 

--- a/packages/trailties/src/engine.ts
+++ b/packages/trailties/src/engine.ts
@@ -46,6 +46,13 @@ export class Engine extends Trailtie {
     return undefined;
   }
 
+  /**
+   * `def self.find_root_with_flag` sits in Engine's `private` section and
+   * carries `# :nodoc:` (`engine.rb:701`) — Ruby's `private` does not reach a
+   * singleton method, but the `:nodoc:` keeps it out of the API reference all
+   * the same.
+   * @internal
+   */
   static async findRootWithFlag(
     flag: string,
     rootPath: string | undefined,
@@ -138,7 +145,11 @@ export class Engine extends Trailtie {
     return this._routes !== undefined;
   }
 
-  /** Mirrors: Rails `_all_load_paths(add_autoload_paths_to_load_path)` (engine.rb:730). */
+  /**
+   * Mirrors: Rails `_all_load_paths(add_autoload_paths_to_load_path)` (engine.rb:730).
+   *
+   * @internal
+   */
   async _allLoadPaths(addAutoloadPathsToLoadPath = true): Promise<string[]> {
     if (this._allLoadPathsCache) return this._allLoadPathsCache;
     const paths = await this.paths();

--- a/packages/trailties/src/generators/app-base.ts
+++ b/packages/trailties/src/generators/app-base.ts
@@ -67,6 +67,7 @@ export abstract class AppBase extends GeneratorBase {
     this.options = this.deduceImpliedOptions(options);
   }
 
+  /** @internal */
   get database(): Database {
     if (!this._database) this._database = Database.build(this.options.database ?? "sqlite3");
     return this._database;
@@ -84,12 +85,15 @@ export abstract class AppBase extends GeneratorBase {
   keeps(): boolean {
     return !this.skip("Keeps");
   }
+  /** @internal */
   devcontainer(): boolean {
     return !!this.options.devcontainer;
   }
+  /** @internal */
   skipDevcontainer(): boolean {
     return !this.options.devcontainer;
   }
+  /** @internal */
   dependsOnSystemTest(): boolean {
     return !(this.skip("SystemTest") || this.skip("Test") || this.options.api);
   }

--- a/packages/trailties/src/generators/generated-attribute.ts
+++ b/packages/trailties/src/generators/generated-attribute.ts
@@ -144,6 +144,7 @@ export class GeneratedAttribute {
   }
 }
 
+/** @internal */
 function parseTypeAndOptions(type: string | undefined): [string | undefined, AttrOptions] {
   if (!type) return [undefined, {}];
   let parsedType: string | undefined;

--- a/packages/trailties/src/generators/named-base.ts
+++ b/packages/trailties/src/generators/named-base.ts
@@ -11,6 +11,7 @@ export class NamedBase extends GeneratorBase {
   name: string;
   attributes: GeneratedAttribute[];
   classPathParts: string[];
+  /** @internal */
   fileName: string;
 
   constructor(options: NamedBaseOptions) {

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -21,6 +21,7 @@ export interface ChangeGeneratorOptions extends GeneratorOptions {
 
 export class ChangeGenerator extends GeneratorBase {
   readonly to: DatabaseName;
+  /** @internal */
   readonly appName: string;
   private _database?: Database;
 
@@ -36,6 +37,7 @@ export class ChangeGenerator extends GeneratorBase {
     this.appName = options.appName ?? this.path.basename(this.cwd);
   }
 
+  /** @internal */
   get database(): Database {
     if (!this._database) this._database = Database.build(this.to);
     return this._database;

--- a/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
+++ b/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
@@ -22,6 +22,7 @@ type ResolvedOptions = Required<Omit<DevcontainerGeneratorOptions, "cwd" | "outp
 
 export class DevcontainerGenerator extends GeneratorBase {
   readonly opts: ResolvedOptions;
+  /** @internal */
   readonly database: Database;
 
   constructor(options: DevcontainerGeneratorOptions) {

--- a/packages/trailties/src/trailtie.ts
+++ b/packages/trailties/src/trailtie.ts
@@ -145,6 +145,7 @@ function blockKey(kind: BlockRunnerKind): string {
   return `_blocks_${kind}`;
 }
 
+/** @internal */
 function registerBlockFor(
   klass: typeof Trailtie,
   kind: BlockRunnerKind,
@@ -153,6 +154,7 @@ function registerBlockFor(
   ownState(klass, blockKey(kind), () => [] as TrailtieBlock[]).push(block);
 }
 
+/** @internal */
 function eachRegisteredBlock(
   instance: Trailtie,
   kind: BlockRunnerKind,

--- a/scripts/api-compare/privates-entities.test.ts
+++ b/scripts/api-compare/privates-entities.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { entitiesByTsFile } from "./privates-entities.js";
+
+describe("entitiesByTsFile", () => {
+  const tsRelFor = (rubyFile: string) => `packages/i18n/src/${rubyFile.replace(/\.rb$/, ".ts")}`;
+
+  it("lists a method-less entity sharing a file with a method-bearing one", () => {
+    const fileEntities = new Map([
+      ["backend/key_value.rb", new Set(["I18n", "Backend", "KeyValue", "Implementation"])],
+    ]);
+    expect(entitiesByTsFile(fileEntities, tsRelFor)).toEqual({
+      "packages/i18n/src/backend/key_value.ts": ["Backend", "I18n", "Implementation", "KeyValue"],
+    });
+  });
+
+  it("merges into an existing entry and skips a file with no entities", () => {
+    const fileEntities = new Map([
+      ["backend/key_value.rb", new Set(["KeyValue"])],
+      ["backend/empty.rb", new Set<string>()],
+    ]);
+    const into = { "packages/i18n/src/backend/key_value.ts": ["Backend"] };
+    expect(entitiesByTsFile(fileEntities, tsRelFor, into)).toEqual({
+      "packages/i18n/src/backend/key_value.ts": ["Backend", "KeyValue"],
+    });
+  });
+});

--- a/scripts/api-compare/privates-entities.ts
+++ b/scripts/api-compare/privates-entities.ts
@@ -1,0 +1,24 @@
+/**
+ * The `entities` half of `eslint/rails-private-methods.json`: for each TS file,
+ * the names of the Ruby entities that project onto it.
+ *
+ * It is keyed off the entity walk alone — `noteEntity` runs once per host in
+ * `build-rails-privates-manifest.ts`'s `visit()`, unconditionally — and NOT off
+ * the per-file visibility map, which only gains a key when some entity
+ * contributes a method to that Ruby file. A Rails entity with no methods would
+ * otherwise be absent from `entities` while a method-bearing sibling in the
+ * same file still listed the file-wide name union, leaving the method-less
+ * entity's members silently un-gated (RFC 0121).
+ */
+export function entitiesByTsFile(
+  fileEntities: Map<string, Set<string>>,
+  tsRelFor: (rubyFile: string) => string,
+  into: Record<string, string[]> = {},
+): Record<string, string[]> {
+  for (const [rubyFile, entities] of fileEntities) {
+    if (entities.size === 0) continue;
+    const tsRel = tsRelFor(rubyFile);
+    into[tsRel] = [...new Set([...(into[tsRel] ?? []), ...entities])].sort();
+  }
+  return into;
+}

--- a/scripts/build-rails-privates-manifest.ts
+++ b/scripts/build-rails-privates-manifest.ts
@@ -54,6 +54,7 @@ import {
 } from "@blazetrails/parity/write-json-manifest";
 import { PACKAGE_DIRS } from "./api-compare/config.js";
 import { railsApiAvailable } from "./api-compare/require-rails-api.js";
+import { entitiesByTsFile } from "./api-compare/privates-entities.js";
 import { diffDeprecatedManifest } from "./deprecated-manifest-diff.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -273,20 +274,18 @@ for (const [pkg, rubyPkg] of Object.entries<RubyPackage>(railsApi.packages)) {
     return tsNames;
   };
 
+  const tsRelFor = (rubyFile: string) =>
+    path.posix.join(pkgDir, rubyFileToTs(rubyFile, pkg).split(path.sep).join("/"));
+
   for (const [rubyFile, names] of fileVis) {
-    const tsRel = path.posix.join(pkgDir, rubyFileToTs(rubyFile, pkg).split(path.sep).join("/"));
     const tsNames = project(names);
-    if (tsNames.size > 0) {
-      const existing = manifest.files[tsRel] ?? [];
-      manifest.files[tsRel] = [...new Set([...existing, ...tsNames])].sort();
-    }
-    const entities = fileEntities.get(rubyFile);
-    if (entities && entities.size > 0) {
-      manifest.entities[tsRel] = [
-        ...new Set([...(manifest.entities[tsRel] ?? []), ...entities]),
-      ].sort();
-    }
+    if (tsNames.size === 0) continue;
+    const tsRel = tsRelFor(rubyFile);
+    const existing = manifest.files[tsRel] ?? [];
+    manifest.files[tsRel] = [...new Set([...existing, ...tsNames])].sort();
   }
+
+  entitiesByTsFile(fileEntities, tsRelFor, manifest.entities);
 }
 
 const sortedFiles: Record<string, string[]> = {};

--- a/scripts/test-compare/assertion-mismatch-mark.json
+++ b/scripts/test-compare/assertion-mismatch-mark.json
@@ -26,9 +26,9 @@
       "value": 54
     },
     "activerecord": {
-      "assertionCount": 1941,
-      "kind": 3912,
-      "value": 36
+      "assertionCount": 1940,
+      "kind": 3909,
+      "value": 32
     },
     "activesupport": {
       "assertionCount": 863,


### PR DESCRIPTION
Five bundled stories.

**RFC 0112 — `findCollectionTarget` consults `find_target?` on every path.**
The ad hoc holder built for a `name` the owner never declared answered
`klass === undefined`, and `find_target?` ends in `&& klass`
(`association.rb:320-321`), so the gate was unevaluable for the inline shape and
the helper skipped it. Its reflection now resolves `klass` from `className` via
`resolveAssocClass`, the way the loaders do, and the `declared` branch is gone:
the gate is read off the holder the record keeps, falling back to the fresh one.
Regression in `strict-loading.trails.test.ts` (fails on baseline).

**RFC 0119 — `Column#deduplicated` / `SqlTypeMetadata#deduplicated`.**
`column.rb:107` assigns `sql_type_metadata.deduplicate` back; the port called it
for effect, so a column kept its own non-canonical metadata whenever an equal
one was already registered. `Deduplicable#deduplicated` is `freeze`
(`deduplicable.rb:26`) and `SqlTypeMetadata` adds nothing to it; ours returned
the receiver unfrozen. New case `interns the sqlTypeMetadata onto the shared
canonical instance` fails on `main`.

**RFC 0119 — `ConnectionDescriptor#name` for a primary class.**
Rails hardcodes `"ActiveRecord::Base"` (`connection_handler.rb:63`), which is
also what `connection_specification_name` answers for a primary class
(`Base.name`) — that agreement is why a descriptor's pool key and a model's
lookup key are the same string. trails spelled both `"Base"`. Both now use the
Rails literal, so `multi_db_migrator_test.rb` matches Rails' assertion verbatim
and the sharding / multi-db tests use the same names Rails' do.
`scripts/test-compare/assertion-mismatch-mark.json` lowered for activerecord
(value 36 → 32, kind 3912 → 3909, assertionCount 1941 → 1940).

**RFC 0121 — privates manifest `entities`.**
`entities` was emitted from the `fileVis` iteration, which only has a key when
some entity contributes a method, so a method-less Rails entity never reached
the map. It is now emitted from the entity walk (`entitiesByTsFile`), with a
builder-level regression. `files` is byte-identical; 45 files gain an entity
list, so no package's `@internal` requirements change.

**RFC 0121 — trailties enrolled in `rails-private-jsdoc`.**
Added to both globs (`eslint.config.mjs` and
`eslint/rails-private-jsdoc.config.mjs`); the rule reported 17 members, each
verified against the vendored Ruby's `private`/`protected` section.
`Engine.findRootWithFlag` is the one nuance — a singleton method inside a
`private` section, so Ruby leaves it public, but it carries `# :nodoc:`
(`engine.rb:701`); noted at the call site.

Local: typecheck, `pnpm lint`, `parity:api:calls`, `parity:api:calls:args`,
`parity:api:extra:gate`, `parity:test:assertions` all green; association,
connection-handling, sharding, prevent-writes, migrator, fixtures, schema-cache
and trailties `db` suites run on sqlite.

Closes-story: find-collection-target-inline-fallback-skips-find-target-gate
Closes-story: enroll-trailties-in-rails-private-jsdoc
Closes-story: privates-manifest-entities-misses-method-less-entity
Closes-story: column-deduplicated-discards-the-interned-metadata
Closes-story: converge-connection-descriptor-name-to-rails-primary-class-form
