### PR TITLE
test(activemodel): port dirty_test.rb's DirtyModel as Rails builds it, exercising ForcedMutationTracker (RFC 0115)

### DIFF
--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -1,266 +1,391 @@
-import { describe, it, expect } from "vitest";
-import { Model } from "./index.js";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  asJson as objectAsJson,
+  extend,
+  include,
+  prepend,
+  InstanceVariablesObject,
+  ToJsonWithActiveSupportEncoder,
+  type Included,
+} from "@blazetrails/activesupport";
+import * as AttributeMethods from "./attribute-methods.js";
+import { Dirty, asJson as dirtyAsJson, initInternals as dirtyInitInternals } from "./dirty.js";
 
 /**
- * Rails' `DirtyModel` (dirty_test.rb:6-43) includes `ActiveModel::API` + `Dirty`
- * with plain `attr_reader`s, so its `initialize` seeds the attributes without
- * dirtying them. trails' `Model` reaches its attributes through
- * `ActiveModel::Attributes`, where constructor assignment IS a `FromUser` write
- * and is dirty (dirty.rb:382-388 → attribute.rb:139-141), so each fixture takes
- * that seeding as its baseline with `changes_applied` (dirty.rb:271-278).
+ * Rails' `DirtyTest::DirtyModel` (dirty_test.rb:6-43) includes
+ * `ActiveModel::API` + `ActiveModel::Dirty` and nothing else — no
+ * `ActiveModel::Attributes`. Having no `@attributes`, it takes the second arm
+ * of `mutations_from_database` (dirty.rb:382-388) and tracks through
+ * `ActiveModel::ForcedMutationTracker`, which is what this file exercises.
+ *
+ * Ruby's `@name` + `attr_reader :name` + a hand-written `name=` port to one
+ * own, enumerable accessor property per ivar: `Object#as_json` serializes an
+ * object through `instance_values` (core_ext/object/json.rb:58-66), i.e. its
+ * own properties, so the ivar has to be spelled with the reader's name — and a
+ * data property of that name would shadow the writer the Ruby model defines.
+ * The values live in `#ivars`, which no `instance_values` can see.
  */
-describe("DirtyTest", () => {
-  it("changes accessible through both strings and symbols", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.changes["name"]).toEqual(["Alice", "Bob"]);
-  });
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (dirty_test.rb:7-8); the class/interface merge is how `include()` surfaces on the type side.
+class DirtyModel {
+  #ivars: Record<string, unknown> = {};
 
-  it("be consistent with symbols arguments after the changes are applied", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p.changesApplied();
-    expect(p.previousChanges["name"]).toEqual(["Alice", "Bob"]);
-    expect(p.isChanged).toBe(false);
-  });
+  constructor() {
+    Object.defineProperty(this, "name", {
+      enumerable: true,
+      configurable: true,
+      get: () => this.#ivars["name"],
+      set: (val: unknown) => {
+        this.nameWillChange();
+        this.#ivars["name"] = val;
+      },
+    });
+    Object.defineProperty(this, "color", {
+      enumerable: true,
+      configurable: true,
+      get: () => this.#ivars["color"],
+      set: (val: unknown) => {
+        if (val !== this.#ivars["color"]) this.colorWillChange();
+        this.#ivars["color"] = val;
+      },
+    });
+    Object.defineProperty(this, "size", {
+      enumerable: true,
+      configurable: true,
+      get: () => this.#ivars["size"],
+      set: (val: unknown) => {
+        if (val !== this.#ivars["size"]) this.attributeWillChangeBang("size");
+        this.#ivars["size"] = val;
+      },
+    });
+    Object.defineProperty(this, "status", {
+      enumerable: true,
+      configurable: true,
+      get: () => this.#ivars["status"],
+      set: (val: unknown) => {
+        if (val !== this.#ivars["status"]) this.statusWillChange();
+        this.#ivars["status"] = val;
+      },
+    });
 
-  it("restore_attributes can restore only some attributes", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-        this.attribute("age", "integer");
-      }
-    }
-    const p = new Person({ name: "Alice", age: 25 });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p._writeAttribute("age", 30);
-    p.clearAttributeChanges(["name"]);
-    expect(p.attributeChanged("name")).toBe(false);
-    expect(p.attributeChanged("age")).toBe(true);
-  });
-
-  class DirtyPerson extends Model {
-    static {
-      this.attribute("name", "string");
-      this.attribute("age", "integer");
-      this.attribute("color", "string");
-    }
+    this.#ivars["name"] = null;
+    this.#ivars["color"] = null;
+    this.#ivars["size"] = null;
+    this.#ivars["status"] = "initialized";
   }
 
+  save(): void {
+    this.changesApplied();
+  }
+
+  /**
+   * `Object#as_json` (core_ext/object/json.rb:58-66), which Ruby's DirtyModel
+   * inherits from `Object` and TypeScript cannot: `Object` is not reopenable,
+   * so the body is spelled at the class Ruby gets it from.
+   */
+  asJson(options?: Record<string, unknown>): unknown {
+    return objectAsJson(InstanceVariablesObject.instanceValues(this), options);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+interface DirtyModel extends Dirty {
+  name: unknown;
+  color: unknown;
+  size: unknown;
+  status: unknown;
+
+  nameWillChange(): void;
+  colorWillChange(): void;
+  statusWillChange(): void;
+  isNameChanged(...args: unknown[]): boolean;
+  isColorChanged(): boolean;
+  isSizeChanged(): boolean;
+  isStatusChanged(): boolean;
+  nameChanged(options?: { from?: unknown; to?: unknown }): boolean;
+  colorChanged(): boolean;
+  sizeChanged(): boolean;
+  statusChanged(): boolean;
+  namePreviouslyChanged(options?: { from?: unknown; to?: unknown }): boolean;
+  nameChange: [unknown, unknown] | null;
+  statusChange: [unknown, unknown] | null;
+  namePreviousChange: [unknown, unknown] | null;
+  nameWas: unknown;
+  restoreName(): void;
+  toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
+}
+
+// `include ActiveModel::AttributeMethods`, which `define_attribute_methods`
+// and every `*_will_change!` come from (attribute_methods.rb:73).
+extend(DirtyModel, {
+  attributeMethodPrefix: AttributeMethods.attributeMethodPrefix,
+  attributeMethodSuffix: AttributeMethods.attributeMethodSuffix,
+  attributeMethodAffix: AttributeMethods.attributeMethodAffix,
+  aliasAttribute: AttributeMethods.aliasAttribute,
+  defineAttributeMethods: AttributeMethods.defineAttributeMethods,
+  defineAttributeMethod: AttributeMethods.defineAttributeMethod,
+  defineAttributeMethodPattern: AttributeMethods.defineAttributeMethodPattern,
+  undefineAttributeMethods: AttributeMethods.undefineAttributeMethods,
+  resolveAttributeName: AttributeMethods.resolveAttributeName,
+  generatedAttributeMethods: AttributeMethods.generatedAttributeMethods,
+  isInstanceMethodAlreadyImplemented: AttributeMethods.isInstanceMethodAlreadyImplemented,
+  attributeMethodPatternsCache: AttributeMethods.attributeMethodPatternsCache,
+  attributeMethodPatternsMatching: AttributeMethods.attributeMethodPatternsMatching,
+});
+include(DirtyModel, AttributeMethods.InstanceMethods);
+
+// `include ActiveModel::Dirty` (dirty_test.rb:8) and its `included do` block
+// (dirty.rb:241-245).
+include(DirtyModel, Dirty);
+const DirtyModelClass = DirtyModel as unknown as {
+  attributeMethodSuffix(...args: unknown[]): void;
+  attributeMethodAffix(affix: Record<string, unknown>): void;
+  defineAttributeMethods(...attrNames: string[]): void;
+};
+DirtyModelClass.attributeMethodSuffix("PreviouslyChanged", "Changed", { parameters: "**options" });
+DirtyModelClass.attributeMethodSuffix("Change", "WillChange!", "Was", { parameters: false });
+DirtyModelClass.attributeMethodSuffix("PreviousChange", "PreviouslyWas", { parameters: false });
+DirtyModelClass.attributeMethodAffix({ prefix: "restore", suffix: "!", parameters: false });
+DirtyModelClass.attributeMethodAffix({ prefix: "clear", suffix: "Change", parameters: false });
+// `ActiveSupport::ToJsonWithActiveSupportEncoder` is included into `Object`
+// (core_ext/object/json.rb:47-49), which TypeScript cannot reopen either.
+include(DirtyModel, ToJsonWithActiveSupportEncoder);
+
+prepend(DirtyModel.prototype, {
+  initInternals: dirtyInitInternals,
+  asJson: dirtyAsJson,
+});
+
+// dirty_test.rb:9
+DirtyModelClass.defineAttributeMethods("name", "color", "size", "status");
+
+describe("DirtyTest", () => {
+  let model: DirtyModel;
+
+  beforeEach(() => {
+    model = new DirtyModel();
+  });
+
   it("setting attribute will result in change", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.isChanged).toBe(true);
+    expect(model.isChanged).toBe(false);
+    expect(model.nameChanged()).toBe(false);
+    model.name = "Ringo";
+    expect(model.isChanged).toBe(true);
+    expect(model.nameChanged()).toBe(true);
   });
 
   it("list of changed attribute keys", () => {
-    const p = new DirtyPerson({ name: "Alice", age: 25 });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.changed).toContain("name");
-    expect(p.changed).not.toContain("age");
+    expect(model.changed).toEqual([]);
+    model.name = "Paul";
+    expect(model.changed).toEqual(["name"]);
   });
 
   it("changes to attribute values", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.attributeChange("name")).toEqual(["Alice", "Bob"]);
+    expect(model.changes["name"]).toBeUndefined();
+    model.name = "John";
+    expect(model.changes["name"]).toEqual([null, "John"]);
   });
 
   it("checking if an attribute has changed to a particular value", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.attributeChanged("name", { to: "Bob" })).toBe(true);
-    expect(p.attributeChanged("name", { to: "Charlie" })).toBe(false);
+    model.name = "Ringo";
+    expect(model.nameChanged({ from: null, to: "Ringo" })).toBe(true);
+    expect(model.nameChanged({ from: "Pete", to: "Ringo" })).toBe(false);
+    expect(model.nameChanged({ to: "Ringo" })).toBe(true);
+    expect(model.nameChanged({ to: "Pete" })).toBe(false);
+    expect(model.nameChanged({ from: null })).toBe(true);
+    expect(model.nameChanged({ from: "Pete" })).toBe(false);
   });
 
-  it("setting color to same value should not result in change being recorded", () => {
-    const p = new DirtyPerson({ color: "red" });
-    p.changesApplied();
-    p._writeAttribute("color", "red");
-    expect(p.isChanged).toBe(false);
+  it("changes accessible through both strings and symbols", () => {
+    model.name = "David";
+    expect(model.changes["name"]).not.toBeNull();
   });
 
-  it("saving should reset model's changed status", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.isChanged).toBe(true);
-    p.changesApplied();
-    expect(p.isChanged).toBe(false);
-  });
-
-  it("saving should preserve previous changes", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p.changesApplied();
-    expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
-  });
-
-  it("setting new attributes should not affect previous changes", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p.changesApplied();
-    p._writeAttribute("name", "Charlie");
-    expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
-  });
-
-  it("saving should preserve model's previous changed status", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p.changesApplied();
-    expect(p.attributePreviouslyChanged("name")).toBe(true);
-  });
-
-  it("checking if an attribute was previously changed to a particular value", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p.changesApplied();
-    expect(p.attributePreviouslyChanged("name", { from: "Alice", to: "Bob" })).toBe(true);
-    expect(p.attributePreviouslyChanged("name", { to: "Charlie" })).toBe(false);
-  });
-
-  it("previous value is preserved when changed after save", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    expect(p.changedAttributes).toEqual({});
-    p._writeAttribute("name", "Bob");
-    // Rails asserts `changed_attributes` — a name->old-value hash.
-    expect(p.changedAttributes).toEqual({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Charlie");
-    expect(p.changedAttributes).toEqual({ name: "Bob" });
-    expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
-    expect(p.changes).toEqual({ name: ["Bob", "Charlie"] });
-  });
-
-  it("changing the same attribute multiple times retains the correct original value", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p._writeAttribute("name", "Charlie");
-    expect(p.attributeChange("name")).toEqual(["Alice", "Charlie"]);
-  });
-
-  it("clear_changes_information should reset all changes", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p.changesApplied();
-    p._writeAttribute("name", "Charlie");
-    p.clearChangesInformation();
-    expect(p.isChanged).toBe(false);
-    expect(Object.keys(p.previousChanges).length).toBe(0);
-  });
-
-  it("restore_attributes should restore all previous data", () => {
-    const p = new DirtyPerson({ name: "Alice", age: 25 });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p._writeAttribute("age", 30);
-    p.restoreAttributes();
-    expect(p._readAttribute("name")).toBe("Alice");
-    expect(p._readAttribute("age")).toBe(25);
-    expect(p.isChanged).toBe(false);
-  });
-
-  it("resetting attribute", () => {
-    const p = new DirtyPerson({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.isChanged).toBe(true);
-    p._writeAttribute("name", "Alice");
-    expect(p.isChanged).toBe(false);
-  });
-
-  it("model can be dup-ed without Attributes", () => {
-    class Bare extends Model {}
-    const b = new Bare();
-    expect(b.isChanged).toBe(false);
-    expect(b.changed).toEqual([]);
-  });
-
-  class Person extends Model {
-    static {
-      this.attribute("name", "string");
-      this.attribute("age", "integer");
-    }
-  }
-
-  it("to_json should work on model", () => {
-    const p = new Person({ name: "Alice", age: 25 });
-    p.changesApplied();
-    const json = p.toJSON();
-    expect(JSON.parse(json)).toEqual({ name: "Alice", age: 25 });
-  });
-
-  it("to_json should work on model with :except string option", () => {
-    const p = new Person({ name: "Alice", age: 25 });
-    p.changesApplied();
-    const json = p.toJSON({ except: ["age"] });
-    expect(JSON.parse(json)).toEqual({ name: "Alice" });
-  });
-
-  it("to_json should work on model with :except array option", () => {
-    const p = new Person({ name: "Alice", age: 25 });
-    p.changesApplied();
-    const json = p.toJSON({ except: ["name", "age"] });
-    expect(JSON.parse(json)).toEqual({});
-  });
-
-  it("to_json should work on model after save", () => {
-    const p = new Person({ name: "Alice", age: 25 });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    p.changesApplied();
-    const json = p.toJSON();
-    expect(JSON.parse(json)).toEqual({ name: "Bob", age: 25 });
+  it("be consistent with symbols arguments after the changes are applied", () => {
+    model.name = "David";
+    expect(model.attributeChanged("name")).toBe(true);
+    model.save();
+    model.name = "Rafael";
+    expect(model.attributeChanged("name")).toBe(true);
   });
 
   it("attribute mutation", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    p.changesApplied();
-    expect(p.isChanged).toBe(false);
-    p._writeAttribute("name", "Bob");
-    expect(p.isChanged).toBe(true);
-    expect(p.changes).toEqual({ name: ["Alice", "Bob"] });
+    // Rails sets `@name` behind the writer, mutates the String in place, and
+    // asserts neither shows as a change — `ForcedMutationTracker#changed_in_place?`
+    // is a flat `false` (attribute_mutation_tracker.rb:95-97). JS strings have
+    // no in-place mutation, so the ivar write stands in for both steps.
+    // Ruby's `instance_variable_set("@name", …)` writes past the writer; the
+    // JS analogue replaces the accessor with the value it would have read.
+    Object.defineProperty(model, "name", { value: "Yam", enumerable: true, configurable: true });
+    expect(model.nameChanged()).toBe(false);
+    model.nameWillChange();
+    expect(model.nameChanged()).toBe(true);
+  });
+
+  it("resetting attribute", () => {
+    model.name = "Bob";
+    model.restoreName();
+    expect(model.name).toBeNull();
+    expect(model.nameChanged()).toBe(false);
+  });
+
+  it("setting color to same value should not result in change being recorded", () => {
+    model.color = "red";
+    expect(model.colorChanged()).toBe(true);
+    model.save();
+    expect(model.colorChanged()).toBe(false);
+    expect(model.isChanged).toBe(false);
+    model.color = "red";
+    expect(model.colorChanged()).toBe(false);
+    expect(model.isChanged).toBe(false);
+  });
+
+  it("saving should reset model's changed status", () => {
+    model.name = "Alf";
+    expect(model.isChanged).toBe(true);
+    model.save();
+    expect(model.isChanged).toBe(false);
+    expect(model.nameChanged()).toBe(false);
+  });
+
+  it("saving should preserve previous changes", () => {
+    model.name = "Jericho Cane";
+    model.status = "waiting";
+    model.save();
+    expect(model.previousChanges["name"]).toEqual([null, "Jericho Cane"]);
+    expect(model.previousChanges["status"]).toEqual(["initialized", "waiting"]);
+  });
+
+  it("setting new attributes should not affect previous changes", () => {
+    model.name = "Jericho Cane";
+    model.status = "waiting";
+    model.save();
+    model.name = "DudeFella ManGuy";
+    model.status = "finished";
+    expect(model.namePreviousChange).toEqual([null, "Jericho Cane"]);
+    expect(model.previousChanges["status"]).toEqual(["initialized", "waiting"]);
+  });
+
+  it("saving should preserve model's previous changed status", () => {
+    model.name = "Jericho Cane";
+    model.save();
+    expect(model.namePreviouslyChanged()).toBe(true);
+  });
+
+  it("checking if an attribute was previously changed to a particular value", () => {
+    model.name = "Ringo";
+    model.save();
+    expect(model.namePreviouslyChanged({ from: null, to: "Ringo" })).toBe(true);
+    expect(model.namePreviouslyChanged({ from: "Pete", to: "Ringo" })).toBe(false);
+    expect(model.namePreviouslyChanged({ to: "Ringo" })).toBe(true);
+    expect(model.namePreviouslyChanged({ to: "Pete" })).toBe(false);
+    expect(model.namePreviouslyChanged({ from: null })).toBe(true);
+    expect(model.namePreviouslyChanged({ from: "Pete" })).toBe(false);
+  });
+
+  it("previous value is preserved when changed after save", () => {
+    expect(model.changedAttributes).toEqual({});
+    model.name = "Paul";
+    model.status = "waiting";
+    expect(model.changedAttributes).toEqual({ name: null, status: "initialized" });
+
+    model.save();
+
+    model.name = "John";
+    model.status = "finished";
+    expect(model.changedAttributes).toEqual({ name: "Paul", status: "waiting" });
+  });
+
+  it("changing the same attribute multiple times retains the correct original value", () => {
+    model.name = "Otto";
+    model.status = "waiting";
+    model.save();
+    model.name = "DudeFella ManGuy";
+    model.name = "Mr. Manfredgensonton";
+    model.status = "processing";
+    model.status = "finished";
+    expect(model.nameChange).toEqual(["Otto", "Mr. Manfredgensonton"]);
+    expect(model.statusChange).toEqual(["waiting", "finished"]);
+    expect(model.nameWas).toBe("Otto");
   });
 
   it("using attribute_will_change! with a symbol", () => {
-    class Person extends Model {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    const p = new Person({ name: "Alice" });
-    p.changesApplied();
-    p._writeAttribute("name", "Bob");
-    expect(p.attributeChanged("name")).toBe(true);
-    expect(p.attributeWas("name")).toBe("Alice");
+    model.size = 1;
+    expect(model.sizeChanged()).toBe(true);
+  });
+
+  it("clear_changes_information should reset all changes", () => {
+    model.name = "Dmitry";
+    model.nameChanged();
+    model.save();
+    model.name = "Bob";
+
+    expect(model.previousChanges["name"]).toEqual([null, "Dmitry"]);
+    expect(model.changedAttributes["name"]).toBe("Dmitry");
+
+    model.clearChangesInformation();
+
+    expect(model.previousChanges).toEqual({});
+    expect(model.changedAttributes).toEqual({});
+  });
+
+  it("restore_attributes should restore all previous data", () => {
+    model.name = "Dmitry";
+    model.color = "Red";
+    model.save();
+    model.name = "Bob";
+    model.color = "White";
+
+    model.restoreAttributes();
+
+    expect(model.isChanged).toBe(false);
+    expect(model.name).toBe("Dmitry");
+    expect(model.color).toBe("Red");
+  });
+
+  it("restore_attributes can restore only some attributes", () => {
+    model.name = "Dmitry";
+    model.color = "Red";
+    model.save();
+    model.name = "Bob";
+    model.color = "White";
+
+    model.restoreAttributes(["name"]);
+
+    expect(model.isChanged).toBe(true);
+    expect(model.name).toBe("Dmitry");
+    expect(model.color).toBe("White");
+  });
+
+  it("model can be dup-ed without Attributes", () => {
+    expect(model).toBeTruthy();
+  });
+
+  it("to_json should work on model", () => {
+    model.name = "Dmitry";
+    expect(model.toJSON()).toBe(
+      '{"name":"Dmitry","color":null,"size":null,"status":"initialized"}',
+    );
+  });
+
+  it("to_json should work on model with :except string option", () => {
+    model.name = "Dmitry";
+    expect(model.toJSON({ except: "name" })).toBe(
+      '{"color":null,"size":null,"status":"initialized"}',
+    );
+  });
+
+  it("to_json should work on model with :except array option", () => {
+    model.name = "Dmitry";
+    expect(model.toJSON({ except: ["name"] })).toBe(
+      '{"color":null,"size":null,"status":"initialized"}',
+    );
+  });
+
+  it("to_json should work on model after save", () => {
+    model.name = "Dmitry";
+    model.save();
+    expect(model.toJSON()).toBe(
+      '{"name":"Dmitry","color":null,"size":null,"status":"initialized"}',
+    );
   });
 });

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -9,7 +9,15 @@ import {
   type Included,
 } from "@blazetrails/activesupport";
 import * as AttributeMethods from "./attribute-methods.js";
-import { Dirty, asJson as dirtyAsJson } from "./dirty.js";
+import { Dirty, asJson as dirtyAsJson, initializeDup as dirtyInitializeDup } from "./dirty.js";
+
+/**
+ * The ivar table Ruby's `@name` / `@color` / `@size` / `@status` live in. A JS
+ * `Symbol` key, the sanctioned spelling for a private slot: `Object.keys`
+ * skips it, so `instance_values` (core_ext/object/json.rb:58-66) sees only the
+ * four readers, while `Reflect.ownKeys` carries it through `dup`.
+ */
+const ivars = Symbol("ivars");
 
 /**
  * Rails' `DirtyTest::DirtyModel` (dirty_test.rb:6-43) includes
@@ -18,64 +26,106 @@ import { Dirty, asJson as dirtyAsJson } from "./dirty.js";
  * of `mutations_from_database` (dirty.rb:382-388) and tracks through
  * `ActiveModel::ForcedMutationTracker`, which is what this file exercises.
  *
+ * The `include ActiveModel::API` half (dirty_test.rb:7) is not wired below:
+ * the fixture's `initialize` (dirty_test.rb:11-17) overrides API's
+ * (api.rb:78-81) and never calls `super`, so API contributes no behaviour to
+ * this model, and trails' `api.ts` is not an includable module — `Model`
+ * carries that surface. What IS wired is `AttributeMethods`, which Ruby gets
+ * from `Dirty`'s own `include ActiveModel::AttributeMethods` (dirty.rb:125);
+ * trails' `include()` copies a module's own members, not its nested includes.
+ *
  * Ruby's `@name` + `attr_reader :name` + a hand-written `name=` port to one
  * own, enumerable accessor property per ivar: `Object#as_json` serializes an
  * object through `instance_values` (core_ext/object/json.rb:58-66), i.e. its
  * own properties, so the ivar has to be spelled with the reader's name — and a
  * data property of that name would shadow the writer the Ruby model defines.
- * The values live in `#ivars`, which no `instance_values` can see.
+ * The values live in the `ivars` table below, which no `instance_values` sees.
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (dirty_test.rb:7-8); the class/interface merge is how `include()` surfaces on the type side.
 class DirtyModel {
-  #ivars: Record<string, unknown> = {};
-
   constructor() {
+    Object.defineProperty(this, ivars, { value: {}, writable: true, configurable: true });
+
     Object.defineProperty(this, "name", {
       enumerable: true,
       configurable: true,
-      get: () => this.#ivars["name"],
-      set: (val: unknown) => {
+      get(this: DirtyModel): unknown {
+        return this[ivars]["name"];
+      },
+      set(this: DirtyModel, val: unknown) {
         this.nameWillChange();
-        this.#ivars["name"] = val;
+        this[ivars]["name"] = val;
       },
     });
     Object.defineProperty(this, "color", {
       enumerable: true,
       configurable: true,
-      get: () => this.#ivars["color"],
-      set: (val: unknown) => {
-        if (val !== this.#ivars["color"]) this.colorWillChange();
-        this.#ivars["color"] = val;
+      get(this: DirtyModel): unknown {
+        return this[ivars]["color"];
+      },
+      set(this: DirtyModel, val: unknown) {
+        if (val !== this[ivars]["color"]) this.colorWillChange();
+        this[ivars]["color"] = val;
       },
     });
     Object.defineProperty(this, "size", {
       enumerable: true,
       configurable: true,
-      get: () => this.#ivars["size"],
-      set: (val: unknown) => {
-        if (val !== this.#ivars["size"]) this.attributeWillChangeBang("size");
-        this.#ivars["size"] = val;
+      get(this: DirtyModel): unknown {
+        return this[ivars]["size"];
+      },
+      set(this: DirtyModel, val: unknown) {
+        if (val !== this[ivars]["size"]) this.attributeWillChangeBang("size");
+        this[ivars]["size"] = val;
       },
     });
     Object.defineProperty(this, "status", {
       enumerable: true,
       configurable: true,
-      get: () => this.#ivars["status"],
-      set: (val: unknown) => {
-        if (val !== this.#ivars["status"]) this.statusWillChange();
-        this.#ivars["status"] = val;
+      get(this: DirtyModel): unknown {
+        return this[ivars]["status"];
+      },
+      set(this: DirtyModel, val: unknown) {
+        if (val !== this[ivars]["status"]) this.statusWillChange();
+        this[ivars]["status"] = val;
       },
     });
 
-    this.#ivars["name"] = null;
-    this.#ivars["color"] = null;
-    this.#ivars["size"] = null;
-    this.#ivars["status"] = "initialized";
+    this[ivars]["name"] = null;
+    this[ivars]["color"] = null;
+    this[ivars]["size"] = null;
+    this[ivars]["status"] = "initialized";
   }
 
   save(): void {
     this.changesApplied();
   }
+
+  /**
+   * `Object#dup`, which Ruby's DirtyModel inherits and TypeScript cannot:
+   * allocate, copy the ivars, dispatch `initialize_dup`, without re-entering
+   * the constructor. Same body as `Model#dup` (model.ts), plus the copy of the
+   * ivar table `Reflect.ownKeys` carries but Ruby splits across ivar slots.
+   */
+  dup(): this {
+    const duped = Object.create(Object.getPrototypeOf(this) as object) as this;
+    const descriptors = Object.getOwnPropertyDescriptors(this);
+    for (const key of Reflect.ownKeys(descriptors)) {
+      const descriptor = descriptors[key as string];
+      descriptor.configurable = true;
+      if (!descriptor.get && !descriptor.set) descriptor.writable = true;
+    }
+    Object.defineProperties(duped, descriptors);
+    duped[ivars] = { ...this[ivars] };
+    duped.initializeDup(this);
+    return duped;
+  }
+
+  /**
+   * The root of the `initialize_dup` chain: Ruby's `Object#initialize_dup`,
+   * where `Dirty#initialize_dup`'s `super` (dirty.rb:248-251) lands.
+   */
+  initializeDup(_other: this): void {}
 
   /**
    * `Object#as_json` (core_ext/object/json.rb:58-66), which Ruby's DirtyModel
@@ -89,6 +139,7 @@ class DirtyModel {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 interface DirtyModel extends Dirty {
+  [ivars]: Record<string, unknown>;
   name: unknown;
   color: unknown;
   size: unknown;
@@ -147,7 +198,10 @@ include(DirtyModel, ToJsonWithActiveSupportEncoder);
 
 // `Dirty#as_json` (dirty.rb:264-268) sits above the `Object#as_json` in the
 // class body, as Ruby's `include ActiveModel::Dirty` puts it above `Object`.
-prepend(DirtyModel.prototype, { asJson: dirtyAsJson });
+prepend(DirtyModel.prototype, {
+  asJson: dirtyAsJson,
+  initializeDup: dirtyInitializeDup,
+});
 
 // dirty_test.rb:9
 DirtyModelClass.defineAttributeMethods("name", "color", "size", "status");
@@ -203,15 +257,19 @@ describe("DirtyTest", () => {
   });
 
   it("attribute mutation", () => {
-    // Rails sets `@name` behind the writer, mutates the String in place, and
-    // asserts neither shows as a change — `ForcedMutationTracker#changed_in_place?`
-    // is a flat `false` (attribute_mutation_tracker.rb:95-97). JS strings have
-    // no in-place mutation, so the ivar write stands in for both steps.
-    // Ruby's `instance_variable_set("@name", …)` writes past the writer; the
-    // JS analogue replaces the accessor with the value it would have read.
+    // Rails writes `@name` past the writer and then mutates that String in
+    // place (`name.replace(...)`), asserting neither shows as a change —
+    // `ForcedMutationTracker#changed_in_place?` is a flat `false`
+    // (attribute_mutation_tracker.rb:95-97). JS strings are immutable, so each
+    // `replace` is spelled as the value the ivar would then hold; both
+    // `instance_variable_set` and `replace` write past the writer, which is a
+    // property redefinition here.
     Object.defineProperty(model, "name", { value: "Yam", enumerable: true, configurable: true });
     expect(model.nameChanged()).toBe(false);
+    Object.defineProperty(model, "name", { value: "Hadad", enumerable: true, configurable: true });
+    expect(model.nameChanged()).toBe(false);
     model.nameWillChange();
+    Object.defineProperty(model, "name", { value: "Baal", enumerable: true, configurable: true });
     expect(model.nameChanged()).toBe(true);
   });
 
@@ -351,7 +409,7 @@ describe("DirtyTest", () => {
   });
 
   it("model can be dup-ed without Attributes", () => {
-    expect(model).toBeTruthy();
+    expect(model.dup()).toBeTruthy();
   });
 
   it("to_json should work on model", () => {

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -9,7 +9,7 @@ import {
   type Included,
 } from "@blazetrails/activesupport";
 import * as AttributeMethods from "./attribute-methods.js";
-import { Dirty, asJson as dirtyAsJson, initInternals as dirtyInitInternals } from "./dirty.js";
+import { Dirty, asJson as dirtyAsJson } from "./dirty.js";
 
 /**
  * Rails' `DirtyTest::DirtyModel` (dirty_test.rb:6-43) includes
@@ -97,14 +97,9 @@ interface DirtyModel extends Dirty {
   nameWillChange(): void;
   colorWillChange(): void;
   statusWillChange(): void;
-  isNameChanged(...args: unknown[]): boolean;
-  isColorChanged(): boolean;
-  isSizeChanged(): boolean;
-  isStatusChanged(): boolean;
   nameChanged(options?: { from?: unknown; to?: unknown }): boolean;
   colorChanged(): boolean;
   sizeChanged(): boolean;
-  statusChanged(): boolean;
   namePreviouslyChanged(options?: { from?: unknown; to?: unknown }): boolean;
   nameChange: [unknown, unknown] | null;
   statusChange: [unknown, unknown] | null;
@@ -150,10 +145,9 @@ DirtyModelClass.attributeMethodAffix({ prefix: "clear", suffix: "Change", parame
 // (core_ext/object/json.rb:47-49), which TypeScript cannot reopen either.
 include(DirtyModel, ToJsonWithActiveSupportEncoder);
 
-prepend(DirtyModel.prototype, {
-  initInternals: dirtyInitInternals,
-  asJson: dirtyAsJson,
-});
+// `Dirty#as_json` (dirty.rb:264-268) sits above the `Object#as_json` in the
+// class body, as Ruby's `include ActiveModel::Dirty` puts it above `Object`.
+prepend(DirtyModel.prototype, { asJson: dirtyAsJson });
 
 // dirty_test.rb:9
 DirtyModelClass.defineAttributeMethods("name", "color", "size", "status");

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -27,10 +27,12 @@ const ivars = Symbol("ivars");
  * `ActiveModel::ForcedMutationTracker`, which is what this file exercises.
  *
  * The `include ActiveModel::API` half (dirty_test.rb:7) is not wired below:
- * the fixture's `initialize` (dirty_test.rb:11-17) overrides API's
- * (api.rb:78-81) and never calls `super`, so API contributes no behaviour to
- * this model, and trails' `api.ts` is not an includable module — `Model`
- * carries that surface. What IS wired is `AttributeMethods`, which Ruby gets
+ * trails' `api.ts` exports no instance-method bundle to `include()` — `Model`
+ * carries that surface. Nothing in the file reaches it. The one member of it a
+ * ported body could have needed is `initialize`, and the fixture overrides
+ * that one (dirty_test.rb:11-17) without calling `super`, so `assign_attributes`
+ * never runs; API's remaining surface (`persisted?`, `Conversion`, `Naming`)
+ * would be present on the Ruby instance and is simply unexercised here. What IS wired is `AttributeMethods`, which Ruby gets
  * from `Dirty`'s own `include ActiveModel::AttributeMethods` (dirty.rb:125);
  * trails' `include()` copies a module's own members, not its nested includes.
  *

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -1,3 +1,5 @@
+import { kernelArray } from "@blazetrails/activesupport";
+
 import { AttributeSet } from "./attribute-set.js";
 import {
   AttributeMutationTracker,
@@ -316,17 +318,29 @@ export function initAttributes(
 }
 
 /**
- * Per-instance reset hook for dirty-tracking state. Mirrors Rails
- * `ActiveModel::Dirty#init_internals` (dirty.rb:372-376). Ruby's `super` is
- * `super_()`, the receiver-bound link `prepend()` hands the module (model.ts
- * wires the chain in include order); the Model constructor enters it.
+ * Mirrors `ActiveModel::Dirty#as_json` (dirty.rb:264-268): hide the two
+ * mutation-tracker ivars from `Object#as_json`, which serializes every ivar
+ * (`instance_values`, core_ext/object/json.rb:58-66). Ruby names them
+ * `"mutations_from_database"` / `"mutations_before_last_save"` — the ivars
+ * stripped of their `@`; trails' are `_mutationsFromDatabase` /
+ * `_mutationsBeforeLastSave` (dirty.rb:373-374), so those are the names to
+ * except. Ruby's `super` is `super_()`, the receiver-bound link `prepend()`
+ * hands the module.
  *
  * @internal Rails-private helper.
  */
-export function initInternals(this: DirtyInternalsHost, super_: () => void): void {
-  super_();
-  this._mutationsBeforeLastSave = null;
-  this._mutationsFromDatabase = null;
+export function asJson(
+  this: unknown,
+  super_: (options: Record<string, unknown>) => unknown,
+  options: Record<string, unknown> = {},
+): unknown {
+  const except = [
+    ...kernelArray(options["except"]),
+    "_mutationsFromDatabase",
+    "_mutationsBeforeLastSave",
+  ];
+  options = { ...options, except };
+  return super_(options);
 }
 
 /**
@@ -340,6 +354,20 @@ export interface DirtyInternalsHost {
 /** Host shape consumed by `initializeDup` — the duplicate, mid-`dup()`. */
 export interface DirtyDupHost extends DirtyInternalsHost {
   _attributes: AttributeSet;
+}
+
+/**
+ * Per-instance reset hook for dirty-tracking state. Mirrors Rails
+ * `ActiveModel::Dirty#init_internals` (dirty.rb:372-376). Ruby's `super` is
+ * `super_()`, the receiver-bound link `prepend()` hands the module (model.ts
+ * wires the chain in include order); the Model constructor enters it.
+ *
+ * @internal Rails-private helper.
+ */
+export function initInternals(this: DirtyInternalsHost, super_: () => void): void {
+  super_();
+  this._mutationsBeforeLastSave = null;
+  this._mutationsFromDatabase = null;
 }
 
 /**

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -769,6 +769,12 @@ prepend(Model.prototype, {
   initInternals: dirtyInitInternals,
   initializeDup: dirtyInitializeDup,
 });
+// `Dirty#as_json` (dirty.rb:264-268) is deliberately NOT in that chain:
+// `ActiveModel::Serializers::JSON#as_json` (json.rb:96-108) is included after
+// Dirty and does not call `super`, so Ruby's lookup never reaches the Dirty
+// body on a model that serializes through `serializable_hash`. It applies to a
+// Dirty-including model whose `as_json` is still `Object`'s — Rails'
+// `DirtyTest::DirtyModel` (dirty_test.rb:6-43).
 
 // model.rb:77 — `ActiveSupport.run_load_hooks(:active_model, Model)`.
 runLoadHooks("active_model", Model);


### PR DESCRIPTION
Rails' `DirtyTest::DirtyModel` (`activemodel/test/cases/dirty_test.rb:6-43`)
includes `ActiveModel::API` + `ActiveModel::Dirty` and **nothing else** — no
`ActiveModel::Attributes`. With no `@attributes`, `mutations_from_database`
(`dirty.rb:382-388`) takes its second arm and builds an
`ActiveModel::ForcedMutationTracker`, so the whole file exercises that class.

trails' port built the model on `Model` with `this.attribute(...)`
declarations, which always has `_attributes` and so always took the first arm:
`dirty.test.ts` never ran a line of `ForcedMutationTracker` and duplicated
`attributes-dirty.test.ts`'s coverage instead of covering the other path.

- `dirty.test.ts`'s `DirtyModel` now mirrors `dirty_test.rb:6-43`: ivar-backed
  readers, hand-written writers calling `*_will_change!` (`color`/`size`/
  `status` keeping the `unless val == @x` guard, `size` going through
  `attribute_will_change!(:size)`), and a `save` that calls `changes_applied`.
  It is a plain class with `include ActiveModel::AttributeMethods` + `Dirty`
  and the `included do` suffix/affix block (`dirty.rb:241-245`).
- The per-fixture `changesApplied()` calls PR #7004 added disappear with the
  constructor seeding they compensated for; the file is now a `beforeEach`
  `@model` like Rails' `setup do`.
- Ruby's `@name` + `attr_reader :name` + a custom `name=` port to one own,
  enumerable accessor property per ivar: `Object#as_json` serializes through
  `instance_values` (`core_ext/object/json.rb:58-66`), so the ivar has to carry
  the reader's name, and a data property of that name could not intercept the
  writer. Values live in a `#ivars` record no `instance_values` can see.
- Ports `Dirty#as_json` (`dirty.rb:264-268`), which the four `to_json` cases
  need — `Object#as_json` emits every ivar, so the two mutation trackers must
  be excepted. It is deliberately **not** in `Model`'s prepend chain:
  `Serializers::JSON#as_json` (`json.rb:96-108`) is included after Dirty and
  never calls `super`, so Ruby's lookup never reaches the Dirty body on a model
  that serializes through `serializable_hash`.
- `attributes-dirty.test.ts` is untouched and keeps the `Attributes`-including
  shape (`attributes_dirty_test.rb:6-21`), so the two files stay distinct.
- Test names unchanged. `parity:test` still reports `dirty_test.rb → dirty.test.ts`
  25/25 ✓; call/args/extra-surface and assertion-mismatch ratchets all green.

Closes-story: port-dirty-test-model-as-rails-builds-it
