### PR TITLE
refactor(activerecord): memoize EncryptedAttributeType#clean_text_scheme (RFC 0112)

### DIFF
--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -27,6 +27,7 @@ export class EncryptedAttributeType extends ValueType {
   private _default?: unknown;
   private _previousTypes?: Map<boolean, EncryptedAttributeType[]>;
   private _previousTypesWithoutCleanText?: EncryptedAttributeType[];
+  private _cleanTextScheme?: Scheme;
   private _serializeWithOldest = false;
 
   constructor(options: {
@@ -306,10 +307,10 @@ export class EncryptedAttributeType extends ValueType {
 
   /** @internal */
   private cleanTextScheme(): Scheme {
-    return new Scheme({
+    return (this._cleanTextScheme ??= new Scheme({
       downcase: this.isDowncase,
       encryptor: new NullEncryptor(),
-    });
+    }));
   }
 
   /** @internal */


### PR DESCRIPTION
## What

Memoizes `cleanTextScheme` into a `_cleanTextScheme` field, mirroring Rails' `@clean_text_scheme ||=` (`activerecord/lib/active_record/encryption/encrypted_attribute_type.rb:162-163`). The rest of that file already memoizes the Rails way (`_previousTypes`, `_previousTypesWithoutCleanText`); this method was missed, so a `supportUnencryptedData` attribute allocated a fresh `Scheme` + `NullEncryptor` per read via `previousSchemes`.

## Bundle stories already landed on main

Two of the three bundled stories needed no code:

- `fold-join-clauses-into-joins-values` — the `_joinClauses` sidecar, `seedJoinClauseAliases` and `relation/merge-joins.ts` were retired by #6773; `emitJoinPlan` now routes everything through `buildJoinBuckets`.
- `remove-relation-distinct-on-invented-surface` — `Relation#distinctOn` / `_distinctOnColumns` were removed by #6744; the only `distinctOn` left is `Arel::SelectManager#distinctOn`.

Both marked done against those PRs.

## Test

`pnpm vitest run packages/activerecord/src/encryption` — 360 passed, 1 skipped.

Closes-story: memoize-encrypted-attribute-type-clean-text-scheme