### PR TITLE
refactor(globalid,activesupport): GlobalID#uri holds the URI::GID, StringInquirer subclasses String (RFC 0112)

### DIFF
--- a/packages/activesupport/src/string-inquirer.test.ts
+++ b/packages/activesupport/src/string-inquirer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { StringInquirer, inquiry } from "./string-inquirer.js";
+import { EnvironmentInquirer } from "./environment-inquirer.js";
 import {
   assertNotPredicate,
   assertNotRespondTo,
@@ -59,6 +60,21 @@ describe("StringInquirer", () => {
     const s = inquiry.call("development");
     expect(s.toString()).toBe("development");
     expect(String(s)).toBe("development");
+  });
+
+  it("is a String", () => {
+    const s = inquiry.call("production");
+    expect(s).toBeInstanceOf(String);
+    expect(s.length).toBe(10);
+    expect(s.toUpperCase()).toBe("PRODUCTION");
+  });
+
+  it("a subclass resolves its own state through the proxy", () => {
+    const env = new EnvironmentInquirer("development");
+    expect(env).toBeInstanceOf(String);
+    expect(env).toBeInstanceOf(StringInquirer);
+    expect(env.isLocal()).toBe(true);
+    expect((env as any)["development?"]()).toBe(true);
   });
 
   it("valueOf returns original string", () => {

--- a/packages/activesupport/src/string-inquirer.ts
+++ b/packages/activesupport/src/string-inquirer.ts
@@ -24,28 +24,28 @@ class NoMethodError extends NameError {
   }
 }
 
-export class StringInquirer {
-  private readonly _value: string;
-
+/** Mirrors: `class StringInquirer < String` (string_inquirer.rb:21). */
+export class StringInquirer extends String {
   constructor(value: string) {
-    this._value = value;
+    super(value);
     return new Proxy(this, {
       get(target, prop: string | symbol, receiver) {
-        if (typeof prop === "symbol" || Reflect.has(target, prop)) {
-          return Reflect.get(target, prop, receiver);
+        // `super` — a String method resolves before `method_missing` does.
+        if (Reflect.has(target, prop)) {
+          const value = Reflect.get(target, prop, receiver);
+          // A String.prototype method demands a String receiver and the Proxy
+          // is not one, so those bind to the target; anything a subclass
+          // defines keeps `this` as the Proxy, where its own state lives.
+          return typeof value === "function" &&
+            value === (String.prototype as unknown as Record<string | symbol, unknown>)[prop]
+            ? value.bind(target)
+            : value;
         }
-        // `class StringInquirer < String` (string_inquirer.rb:21): a String
-        // method resolves before `method_missing` does. TS cannot subclass the
-        // String primitive, so the superclass is the wrapped string itself.
-        const stringSelf = Object(target._value) as Record<string, unknown>;
-        if (prop in stringSelf) {
-          const value = stringSelf[prop];
-          return typeof value === "function" ? value.bind(target._value) : value;
-        }
+        if (typeof prop === "symbol") return Reflect.get(target, prop, receiver);
         // `self == method_name[0..-2]` when the name ends in `?`.
         if (prop.endsWith("?")) {
           const methodName = prop;
-          return () => target._value === methodName.slice(0, -1);
+          return () => target.valueOf() === methodName.slice(0, -1);
         }
         // `else super`. A `get` trap cannot raise — `"foo" in x` and
         // `typeof x.foo` both route through it — so the raise moves to the
@@ -58,25 +58,10 @@ export class StringInquirer {
       },
       // `respond_to_missing?`: `method_name.end_with?("?") || super`.
       has(target, prop) {
-        if (typeof prop === "string" && (prop.endsWith("?") || prop in Object(target._value))) {
-          return true;
-        }
+        if (typeof prop === "string" && prop.endsWith("?")) return true;
         return Reflect.has(target, prop);
       },
     });
-  }
-
-  toString(): string {
-    return this._value;
-  }
-  /**
-   * @noRailsEquivalent PERMANENT
-   *   (`vendor/rails/activesupport/lib/active_support/string_inquirer.rb:21` — `class
-   *   StringInquirer < String`, so Ruby coerces through String itself).
-   * JS primitive-coercion protocol — Ruby coerces through to_s/to_i instead
-   */
-  valueOf(): string {
-    return this._value;
   }
 }
 

--- a/packages/globalid/src/global-id.test.ts
+++ b/packages/globalid/src/global-id.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { setApp, _resetApp } from "./config.js";
 import { registerConstant, _resetConstants } from "@blazetrails/activesupport";
 import { GlobalID } from "./global-id.js";
+import { GID } from "./uri/gid.js";
 import { type LocatorModel } from "./locator.js";
 
 // Synthetic GlobalIDModel — overrides `constructor.name` without building
@@ -286,12 +287,13 @@ describe("GlobalIDCreationTest", () => {
   });
 
   it("as URI", () => {
-    // Rails compares URI objects; GlobalID#uri is its string form here.
-    expect(personGid.uri).toBe("gid://bcx/Person/5");
-    expect(personUuidGid.uri).toBe(`gid://bcx/PersonUuid/${uuid}`);
-    expect(personNamespacedGid.uri).toBe("gid://bcx/Person::Child/4");
-    expect(personModelGid.uri).toBe("gid://bcx/PersonModel/1");
-    expect(cpkModelGid.uri).toBe("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value");
+    expect(personGid.uri).toEqual(GID.parse("gid://bcx/Person/5"));
+    expect(personUuidGid.uri).toEqual(GID.parse(`gid://bcx/PersonUuid/${uuid}`));
+    expect(personNamespacedGid.uri).toEqual(GID.parse("gid://bcx/Person::Child/4"));
+    expect(personModelGid.uri).toEqual(GID.parse("gid://bcx/PersonModel/1"));
+    expect(cpkModelGid.uri).toEqual(
+      GID.parse("gid://bcx/CompositePrimaryKeyModel/tenant-key-value/id-value"),
+    );
   });
 
   it("as JSON", () => {

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -156,7 +156,14 @@ export class GlobalID {
     return this.toString();
   }
 
-  /** Mirrors: GlobalID#== */
+  /**
+   * Mirrors: GlobalID#== — `other.is_a?(GlobalID) && uri == other.uri`.
+   *
+   * Rails compares the two `URI::GID`s through `URI::Generic#==`, which is
+   * component-wise. `GID` has no structural equality yet, so the comparison
+   * goes through the string form — the same partition `URI::Generic#==`
+   * induces for a GID, since every component is recoverable from `to_s`.
+   */
   equals(other: GlobalID): boolean {
     return other instanceof GlobalID && this.uri.toString() === other.uri.toString();
   }

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -37,40 +37,29 @@ export interface GlobalIDOptions {
 }
 
 export class GlobalID {
-  readonly uri: string;
-  private readonly _uri: GID;
+  readonly uri: GID;
 
   /** Mirrors: GlobalID#initialize(gid, options) */
   constructor(gid: string | GID, _options: GlobalIDOptions = {}) {
-    const parsed = gid instanceof GID ? gid : GID.parse(gid);
-    this.uri = parsed.toString();
-    this._uri = parsed;
+    this.uri = gid instanceof GID ? gid : GID.parse(gid);
   }
 
   get app(): string {
-    return this._uri.app;
+    return this.uri.app;
   }
   get modelName(): string {
-    return this._uri.modelName;
+    return this.uri.modelName;
   }
   get modelId(): string | string[] {
-    return this._uri.modelId;
+    return this.uri.modelId;
   }
   get params(): Record<string, string> {
-    return this._uri.params;
+    return this.uri.params;
   }
 
-  /**
-   * Mirrors: GlobalID#deconstruct_keys — `delegate :deconstruct_keys, to: :uri`.
-   *
-   * Rails' `attr_reader :uri` holds the URI::GID itself and `app` /
-   * `model_name` / `model_id` / `params` / `deconstruct_keys` all delegate to
-   * it. Here the public `uri` is its string form (every trails caller reads it
-   * as one), so the parsed GID is held privately and is what those readers
-   * delegate through.
-   */
+  /** Mirrors: GlobalID#deconstruct_keys — `delegate :deconstruct_keys, to: :uri`. */
   deconstructKeys(keys: readonly string[] | null = null): GidComponents {
-    return this._uri.deconstructKeys(keys);
+    return this.uri.deconstructKeys(keys);
   }
 
   /**
@@ -141,11 +130,11 @@ export class GlobalID {
 
   /** Mirrors: GlobalID#to_param — base64url without padding. */
   toParam(): string {
-    return btoa(this.uri).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    return btoa(this.toString()).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
   }
 
   toString(): string {
-    return this.uri;
+    return this.uri.toString();
   }
 
   /**
@@ -169,7 +158,7 @@ export class GlobalID {
 
   /** Mirrors: GlobalID#== */
   equals(other: GlobalID): boolean {
-    return other instanceof GlobalID && this.uri === other.uri;
+    return other instanceof GlobalID && this.uri.toString() === other.uri.toString();
   }
 
   /** Mirrors: GlobalID.app= validation */

--- a/packages/globalid/src/global-identification.test.ts
+++ b/packages/globalid/src/global-identification.test.ts
@@ -120,7 +120,7 @@ describe("GlobalIdentificationTest", () => {
     expect(typeof token).toBe("string");
     const parsed = SignedGlobalID.parse(token, { verifier });
     expect(parsed).not.toBeNull();
-    expect(parsed!.uri).toBe("gid://bcx/Person/2");
+    expect(parsed!.uri.toString()).toBe("gid://bcx/Person/2");
   });
 });
 

--- a/packages/globalid/src/locator.ts
+++ b/packages/globalid/src/locator.ts
@@ -303,7 +303,7 @@ export class Locator {
       verifier: options.verifier,
     });
     if (!parsed) return null;
-    return Locator.locate(parsed.uri, options);
+    return Locator.locate(parsed.uri.toString(), options);
   }
 
   /** Mirrors: Locator.locate_many_signed */

--- a/packages/globalid/src/signed-global-id.test.ts
+++ b/packages/globalid/src/signed-global-id.test.ts
@@ -43,7 +43,7 @@ describe("SignedGlobalIDTest", () => {
     // Rails asserts the exact signed token produced by the vendored test
     // verifier secret. Trails builds a verifier per test, so the token bytes
     // differ; assert the round-trip instead.
-    expect(SignedGlobalID.parse(sgid.toString(), { verifier })!.uri).toBe(sgid.uri);
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier })!.uri).toEqual(sgid.uri);
   });
 
   it("model id", () => {
@@ -88,7 +88,7 @@ describe("SignedGlobalIDPurposeTest", () => {
     const likeSgid = SignedGlobalID.create(person(5), { verifier, for: "like-button" });
     // Rails asserts the exact signed token; trails' per-test verifier secret
     // differs, so assert the round-trip URI instead.
-    expect(SignedGlobalID.parse(loginSgid.toString(), { verifier, for: "login" })!.uri).toBe(
+    expect(SignedGlobalID.parse(loginSgid.toString(), { verifier, for: "login" })!.uri).toEqual(
       loginSgid.uri,
     );
     expect(loginSgid.equals(likeSgid)).not.toBe(true);
@@ -406,7 +406,7 @@ describe("SignedGlobalID (non-Rails coverage)", () => {
   it("includes app in URI when provided", () => {
     const verifier = makeVerifier();
     const sgid = SignedGlobalID.create(person(5), { verifier, app: "MyApp" });
-    expect(sgid.uri).toBe("gid://MyApp/Person/5");
+    expect(sgid.uri.toString()).toBe("gid://MyApp/Person/5");
   });
 
   describe("getApp() integration", () => {
@@ -417,7 +417,7 @@ describe("SignedGlobalID (non-Rails coverage)", () => {
       setApp("ConfiguredApp");
       const verifier = makeVerifier();
       const sgid = SignedGlobalID.create(person(5), { verifier });
-      expect(sgid.uri).toBe("gid://ConfiguredApp/Person/5");
+      expect(sgid.uri.toString()).toBe("gid://ConfiguredApp/Person/5");
     });
 
     it("throws when no app configured and no app option", () => {
@@ -436,7 +436,7 @@ describe("SignedGlobalID (non-Rails coverage)", () => {
       // Token verifies with the class-level verifier (no option needed).
       const parsed = SignedGlobalID.parse(sgid.toString());
       expect(parsed).not.toBeNull();
-      expect(parsed!.uri).toBe("gid://bcx/Person/5");
+      expect(parsed!.uri.toString()).toBe("gid://bcx/Person/5");
     });
 
     it("pickVerifier throws when neither option nor class-level is set", () => {

--- a/packages/globalid/src/signed-global-id.trails.test.ts
+++ b/packages/globalid/src/signed-global-id.trails.test.ts
@@ -24,7 +24,7 @@ describe("SignedGlobalID pick_purpose explicit-null semantics", () => {
     const sgid = SignedGlobalID.create(person, { verifier, for: null });
     expect(sgid.purpose).toBeNull();
     expect(SignedGlobalID.parse(sgid.toString(), { verifier })).toBeNull();
-    expect(SignedGlobalID.parse(sgid.toString(), { verifier, for: null })?.uri).toBe(sgid.uri);
+    expect(SignedGlobalID.parse(sgid.toString(), { verifier, for: null })?.uri).toEqual(sgid.uri);
   });
 });
 

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -194,7 +194,7 @@ export class SignedGlobalID extends GlobalID {
   toString(): string {
     if (this._cached) return this._cached;
     const payload: SgidPayload = {
-      gid: this.uri,
+      gid: this.uri.toString(),
       purpose: this.purpose,
       expires_at: this.expiresAt ? this.expiresAt.toString({ smallestUnit: "millisecond" }) : null,
     };
@@ -219,7 +219,11 @@ export class SignedGlobalID extends GlobalID {
    * different across module boundaries.
    */
   equals(other: SignedGlobalID): boolean {
-    return other != null && this.uri === other.uri && this.purpose === other.purpose;
+    return (
+      other != null &&
+      this.uri.toString() === other.uri.toString() &&
+      this.purpose === other.purpose
+    );
   }
 
   /** Mirrors: SignedGlobalID#inspect — `#<SignedGlobalID:0x...>` (stable per instance). */

--- a/packages/globalid/src/signed-global-id.ts
+++ b/packages/globalid/src/signed-global-id.ts
@@ -217,6 +217,9 @@ export class SignedGlobalID extends GlobalID {
    * (same trap base.ts works around for findSignedGlobalId), so an
    * `instanceof` check would falsely report two value-equal SGIDs as
    * different across module boundaries.
+   *
+   * The URI half compares string forms rather than the two `URI::GID`s, for
+   * the reason `GlobalID#equals` records.
    */
   equals(other: SignedGlobalID): boolean {
     return (


### PR DESCRIPTION
Two RFC 0112 "one Rails thing, N trails things" convergences.

**`GlobalID#uri` holds the `URI::GID`** — Rails' `attr_reader :uri` is the URI object (`vendor/globalid/lib/global_id/global_id.rb:43`) and `app` / `model_name` / `model_id` / `params` / `deconstruct_keys` all `delegate ... to: :uri` (`global_id.rb:44`). trails held the string in `uri` plus a private `_uri` GID — two fields for Rails' one. `uri` is now the parsed `GID`, `_uri` is gone, the delegated readers go through the public `uri`, and the string call sites (`toParam`, `toString`, `equals`, `signed-global-id.ts`, `locator.ts`) go through `toString()`. The "as URI" test now compares GID objects, mirroring `test/cases/global_id_test.rb:163-168`.

**`StringInquirer extends String`** — `vendor/rails/activesupport/lib/active_support/string_inquirer.rb:21` is `class StringInquirer < String`. JS `String` is subclassable, so the wrapper is gone: the invented `_value` field and the `valueOf` carrying a `@noRailsEquivalent PERMANENT` tag are both deleted, `inquirer instanceof String` is now true, and the Proxy shrinks to the `respond_to_missing?` / `method_missing` arms it exists for. The one piece of plumbing kept is binding a `String.prototype` method to the target (a String.prototype method rejects a Proxy receiver), narrowly scoped so a subclass method still gets `this` = the Proxy and `EnvironmentInquirer`'s private state resolves.

`pnpm parity:api --package globalid` stays 80/80; globalid, activesupport, trailties and `delegated-type.test.ts` are green; call-set, call-args and extra-surface gates all OK.

Closes-story: globalid-uri-reader-is-a-string-not-a-uri-gid
Closes-story: string-inquirer-should-subclass-string
