### PR TITLE
refactor(activemodel,activerecord): retire the _attributeDefinitions registry (RFC 0115)

### DIFF
--- a/packages/activemodel/src/attribute-registration.test.ts
+++ b/packages/activemodel/src/attribute-registration.test.ts
@@ -336,9 +336,9 @@ describe("AttributeRegistrationTest", () => {
         this.attribute("age", "integer");
       }
     }
-    const defs = Person._attributeDefinitions;
-    expect(defs.get("name")!.type.name).toBe("string");
-    expect(defs.get("age")!.type.name).toBe("integer");
+    const types = Person.attributeTypes();
+    expect(types["name"].name).toBe("string");
+    expect(types["age"].name).toBe("integer");
   });
 
   it(".type_for_attribute returns the registered attribute type", () => {

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -1,10 +1,10 @@
 import { DescendantsTracker, registerSubclass } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
-import { defaultValue, defaultValue as typeDefaultValue } from "./type.js";
+import { defaultValue } from "./type.js";
 import { typeRegistry } from "./type/registry.js";
 import { Attribute } from "./attribute.js";
 import { AttributeSet } from "./attribute-set.js";
-import type { AttributeDefinition, AttributeOptions } from "./attributes.js";
+import type { AttributeOptions } from "./attributes.js";
 
 /**
  * AttributeRegistration mixin — provides the static attribute() method
@@ -101,7 +101,6 @@ export class PendingDefault implements PendingModification {
  * `AttributeRegistration::ClassMethods`.
  */
 export interface AttributeRegistrationHost extends AttributeHostInternals {
-  _attributeDefinitions: Map<string, AttributeDefinition>;
   /** @internal */
   resolveTypeName(name: string, options?: Record<string, unknown>): Type;
   /** @internal */
@@ -134,59 +133,39 @@ export function attribute(
     typeName = undefined;
   }
   const typeProvided = typeName !== undefined;
-  if (!Object.hasOwn(this, "_attributeDefinitions")) {
-    this._attributeDefinitions = new Map(this._attributeDefinitions);
-  }
-  const existing = this._attributeDefinitions.get(name);
-  // When the type is omitted, preserve the existing attribute's type (Rails'
-  // PendingType `with_type` inheritance path); fall back to the value type only
-  // when nothing is known about the attribute yet.
-  // Rails' `attribute(name, ...)` forwards `**options` straight to the type
-  // registry (attributes.rb:59-62 → attribute_registration.rb:18); the two keys
-  // consumed here — `default` and `virtual` — are the ones Rails names
-  // explicitly, so only the rest reach the registry.
+  // Rails' `attribute(name, type = nil, default: (no_default = true), **options)`
+  // forwards `**options` straight to the type registry
+  // (attribute_registration.rb:13); the two keys trails names explicitly —
+  // `default` and `virtual` — are consumed here, so only the rest reach it.
   const { default: _default, virtual: _virtual, ...typeOptions } = options ?? {};
-  let type = typeProvided
-    ? typeName instanceof Type
-      ? typeName
-      : this.resolveTypeName(
-          typeName as string,
-          Object.keys(typeOptions).length > 0
-            ? (typeOptions as Record<string, unknown>)
-            : undefined,
-        )
-    : (existing?.type ?? typeDefaultValue());
-  // attribute_registration.rb:15 — `type = hook_attribute_type(name, type) if type`.
-  if (typeProvided) type = this.hookAttributeType(name, type);
-  // Preserve the existing defaultValue when no default is explicitly provided,
-  // matching Rails' PendingType behavior: with_type only changes the type and
-  // leaves the current default/value untouched.
-  const defaultValue =
-    options?.default !== undefined ? options.default : (existing?.defaultValue ?? null);
-  this._attributeDefinitions.set(name, {
-    ...existing,
-    name,
-    type,
-    defaultValue,
-    virtual: options?.virtual ?? existing?.virtual,
-    ...(options?.limit != null ? { limit: options.limit } : {}),
-  });
+  // attribute_registration.rb:14-15 — `type = resolve_type_name(type, **options)
+  // if type.is_a?(Symbol)` then `type = hook_attribute_type(name, type) if type`.
+  let type: Type | null = null;
+  if (typeProvided) {
+    type =
+      typeName instanceof Type
+        ? typeName
+        : this.resolveTypeName(
+            typeName as string,
+            Object.keys(typeOptions).length > 0
+              ? (typeOptions as Record<string, unknown>)
+              : undefined,
+          );
+    type = this.hookAttributeType(name, type);
+  }
 
-  // Push to pending-modification queue so _defaultAttributes() replays in
-  // the correct order relative to schema-reflected columns (AR) or other
-  // pending modifications (AM inheritance).
-  // Mirrors: ActiveModel::AttributeRegistration#attribute —
-  //   pending << PendingType.new(name, type) if type || no_default
-  //   pending << PendingDefault.new(name, default) unless no_default
+  // Mirrors: ActiveModel::AttributeRegistration#attribute (attribute_registration.rb:16-18)
+  //   pending_attribute_modifications << PendingType.new(name, type) if type || no_default
+  //   pending_attribute_modifications << PendingDefault.new(name, default) unless no_default
   // A bare re-declaration (no type, no default) still pushes a PendingType with
   // a nil type so it re-anchors to the attribute's current type at replay; a
   // default-only call pushes only PendingDefault, preserving the existing type.
   const noDefault = options?.default === undefined;
-  if (typeProvided || noDefault) {
-    this.pendingAttributeModifications().push(new PendingType(name, typeProvided ? type : null));
+  if (type != null || noDefault) {
+    this.pendingAttributeModifications().push(new PendingType(name, type));
   }
   if (!noDefault) {
-    this.pendingAttributeModifications().push(new PendingDefault(name, defaultValue));
+    this.pendingAttributeModifications().push(new PendingDefault(name, options?.default));
   }
 
   // Mirrors: Rails reset_default_attributes — invalidate cache on this class
@@ -206,7 +185,7 @@ export function attribute(
  *
  * The decoration itself is applied when `_default_attributes` next
  * materializes (attribute_registration.rb:32-36) — nothing is written to
- * `_attributeDefinitions` here.
+ * the pending-modification queue here.
  */
 export function decorateAttributes(
   this: AttributeHostInternals,

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -134,12 +134,13 @@ export function attribute(
   }
   const typeProvided = typeName !== undefined;
   // Rails' `attribute(name, type = nil, default: (no_default = true), **options)`
-  // forwards `**options` straight to the type registry
-  // (attribute_registration.rb:13); the two keys trails names explicitly —
-  // `default` and `virtual` — are consumed here, so only the rest reach it.
+  // (attribute_registration.rb:12) forwards `**options` straight to
+  // `resolve_type_name`; the two keys trails names explicitly — `default` and
+  // `virtual` — are consumed here, so only the rest reach it.
   const { default: _default, virtual: _virtual, ...typeOptions } = options ?? {};
-  // attribute_registration.rb:14-15 — `type = resolve_type_name(type, **options)
-  // if type.is_a?(Symbol)` then `type = hook_attribute_type(name, type) if type`.
+  // attribute_registration.rb:14-15:
+  //   type = resolve_type_name(type, **options) if type.is_a?(Symbol)
+  //   type = hook_attribute_type(name, type) if type
   let type: Type | null = null;
   if (typeProvided) {
     type =
@@ -154,7 +155,7 @@ export function attribute(
     type = this.hookAttributeType(name, type);
   }
 
-  // Mirrors: ActiveModel::AttributeRegistration#attribute (attribute_registration.rb:16-18)
+  // attribute_registration.rb:17-18:
   //   pending_attribute_modifications << PendingType.new(name, type) if type || no_default
   //   pending_attribute_modifications << PendingDefault.new(name, default) unless no_default
   // A bare re-declaration (no type, no default) still pushes a PendingType with
@@ -184,8 +185,7 @@ export function attribute(
  *   end
  *
  * The decoration itself is applied when `_default_attributes` next
- * materializes (attribute_registration.rb:32-36) — nothing is written to
- * the pending-modification queue here.
+ * materializes (attribute_registration.rb:32-36).
  */
 export function decorateAttributes(
   this: AttributeHostInternals,

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -13,14 +13,6 @@ import {
   type AttributeRegistrationHost,
 } from "./attribute-registration.js";
 
-export interface AttributeDefinition {
-  name: string;
-  type: Type;
-  defaultValue: unknown;
-  virtual?: boolean;
-  limit?: number | null;
-}
-
 /**
  * Return all attributes as a plain hash.
  *

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -39,10 +39,12 @@ export {
 } from "./attribute-mutation-tracker.js";
 export {
   applyPendingAttributeModifications,
+  PendingDefault,
+  PendingType,
   resetDefaultAttributes,
 } from "./attribute-registration.js";
 export { Attributes } from "./attributes.js";
-export type { AttributeDefinition, AttributeOptions } from "./attributes.js";
+export type { AttributeOptions } from "./attributes.js";
 export {
   Attribute,
   FromDatabase,

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -64,7 +64,6 @@ import {
   validatesWith as withValidatesWith,
 } from "./validations/with.js";
 import {
-  type AttributeDefinition,
   Attributes,
   attribute,
   attributeNames,
@@ -252,7 +251,6 @@ export class Model {
    * (conversion.rb:32), installed by `Conversion.[included]`.
    */
   declare static paramDelimiter: string;
-  static _attributeDefinitions: Map<string, AttributeDefinition> = new Map();
   declare private static _modelName: ModelName | null;
   // Runtime accessors come from the `classAttribute()` calls at the bottom of
   // this file (attribute_methods.rb:70-73).

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -184,8 +184,7 @@ describe("AcceptanceValidationTest", () => {
         this.validates("terms", { acceptance: true });
       }
     }
-    expect(Agreement._attributeDefinitions.get("terms")!.type.name).toBe("boolean");
-    expect(Agreement._attributeDefinitions.get("terms")!.virtual).toBeUndefined();
+    expect(Agreement.attributeTypes()["terms"].name).toBe("boolean");
   });
 });
 describe("acceptance skips nil", () => {

--- a/packages/activemodel/src/validations/confirmation-validation.test.ts
+++ b/packages/activemodel/src/validations/confirmation-validation.test.ts
@@ -142,7 +142,7 @@ describe("ConfirmationValidationTest", () => {
         this.validates("email", { confirmation: true });
       }
     }
-    expect(Person._attributeDefinitions.has("emailConfirmation")).toBe(true);
+    expect(Person.attributeNames()).toContain("emailConfirmation");
   });
 });
 describe("ConfirmationValidator caseSensitive", () => {

--- a/packages/activerecord/src/attribute-methods/read.test.ts
+++ b/packages/activerecord/src/attribute-methods/read.test.ts
@@ -19,11 +19,6 @@ describe("ReadTest", () => {
   // statics below are that include.
   function buildKlass() {
     class Klass {
-      static _attributeDefinitions = new Map<string, { name: string }>([
-        ["one", { name: "one" }],
-        ["two", { name: "two" }],
-        ["three", { name: "three" }],
-      ]);
       static _attributeMethodsGenerated = false;
       // read_test.rb:18's `def self.load_schema; end` — the fake klass has no
       // table, so the `load_schema` `define_attribute_methods` calls

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -860,6 +860,20 @@ export class Base extends Model {
    */
   declare static _virtualAttributesReconciled?: boolean;
 
+  /**
+   * Names declared with trails' `attribute(..., { virtual: true })` — an
+   * attribute with no backing DB column. Rails has no such option: its
+   * `columns_hash` is a DB read, so a declared-but-column-less attribute is
+   * simply absent from it. trails synthesizes `columnsHash` for table-less
+   * models, so it has to be told which declarations are not columns.
+   * Copy-on-write per class, like every other inherited registry here.
+   *
+   * @internal
+   * @noRailsEquivalent CONVERGEABLE — retired together with the virtual flag by
+   * RFC 0115 `retire-virtual-attribute-reconciliation`.
+   */
+  declare static _virtualAttributes?: Set<string>;
+
   /** Mirrors: ActiveRecord.writing_role */
   static writingRole = WRITING_ROLE;
   /** Mirrors: ActiveRecord.reading_role */
@@ -1141,6 +1155,16 @@ export class Base extends Model {
       _initializeGeneratedModules.call(this as never);
     }
     super.attribute(name, typeName, options);
+    const attributeOptions =
+      typeName != null && typeof typeName === "object" && !(typeName instanceof Type)
+        ? typeName
+        : options;
+    if (attributeOptions?.virtual) {
+      if (!Object.prototype.hasOwnProperty.call(this, "_virtualAttributes")) {
+        this._virtualAttributes = new Set(this._virtualAttributes);
+      }
+      this._virtualAttributes!.add(name);
+    }
     // Rails' `attribute` ends in `reload_schema_from_cache`, which nils
     // `@attribute_names` recursively.
     ModelSchema.clearAttributeNamesMemo(this as never);
@@ -1160,7 +1184,7 @@ export class Base extends Model {
     // push their durable decorator eagerly at declaration, so — now that
     // `type_for_attribute` / `TypeCaster::Map` resolve through
     // `attribute_types` (the decorated default attribute set) — they need
-    // no per-feature `_attributeDefinitions` replay here.
+    // no per-feature declaration-registry replay here.
     encryptionHooks.applyPendingEncryptions(this);
   }
 
@@ -1190,7 +1214,7 @@ export class Base extends Model {
     // `Type.default_value` hash default (attribute_registration.rb:43-50). The set
     // replays every pending decorator (serialize/normalizes/encrypts) onto the
     // reflected column type, so query-side decorations are honored without a
-    // per-feature post-reflection replay onto `_attributeDefinitions`. Read the
+    // per-feature post-reflection replay onto a declaration registry. Read the
     // single attribute (O(1), and `getAttribute` returns a `value`-typed Null for
     // an unknown name) rather than `attributeTypes()[name]` — even though the
     // cast-types record + Proxy are now memoized, this avoids the record's
@@ -1210,7 +1234,7 @@ export class Base extends Model {
    * Get the Arel table for this model.
    *
    * Wires a TypeCasterMap so `arelTable.typeForAttribute(col)` resolves
-   * through the model's `_attributeDefinitions`. Predicate-builder bind
+   * through the model's `attributeTypes`. Predicate-builder bind
    * values rely on this to serialize through the right Type (e.g.
    * EncryptedAttributeType for deterministic encryption) — without a
    * typeCaster, `.where({col: "x"})` would emit the raw `"x"` in SQL
@@ -1296,7 +1320,7 @@ export class Base extends Model {
   }
 
   /**
-   * Await schema reflection — ensures `_attributeDefinitions` is populated
+   * Await schema reflection — ensures `columnsHash` is populated
    * from the adapter's schema cache before proceeding. Idempotent; cheap
    * to call repeatedly.
    *
@@ -1345,17 +1369,17 @@ export class Base extends Model {
     // would otherwise synthesize a columnsHash containing only the virtual
     // attrs and mark the model schema-loaded, hiding every real column.
     //
-    // `_attributeDefinitions` holds user `attribute()` declarations only —
-    // reflected columns live in `columns_hash` — so a concrete (non-virtual)
+    // The pending-modification queue holds user `attribute()` declarations only
+    // — reflected columns live in `columns_hash` — so a concrete (non-virtual)
     // declaration means the model spelled its own schema out and needs no DB
     // reflection. Enum-declared attrs (registered by `_enum` via
     // `this.attribute()`) must NOT block reflection: they are type overlays,
     // not full schema declarations, and the model still needs the DB to
     // discover its other columns.
     const enumNames = (this as any)._enums as Map<string, unknown> | undefined;
-    for (const [name, def] of this._attributeDefinitions) {
-      const d = def as { virtual?: boolean };
-      if (!d.virtual && !enumNames?.has(name)) {
+    const virtual = this._virtualAttributes;
+    for (const name of ModelSchema.declaredAttributeNames.call(this as never)) {
+      if (!virtual?.has(name) && !enumNames?.has(name)) {
         // Some declared attributes may be virtual (no backing DB column).
         // Rails' `column_names` is always DB-sourced, so reconcile against the
         // real columns and flag those as virtual — keeping `columnNames()`
@@ -2752,7 +2776,7 @@ export class Base extends Model {
       ) as InstanceType<T>;
     }
 
-    // Ensure schema reflection has populated _attributeDefinitions with
+    // Ensure schema reflection has populated columnsHash with
     // adapter-resolved cast types before hydrating from the row — otherwise
     // `attributes_builder`'s `attribute_types` falls back to ValueType and PG
     // OID casts (uuid/jsonb/hstore/inet/range) are lost. Sync path only

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -868,9 +868,10 @@ export class Base extends Model {
    * models, so it has to be told which declarations are not columns.
    * Copy-on-write per class, like every other inherited registry here.
    *
+   * Retired together with the virtual flag by RFC 0115
+   * `retire-virtual-attribute-reconciliation`.
+   *
    * @internal
-   * @noRailsEquivalent CONVERGEABLE — retired together with the virtual flag by
-   * RFC 0115 `retire-virtual-attribute-reconciliation`.
    */
   declare static _virtualAttributes?: Set<string>;
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1154,16 +1154,21 @@ export class Base extends Model {
     if (!Object.prototype.hasOwnProperty.call(this, "_generatedAttributeMethods")) {
       _initializeGeneratedModules.call(this as never);
     }
+    // Ruby reads `attribute(name, type = nil, **options)` off the call itself, so
+    // AR's override never has to work out which argument is the options bag.
+    // Collapse the two-arity call to the three-arity one once, with
+    // AttributeRegistration#attribute's own test, so `super` re-runs it as a
+    // no-op and the two spellings cannot drift.
+    if (typeName !== undefined && typeof typeName !== "string" && !(typeName instanceof Type)) {
+      options = typeName;
+      typeName = undefined;
+    }
     super.attribute(name, typeName, options);
-    const attributeOptions =
-      typeName != null && typeof typeName === "object" && !(typeName instanceof Type)
-        ? typeName
-        : options;
-    if (attributeOptions?.virtual) {
-      if (!Object.prototype.hasOwnProperty.call(this, "_virtualAttributes")) {
-        this._virtualAttributes = new Set(this._virtualAttributes);
-      }
-      this._virtualAttributes!.add(name);
+    if (options?.virtual) {
+      const virtual = Object.prototype.hasOwnProperty.call(this, "_virtualAttributes")
+        ? this._virtualAttributes!
+        : (this._virtualAttributes = new Set(this._virtualAttributes));
+      virtual.add(name);
     }
     // Rails' `attribute` ends in `reload_schema_from_cache`, which nils
     // `@attribute_names` recursively.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1320,9 +1320,9 @@ export class Base extends Model {
   }
 
   /**
-   * Await schema reflection — ensures `columnsHash` is populated
-   * from the adapter's schema cache before proceeding. Idempotent; cheap
-   * to call repeatedly.
+   * Await schema reflection — ensures `columnsHash` is populated from the
+   * adapter's schema cache before proceeding. Idempotent; cheap to call
+   * repeatedly.
    *
    * Mirrors: ActiveRecord::ModelSchema#load_schema (explicit variant).
    */
@@ -2776,7 +2776,7 @@ export class Base extends Model {
       ) as InstanceType<T>;
     }
 
-    // Ensure schema reflection has populated columnsHash with
+    // Ensure schema reflection has populated `columns_hash` with
     // adapter-resolved cast types before hydrating from the row — otherwise
     // `attributes_builder`'s `attribute_types` falls back to ValueType and PG
     // OID casts (uuid/jsonb/hstore/inet/range) are lost. Sync path only

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -73,7 +73,7 @@ interface PendingEncryption {
  * The type wrapping itself is NOT done here: `encryptAttribute` pushes the
  * durable PendingDecorator once at declaration time, and every type inspection
  * resolves through `typeForAttribute` (Rails' single lookup surface) — there is
- * no eager `_attributeDefinitions` re-wrap to maintain. What remains is the
+ * no eager type re-wrap to maintain. What remains is the
  * bookkeeping Rails runs from `validate`: the frozen-encryption validator
  * install. The column-size validation is `load_schema!`'s
  * (encryptable_record.rb:126-130) and runs from that chain instead.

--- a/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.trails.test.ts
@@ -26,7 +26,7 @@ import { BinaryType } from "@blazetrails/activemodel";
  * TS-only extras for EncryptableRecord. Rails has no equivalent test: its
  * `serialized binary data can be encrypted` asserts only the round-trip, which
  * a doubly-wrapped type can still satisfy for some coders. trails eagerly bakes
- * decorations into `_attributeDefinitions[name].type` (a back-compat
+ * decorations into a per-class type registry (a back-compat
  * convenience Rails lacks), so seeding `_defaultAttributes` from that decorated
  * type silently double-applied every decorator that also lives in the pending
  * queue. These assert the resolved chain directly so a re-introduced wrapper

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -379,7 +379,7 @@ describe("Enum subtype resolved from the reflected column type", () => {
 // `decimal_number` is a real `decimal` column, so an integer-valued enum on it
 // must delegate to the reflected `DecimalType`, even though (a) mapping-shape
 // inference would guess `integer` and (b) reflection skips the user-provided
-// enum def, leaving `_attributeDefinitions` carrying the pre-reflection integer
+// enum def, leaving the pending `PendingType` carrying the pre-reflection integer
 // EnumType — so the reflected subtype only lives in the replayed AttributeSet.
 describe("Enum subtype resolved from a schema-reflected column type", () => {
   fixtures(["books"]);

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -172,9 +172,9 @@ export function installEnumAttribute(
     return enumTypeFrom(name, mapping, subtype, raiseOnInvalidValues);
   });
 
-  // Define the getter after attribute() so the EnumType is already in
-  // _attributeDefinitions / the pending-type queue when we overwrite whatever
-  // accessor attribute() installed.
+  // Define the getter after attribute() so the EnumType is already in the
+  // pending-type queue when we overwrite whatever accessor attribute()
+  // installed.
   Object.defineProperty(klass.prototype, name, {
     get(this: Base) {
       // `readAttribute`, not a direct `_attributes` read: an aliased enum is
@@ -962,11 +962,10 @@ export function raiseConflictError(
  * Fetch the single registered EnumType for an enum attribute — the one source
  * of truth built lazily from the reflected column type via the
  * `decorateAttributes` decorator. Resolves through the replayed AttributeSet
- * (`_defaultAttributes`), NOT `_attributeDefinitions`: reflection skips a
- * user-provided enum def, so its `type` stays the pre-reflection (mapping-shape-
- * inferred) EnumType, whereas the replayed decorator rebuilds the EnumType from
- * the reflected column subtype. Returns null when the attribute isn't an enum
- * on this class.
+ * (`_defaultAttributes`), NOT the pending `PendingType` the declaration pushed:
+ * that type is the pre-reflection (mapping-shape-inferred) EnumType, whereas the
+ * replayed decorator rebuilds the EnumType from the reflected column subtype.
+ * Returns null when the attribute isn't an enum on this class.
  *
  * @internal
  */

--- a/packages/activerecord/src/model-schema-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load.trails.test.ts
@@ -4,8 +4,8 @@ type Type = ValueType;
 import { Base } from "./base.js";
 import { declaredAttributeNames, loadSchemaFromAdapter } from "./model-schema.js";
 
-/** The names a class declared with `attribute()` — the pending-queue read that
- * replaced the retired `_attributeDefinitions` registry. */
+/** The names a class declared with `attribute()`, read off the pending
+ * -modification queue the way `columnsHash`' synthesis does. */
 const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
 
 

--- a/packages/activerecord/src/model-schema-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load.trails.test.ts
@@ -4,10 +4,9 @@ type Type = ValueType;
 import { Base } from "./base.js";
 import { declaredAttributeNames, loadSchemaFromAdapter } from "./model-schema.js";
 
-/** The names a class declared with `attribute()`, read off the pending
- * -modification queue the way `columnsHash`' synthesis does. */
+/** The names a class declared with `attribute()`, read off the
+ * pending-modification queue the way `columnsHash`' synthesis does. */
 const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
-
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";

--- a/packages/activerecord/src/model-schema-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load.trails.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { ValueType, typeRegistry } from "@blazetrails/activemodel";
 type Type = ValueType;
 import { Base } from "./base.js";
-import { loadSchemaFromAdapter } from "./model-schema.js";
+import { declaredAttributeNames, loadSchemaFromAdapter } from "./model-schema.js";
+
+/** The names a class declared with `attribute()` — the pending-queue read that
+ * replaced the retired `_attributeDefinitions` registry. */
+const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
+
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
@@ -57,7 +62,7 @@ describe("loadSchemaFromAdapter", () => {
     // through a class-level registry, which holds user declarations only.
     expect(Model.typeForAttribute("guid").name).toBe("uuid");
     expect(Model.typeForAttribute("payload").name).toBe("jsonb");
-    expect(Model._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Model)).not.toContain("guid");
   });
 
   it("does not overwrite user-declared attributes", async () => {
@@ -67,9 +72,8 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    const def = Model._attributeDefinitions.get("guid");
-    expect(def?.type.name).toBe("string");
-    expect(Model._attributeDefinitions.has("guid")).toBe(true);
+    expect(Model.typeForAttribute("guid").name).toBe("string");
+    expect(declared(Model)).toContain("guid");
   });
 
   it("is a no-op for abstract classes", async () => {
@@ -79,7 +83,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(Model._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Model)).not.toContain("guid");
   });
 
   it("reflects on a concrete subclass of an abstract parent", async () => {
@@ -110,7 +114,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(Model._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Model)).not.toContain("guid");
   });
 
   it("falls through when dataSourceExists returns undefined (probe not implemented)", async () => {
@@ -125,7 +129,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(Model._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Model)).not.toContain("guid");
   });
 
   it("falls back to ValueType when adapter has no cast type", async () => {
@@ -145,7 +149,7 @@ describe("loadSchemaFromAdapter", () => {
     expect(Model.typeForAttribute("mystery")).toBeInstanceOf(
       typeRegistry.lookup("value").constructor,
     );
-    expect(Model._attributeDefinitions.has("mystery")).toBe(false);
+    expect(declared(Model)).not.toContain("mystery");
   });
 
   it("invalidates the _attributesBuilder cache", async () => {
@@ -220,8 +224,8 @@ describe("loadSchemaFromAdapter integration details", () => {
     await Post.loadSchema();
 
     // User-declared def survives ignoredColumns.
-    expect(Post._attributeDefinitions.has("age")).toBe(true);
-    expect(Post._attributeDefinitions.has("age")).toBe(true);
+    expect(declared(Post)).toContain("age");
+    expect(declared(Post)).toContain("age");
     // Accessor stripped.
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "age")).toBeUndefined();
   });
@@ -251,7 +255,7 @@ describe("loadSchemaFromAdapter integration details", () => {
     await Post.loadSchema();
 
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "id")).toBeUndefined();
-    expect(Post._attributeDefinitions.has("id")).toBe(false);
+    expect(declared(Post)).not.toContain("id");
 
     const rec = new Post();
     rec.writeAttribute("id", "abc-123");
@@ -275,7 +279,6 @@ describe("loadSchemaFromAdapter integration details", () => {
     const host = {
       adapter: firstAdapter,
       tableName: "posts",
-      _attributeDefinitions: new Map(),
       prototype: {},
     };
 
@@ -285,7 +288,7 @@ describe("loadSchemaFromAdapter integration details", () => {
     resolveColumns({ guid: { sqlType: "uuid" } });
     await inflight;
 
-    expect(host._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(host)).not.toContain("guid");
   });
 });
 
@@ -300,6 +303,6 @@ describe("set adapter auto-loads schema", () => {
     await Post.loadSchema();
 
     expect(Post.typeForAttribute("guid").name).toBe("uuid");
-    expect(Post._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Post)).not.toContain("guid");
   });
 });

--- a/packages/activerecord/src/model-schema-sync-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.trails.test.ts
@@ -4,10 +4,9 @@ import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
 import { resetColumnInformation } from "./model-schema.js";
 import { declaredAttributeNames } from "./model-schema.js";
-/** The names a class declared with `attribute()`, read off the pending
- * -modification queue the way `columnsHash`' synthesis does. */
+/** The names a class declared with `attribute()`, read off the
+ * pending-modification queue the way `columnsHash`' synthesis does. */
 const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
-
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";

--- a/packages/activerecord/src/model-schema-sync-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.trails.test.ts
@@ -3,6 +3,11 @@ import { ValueType } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
 import { resetColumnInformation } from "./model-schema.js";
+import { declaredAttributeNames } from "./model-schema.js";
+/** The names a class declared with `attribute()` — the pending-queue read that
+ * replaced the retired `_attributeDefinitions` registry. */
+const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
+
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
@@ -33,7 +38,7 @@ describe("sync loadSchema / columnsHash", () => {
     const hash = Post.columnsHash();
 
     expect(hash.guid).toBe(cols.guid);
-    expect(Post._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Post)).not.toContain("guid");
   });
 
   it("columnsHash filters ignoredColumns out of the cached hash", () => {
@@ -81,7 +86,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(Circle._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Circle)).not.toContain("guid");
     expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(true);
     expect(Object.keys(Circle.columnsHash())).toContain("guid");
     // The subclass's own map is its own — but the base reflects too: generating
@@ -114,8 +119,8 @@ describe("sync loadSchema / columnsHash", () => {
 
     // Reflection should have landed on the STI base via subclass adapter;
     // subclass shares the base's map reference.
-    expect(Shape._attributeDefinitions.has("guid")).toBe(false);
-    expect(Circle._attributeDefinitions).toBe(Shape._attributeDefinitions);
+    expect(declared(Shape)).not.toContain("guid");
+    expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(false);
   });
 
   it("columnsHash on STI subclass returns cached Column objects from base adapter", () => {
@@ -165,7 +170,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(true);
     expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
-    expect(Circle._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Circle)).not.toContain("guid");
   });
 
   it("preserves subclass-declared attributes across the subclass's reflection", () => {
@@ -187,10 +192,10 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(Circle._attributeDefinitions.has("guid")).toBe(false);
-    expect(Circle._attributeDefinitions.has("radius")).toBe(true);
-    expect(Shape._attributeDefinitions.has("radius")).toBe(false);
-    expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
+    expect(declared(Circle)).not.toContain("guid");
+    expect(declared(Circle)).toContain("radius");
+    expect(declared(Shape)).not.toContain("radius");
+    expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
   });
 
   it("reflection replaces a stale own columnsHash on the reflecting class", () => {
@@ -320,7 +325,7 @@ describe("sync loadSchema / columnsHash", () => {
     const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
     (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Shape.columnsHash();
-    expect(Shape._attributeDefinitions.has("guid")).toBe(false);
+    expect(declared(Shape)).not.toContain("guid");
 
     (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
 
@@ -339,13 +344,13 @@ describe("sync loadSchema / columnsHash", () => {
     (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Post.columnsHash(); // triggers reflection
 
-    expect(Post._attributeDefinitions.has("guid")).toBe(false);
-    expect(Post._attributeDefinitions.has("title")).toBe(true);
+    expect(declared(Post)).not.toContain("guid");
+    expect(declared(Post)).toContain("title");
 
     (resetColumnInformation as any).call(Post);
 
-    expect(Post._attributeDefinitions.has("guid")).toBe(false);
-    expect(Post._attributeDefinitions.has("title")).toBe(true);
+    expect(declared(Post)).not.toContain("guid");
+    expect(declared(Post)).toContain("title");
   });
 
   // An internalSchemaCache that starts warm and tracks whether resetColumnInformation

--- a/packages/activerecord/src/model-schema-sync-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.trails.test.ts
@@ -4,8 +4,8 @@ import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
 import { resetColumnInformation } from "./model-schema.js";
 import { declaredAttributeNames } from "./model-schema.js";
-/** The names a class declared with `attribute()` — the pending-queue read that
- * replaced the retired `_attributeDefinitions` registry. */
+/** The names a class declared with `attribute()`, read off the pending
+ * -modification queue the way `columnsHash`' synthesis does. */
 const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
 
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -5,6 +5,9 @@ import {
   AttributeSet,
   AttributeSetBuilder,
   YAMLEncoder,
+  PendingDefault,
+  PendingType,
+  type Attribute,
   type Type,
 } from "@blazetrails/activemodel";
 import {
@@ -313,19 +316,92 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   // Synthesized fallback: filter ignoredColumns and virtual attrs to match
   // loadSchema's fallback and Rails behavior (virtual attrs are not DB columns).
   const ignored = new Set(this.ignoredColumns ?? []);
+  const virtual = this._virtualAttributes ?? new Set<string>();
+  const declared = declaredAttributes(this as unknown as SchemaHost);
   const result: Record<string, ColumnLike> = {};
-  for (const [name, def] of this._attributeDefinitions) {
+  for (const name of declared.keys()) {
     if (ignored.has(name)) continue;
-    if ((def as any).virtual) continue;
-    const fn = (def as any).defaultFunction ?? null;
-    result[name] = {
-      name,
-      type: def.type?.name ?? null,
-      default: def.defaultValue ?? null,
-      ...(fn != null ? { defaultFunction: fn } : {}),
-    };
+    if (virtual.has(name)) continue;
+    result[name] = synthesizedColumn(name, declared.getAttribute(name)) as ColumnLike;
   }
   return result;
+}
+
+/**
+ * The attribute set a model's own `attribute()` declarations replay to, with no
+ * schema columns underneath — Rails' `_default_attributes` seeded from an empty
+ * hash instead of `columns_hash` (attribute_registration.rb:53-58 vs
+ * attributes.rb:241-252).
+ *
+ * Rails never needs this: `columns_hash` is a DB read, so a model with no table
+ * simply has no columns. trails supports table-less attribute-only models, whose
+ * `columnsHash` is synthesized from what they declared, and that is the only
+ * thing this feeds. It cannot go through `_defaultAttributes()`, which re-enters
+ * `columnsHash()` on an unreflected class.
+ */
+function declaredAttributes(host: SchemaHost): AttributeSet {
+  const attributeSet = new AttributeSet(new Map<string, Attribute>());
+  applyDeclarations(host, attributeSet);
+  return attributeSet;
+}
+
+/**
+ * `apply_pending_attribute_modifications` (attribute_registration.rb:78-86)
+ * restricted to the two modifications that INTRODUCE an attribute. The
+ * decorators are skipped deliberately: they read the type the column seed put
+ * there, and `enum`'s raises outright when it finds the `Type.default_value`
+ * an unseeded set answers with (enum.ts:164-168).
+ */
+function applyDeclarations(cls: SchemaHost, attributeSet: AttributeSet): void {
+  const superclass = Object.getPrototypeOf(cls) as
+    | (SchemaHost & { _defaultAttributes?: unknown; _pendingAttributeModifications?: unknown[] })
+    | null;
+  if (superclass && typeof superclass._defaultAttributes === "function") {
+    applyDeclarations(superclass, attributeSet);
+  }
+  if (!Object.hasOwn(cls, "_pendingAttributeModifications")) return;
+  const pending = (cls as { _pendingAttributeModifications?: unknown[] })
+    ._pendingAttributeModifications;
+  for (const modification of pending ?? []) {
+    if (modification instanceof PendingType || modification instanceof PendingDefault) {
+      modification.applyTo(attributeSet);
+    }
+  }
+}
+
+/**
+ * The names this model declared with `attribute()`, its ancestors' included.
+ *
+ * @internal
+ * @noRailsEquivalent CONVERGEABLE — feeds `ensureSchemaLoaded`'s reflection
+ * gate, itself a trails-only bridge for Rails' synchronous `load_schema!`.
+ */
+export function declaredAttributeNames(this: SchemaHost): string[] {
+  return declaredAttributes(this).keys();
+}
+
+/**
+ * The own, copy-on-write virtual-attribute name set for `host` — the same
+ * per-class fork `attribute()` does, so a subclass never mutates its parent's.
+ */
+function ownVirtualAttributes(host: SchemaHost): Set<string> {
+  if (!Object.hasOwn(host, "_virtualAttributes")) {
+    host._virtualAttributes = new Set(host._virtualAttributes);
+  }
+  return host._virtualAttributes as Set<string>;
+}
+
+/**
+ * `columnsHash`-shaped metadata for one declared attribute.
+ */
+function synthesizedColumn(name: string, attribute: Attribute): Record<string, unknown> {
+  const type = attribute.type as Type & { limit?: number | null };
+  return {
+    name,
+    type: type?.name ?? null,
+    default: attribute.valueBeforeTypeCast ?? null,
+    limit: type?.limit ?? null,
+  };
 }
 
 type DatabaseAdapterLike = { internalSchemaCache?: unknown };
@@ -494,6 +570,7 @@ export async function createTable(this: typeof Base): Promise<void> {
   const isPg = adapterName === "postgres";
   const pkSet = new Set(pks);
   const a = this.connection;
+  const declared = declaredAttributes(this);
 
   // eslint-disable-next-line blazetrails/no-raw-sql -- DDL: Arel has no schema-statement nodes; Rails builds this SQL as a string too.
   await a.execute(`DROP TABLE IF EXISTS ${a.quoteTableName(table)}`);
@@ -509,15 +586,14 @@ export async function createTable(this: typeof Base): Promise<void> {
     colDefs.push(pkDef);
   } else {
     for (const pk of pks) {
-      const pkDef = this._attributeDefinitions.get(pk);
-      const pkType = sqlTypeFor(pkDef?.type?.name || "integer", adapterName);
+      const pkType = sqlTypeFor(declared.getAttribute(pk).type?.name || "integer", adapterName);
       colDefs.push(`${a.quoteColumnName(pk)} ${pkType} NOT NULL`);
     }
   }
 
-  for (const [name, def] of this._attributeDefinitions) {
+  for (const name of declared.keys()) {
     if (pkSet.has(name)) continue;
-    const sqlType = sqlTypeFor(def.type?.name || "string", adapterName);
+    const sqlType = sqlTypeFor(declared.getAttribute(name).type?.name || "string", adapterName);
     colDefs.push(`${a.quoteColumnName(name)} ${sqlType}`);
   }
 
@@ -560,7 +636,7 @@ export interface SchemaHost {
   _abstractClass?: boolean;
   _ignoredColumns?: string[];
   _protectedEnvironments?: string[];
-  _attributeDefinitions: Map<string, any>;
+  _virtualAttributes?: Set<string>;
   _defaultAttributes(): AttributeSet;
   _columnsHash?: Record<string, unknown>;
   _columns?: any[];
@@ -944,7 +1020,7 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
  * Mirrors: ActiveRecord::ModelSchema#load_schema
  *
  * Sync: consults the adapter's schema cache if it's already populated
- * (no I/O), and reflects columns into `_attributeDefinitions`. For
+ * (no I/O), and reflects columns into `columnsHash`. For
  * models without a backing table (test fixtures with only user
  * `attribute()` declarations), falls back to synthesizing `_columnsHash`
  * from existing defs so downstream readers continue to work.
@@ -1023,32 +1099,28 @@ function loadSchemaBangAnchor(this: SchemaHost): void {
   // columns once a cache entry exists. The find path passing the raw string id
   // to the bind for a tableless model in the meantime is harmless — there is
   // no DB column type to cast through.
+  const declared = declaredAttributes(this);
+  const declaredNames = declared.keys();
   let pkStillMissing = false;
-  if (this._attributeDefinitions.size > 0) {
+  if (declaredNames.length > 0) {
     const pks = Array.isArray(this.primaryKey)
       ? this.primaryKey
       : this.primaryKey != null
         ? [this.primaryKey]
         : [];
-    if (pks.some((pk) => !this._attributeDefinitions.has(pk))) {
+    if (pks.some((pk) => !declaredNames.includes(pk))) {
       pkStillMissing = true;
     }
   }
 
-  if (!ownSchemaMemo(this, "_columnsHash") && this._attributeDefinitions.size > 0) {
+  if (!ownSchemaMemo(this, "_columnsHash") && declaredNames.length > 0) {
     const hash: Record<string, unknown> = {};
     const ignored = new Set(this._ignoredColumns ?? []);
-    for (const [name, def] of this._attributeDefinitions) {
+    const virtual = this._virtualAttributes ?? new Set<string>();
+    for (const name of declaredNames) {
       if (ignored.has(name)) continue;
-      if (def.virtual) continue;
-      const fn = def.defaultFunction ?? null;
-      hash[name] = {
-        name,
-        type: def.type?.name ?? null,
-        default: def.defaultValue ?? null,
-        limit: def.limit ?? null,
-        ...(fn != null ? { defaultFunction: fn } : {}),
-      };
+      if (virtual.has(name)) continue;
+      hash[name] = synthesizedColumn(name, declared.getAttribute(name));
     }
     this._columnsHash = hash;
   }
@@ -1358,9 +1430,10 @@ export async function reconcileVirtualAttributes(this: SchemaHost, reflect = fal
   if (ownSchemaMemo(host, "_virtualAttributesReconciled")) return;
   const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
   if (!real) return;
-  for (const [name, def] of host._attributeDefinitions) {
-    const isVirtual = !real.has(name);
-    if (!!def.virtual !== isVirtual) def.virtual = isVirtual;
+  const virtual = ownVirtualAttributes(host);
+  for (const name of declaredAttributes(host).keys()) {
+    if (real.has(name)) virtual.delete(name);
+    else virtual.add(name);
   }
   host._virtualAttributesReconciled = true;
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -335,9 +335,8 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
  *
  * Rails never needs this: `columns_hash` is a DB read, so a model with no table
  * simply has no columns. trails supports table-less attribute-only models, whose
- * `columnsHash` is synthesized from what they declared, and that is the only
- * thing this feeds. It cannot go through `_defaultAttributes()`, which re-enters
- * `columnsHash()` on an unreflected class.
+ * `columnsHash` is synthesized from what they declared. It cannot go through
+ * `_defaultAttributes()`, which re-enters `columnsHash()` on an unreflected class.
  */
 function declaredAttributes(host: SchemaHost): AttributeSet {
   const attributeSet = new AttributeSet(new Map<string, Attribute>());
@@ -360,9 +359,8 @@ function applyDeclarations(cls: SchemaHost, attributeSet: AttributeSet): void {
     applyDeclarations(superclass, attributeSet);
   }
   if (!Object.hasOwn(cls, "_pendingAttributeModifications")) return;
-  const pending = (cls as { _pendingAttributeModifications?: unknown[] })
-    ._pendingAttributeModifications;
-  for (const modification of pending ?? []) {
+  for (const modification of (cls as unknown as { _pendingAttributeModifications: unknown[] })
+    ._pendingAttributeModifications) {
     if (modification instanceof PendingType || modification instanceof PendingDefault) {
       modification.applyTo(attributeSet);
     }
@@ -392,7 +390,7 @@ function ownVirtualAttributes(host: SchemaHost): Set<string> {
 }
 
 /**
- * `columnsHash`-shaped metadata for one declared attribute.
+ * One declared attribute in the shape `columnsHash`' readers expect of a column.
  */
 function synthesizedColumn(name: string, attribute: Attribute): Record<string, unknown> {
   const type = attribute.type as Type & { limit?: number | null };
@@ -1023,7 +1021,7 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
  * (no I/O), and reflects columns into `columnsHash`. For
  * models without a backing table (test fixtures with only user
  * `attribute()` declarations), falls back to synthesizing `_columnsHash`
- * from existing defs so downstream readers continue to work.
+ * from the declarations so downstream readers continue to work.
  *
  * For a full async reflection (fetching from the adapter if the cache
  * isn't populated), call `Base.loadSchema()` (base.ts).

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -19,9 +19,9 @@ describe("MultiParameterAttributeTest", () => {
   fixtures(["topics"]);
 
   beforeAll(async () => {
-    // Eagerly populate Topic._attributeDefinitions from the warm pool schema cache.
+    // Eagerly populate Topic's columnsHash from the warm pool schema cache.
     // Without this, the sync loadSchema path runs before the cache is applied to the
-    // model class and marks _schemaLoaded=true with empty _attributeDefinitions.
+    // model class and marks _schemaLoaded=true with no columns.
     await Topic.loadSchema();
   });
 

--- a/packages/activerecord/src/normalized-attribute.trails.test.ts
+++ b/packages/activerecord/src/normalized-attribute.trails.test.ts
@@ -3,7 +3,7 @@
  * subclass's attribute types. Rails keeps this per-class (`normalized_attributes`
  * is a `class_attribute` and `_default_attributes` replays only the class's own
  * pending decorators), but trails' STI reflection installed the base's shared
- * `_attributeDefinitions` map as an OWN property of the subclass, so a
+ * pending-modification queue as an OWN property of the subclass, so a
  * subclass decoration could land on the base and leak to sibling subclasses.
  * The decorated type is read where Rails reads it — `type_for_attribute` over
  * the replayed attribute set (attribute_registration.rb:43-51).

--- a/packages/activerecord/src/persistence.trails.test.ts
+++ b/packages/activerecord/src/persistence.trails.test.ts
@@ -196,13 +196,13 @@ describe("PersistenceTest (trails)", () => {
   // per-class off the class's own `table_name`, model_schema.rb): the residual
   // case PR #4680 left uncovered. A non-STI subclass that overrides
   // `_tableName` AND declares an `attribute()` before its first reflection
-  // forks its own `_attributeDefinitions`, copying the ancestor's foreign
+  // forks its own pending-modification queue, copying the ancestor's foreign
   // schema defs. `ensureSchemaLoaded` must still reflect the subclass's own
   // table rather than trusting those copied defs and silently dropping writes.
   // Mirrors `persist inherited class with different table name` (the Rails
   // test in persistence.test.ts) plus a predeclared virtual attribute.
   it("persist inherited class with different table name and predeclared attribute", async () => {
-    // Reflect the ancestor first so its `_attributeDefinitions` holds
+    // Reflect the ancestor first so its `columnsHash` holds
     // schema-sourced defs for the `minimalistics` table — the state the
     // subclass's map is forked from.
     await Minimalistic.create({});

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -945,7 +945,7 @@ describe("ReflectionTest", () => {
 
       static {
         // Use a table absent from the canonical schema so columnsHash() falls
-        // back to _attributeDefinitions instead of the DB schema cache.
+        // back to the declared attributes instead of the DB schema cache.
         this._tableName = "refl_articles";
         this.attribute("title", "string");
       }

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -234,7 +234,7 @@ describe("ReflectionTest", () => {
   it("columns reports the column's own type, not the decorated cast type", async () => {
     // Rails' `columns` is `columns_hash.values` (model_schema.rb:432-434) —
     // schema-sourced, never attribute-decorated. trails previously built it
-    // from `_attributeDefinitions[].type.constructor.name`, so a decorated
+    // from the declared attribute's `type.constructor.name`, so a decorated
     // column (serialize + encrypts here) reported the wrapper class instead
     // of the column's own type.
     const configSnapshot = snapshotEncryptionConfig();

--- a/packages/activerecord/src/serialize.ts
+++ b/packages/activerecord/src/serialize.ts
@@ -171,6 +171,6 @@ export function serialize(
   // `_defaultAttributes` rebuild, so the query-side lookup (`type_for_attribute` /
   // `TypeCaster::Map`), which now resolves through `attribute_types` (the decorated
   // default attribute set), sees the `Serialized` cast type once columns reflect —
-  // no per-feature `_attributeDefinitions` replay needed.
+  // no per-feature post-reflection replay needed.
   modelClass.decorateAttributes([attribute], decorator);
 }

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
 import { declaredAttributeNames } from "./model-schema.js";
-/** The names a class declared with `attribute()`, read off the pending
- * -modification queue the way `columnsHash`' synthesis does. */
+/** The names a class declared with `attribute()`, read off the
+ * pending-modification queue the way `columnsHash`' synthesis does. */
 const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
-
 
 describe("STI subclass attribute() registration", () => {
   it("keeps subclass attribute() calls on the subclass, not the STI base", () => {

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
+import { declaredAttributeNames } from "./model-schema.js";
+/** The names a class declared with `attribute()` — the pending-queue read that
+ * replaced the retired `_attributeDefinitions` registry. */
+const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
+
 
 describe("STI subclass attribute() registration", () => {
   it("keeps subclass attribute() calls on the subclass, not the STI base", () => {
@@ -15,10 +20,10 @@ describe("STI subclass attribute() registration", () => {
       }
     }
 
-    expect(Circle._attributeDefinitions.has("radius")).toBe(true);
-    expect(Shape._attributeDefinitions.has("radius")).toBe(false);
+    expect(declared(Circle)).toContain("radius");
+    expect(declared(Shape)).not.toContain("radius");
 
-    expect(Object.prototype.hasOwnProperty.call(Circle, "_attributeDefinitions")).toBe(true);
+    expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
   });
 
   it("still forks the STI base itself (non-subclass) on attribute() — unchanged", () => {
@@ -31,8 +36,8 @@ describe("STI subclass attribute() registration", () => {
     }
 
     // Shape IS the STI base (not a subclass), so its map is its own.
-    expect(Object.prototype.hasOwnProperty.call(Shape, "_attributeDefinitions")).toBe(true);
-    expect(Shape._attributeDefinitions.has("name")).toBe(true);
+    expect(Object.hasOwn(Shape, "_pendingAttributeModifications")).toBe(true);
+    expect(declared(Shape)).toContain("name");
   });
 
   it("non-STI classes are unaffected", () => {
@@ -42,8 +47,8 @@ describe("STI subclass attribute() registration", () => {
       }
     }
 
-    expect(Object.prototype.hasOwnProperty.call(Widget, "_attributeDefinitions")).toBe(true);
-    expect(Widget._attributeDefinitions.has("price")).toBe(true);
+    expect(Object.hasOwn(Widget, "_pendingAttributeModifications")).toBe(true);
+    expect(declared(Widget)).toContain("price");
   });
 
   it("STI subclass attribute declared AFTER base inherits the base's attrs too", () => {
@@ -60,9 +65,9 @@ describe("STI subclass attribute() registration", () => {
       }
     }
 
-    expect(Triangle._attributeDefinitions.get("name")?.type.name).toBe("string");
-    expect(Triangle._attributeDefinitions.get("sides")?.type.name).toBe("integer");
-    expect(Shape._attributeDefinitions.has("sides")).toBe(false);
+    expect(Triangle.typeForAttribute("name").name).toBe("string");
+    expect(Triangle.typeForAttribute("sides").name).toBe("integer");
+    expect(declared(Shape)).not.toContain("sides");
   });
 
   it("STI subclass encrypts() stays on the subclass, unlike attribute()", async () => {
@@ -133,8 +138,8 @@ describe("STI subclass attribute() registration", () => {
     await (loadSchemaFromAdapter as unknown as (this: typeof Base) => Promise<void>).call(Circle);
 
     expect(Shape.typeForAttribute("guid").name).toBe("uuid");
-    expect(Shape._attributeDefinitions.has("radius")).toBe(false);
-    expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
+    expect(declared(Shape)).not.toContain("radius");
+    expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
     expect(Circle.typeForAttribute("radius").name).toBe("integer");
     expect(Circle.typeForAttribute("guid").name).toBe("uuid");
   });
@@ -160,17 +165,17 @@ describe("STI subclass attribute() registration", () => {
       }
     }
 
-    expect(Object.prototype.hasOwnProperty.call(Ticket, "_attributeDefinitions")).toBe(true);
-    expect(Ticket._attributeDefinitions.get("priority")?.type.name).toBe("integer");
-    expect(Shape._attributeDefinitions.has("priority")).toBe(false);
-    expect(Circle._attributeDefinitions.has("priority")).toBe(false);
+    expect(Object.hasOwn(Ticket, "_pendingAttributeModifications")).toBe(true);
+    expect(Ticket.typeForAttribute("priority").name).toBe("integer");
+    expect(declared(Shape)).not.toContain("priority");
+    expect(declared(Circle)).not.toContain("priority");
 
-    expect(Circle._attributeDefinitions).not.toBe(Shape._attributeDefinitions);
-    expect(Shape._attributeDefinitions.has("radius")).toBe(false);
-    expect(Circle._attributeDefinitions.get("radius")?.type.name).toBe("integer");
+    expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
+    expect(declared(Shape)).not.toContain("radius");
+    expect(Circle.typeForAttribute("radius").name).toBe("integer");
 
     // Inherited (shared-ancestor) declarations remain visible on the descendant.
-    expect(Ticket._attributeDefinitions.get("radius")?.type.name).toBe("integer");
+    expect(Ticket.typeForAttribute("radius").name).toBe("integer");
   });
   it("own-table descendant does not clobber the STI base's attributesBuilder cache", () => {
     class Shape extends Base {

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
 import { declaredAttributeNames } from "./model-schema.js";
-/** The names a class declared with `attribute()` — the pending-queue read that
- * replaced the retired `_attributeDefinitions` registry. */
+/** The names a class declared with `attribute()`, read off the pending
+ * -modification queue the way `columnsHash`' synthesis does. */
 const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
 
 

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -18,10 +18,10 @@ export class Map {
     // Rails' `model.type_caster` (TypeCaster::Map → `klass.type_for_attribute`)
     // is EnumType-aware: an enum attribute serializes the label → its stored
     // database value. Resolve the enum through `enumTypeOf` (the replayed
-    // AttributeSet) rather than the local `_attributeDefinitions` O(1) cache:
-    // that cache keeps the pre-reflection EnumType, whose subtype was inferred
-    // from the mapping shape, whereas the AttributeSet carries the EnumType
-    // built from the reflected column type. `whereValuesHash` / `scopeForCreate`
+    // AttributeSet) rather than the `PendingType` the declaration pushed: that
+    // type is the pre-reflection EnumType, whose subtype was inferred from the
+    // mapping shape, whereas the AttributeSet carries the EnumType built from
+    // the reflected column type. `whereValuesHash` / `scopeForCreate`
     // round-trip the label through the same reflected type.
     const enumType = enumTypeOf(this._klass, String(attrName));
     if (enumType) return enumType.serialize(value);
@@ -47,8 +47,8 @@ export class Map {
     // alias resolution and the decorated
     // default attribute set (`attribute_types`) for free — so pending decorators
     // (serialize/normalizes/encrypts) are honored on the query side without a
-    // per-feature post-reflection replay onto `_attributeDefinitions`. `ValueType`
-    // is the fallback for non-model `klass` shapes lacking `typeForAttribute`.
+    // per-feature post-reflection replay. `ValueType` is the fallback for
+    // non-model `klass` shapes lacking `typeForAttribute`.
     if (typeof klass.typeForAttribute === "function") {
       return klass.typeForAttribute(name) as Type;
     }


### PR DESCRIPTION
Rails keeps no class-level registry of user attribute declarations. `attribute`
pushes a `PendingType` / `PendingDefault` onto the pending-modification queue and
does nothing else (`activemodel/lib/active_model/attribute_registration.rb:12-20`),
and every reader derives from `_default_attributes` / `attribute_types`.

`retire-attribute-definitions-registry-for-default-attributes` (#6948) already took
schema-reflected columns out of `_attributeDefinitions`. This retires the map itself,
along with the `AttributeDefinition` interface.

### Writer

`ActiveModel::AttributeRegistration::ClassMethods#attribute` converges to the Rails
body: no copy-on-write fork, and no `existing` lookup for the type or the default.
Both were only there to keep the registry coherent — the replay already resolves them
(`type || attribute.type`, `attribute_registration.rb:72`), which is exactly why Rails'
`PendingType#type` is nilable.

### Readers

The four ActiveRecord readers — the table-less `columnsHash` synthesis, the same
synthesis in `loadSchemaBang`, the `createTable` DDL helper, and
`reconcileVirtualAttributes` — plus `ensureSchemaLoaded`'s declaration-scan gate now
resolve through `declaredAttributes`: `_default_attributes` seeded from an empty hash
rather than `columns_hash` (`attribute_registration.rb:53-58` vs
`attributes.rb:241-252`). It cannot go through `_defaultAttributes()` itself, which
re-enters `columnsHash()` on an unreflected class.

The replay is restricted to `PendingType` / `PendingDefault`, the two modifications
that introduce an attribute. Decorators are skipped deliberately: they read the type
the column seed put there, and `enum`'s raises outright on the `Type.default_value`
an unseeded set answers with (`enum.ts:164-168`).

### `virtual`

trails' `attribute(..., { virtual: true })` has no Rails counterpart — Rails'
`columns_hash` is a DB read, so a column-less declaration is simply absent from it,
while trails synthesizes `columnsHash` for table-less models and has to be told which
declarations are not columns. The flag moves out of the retired map into
`Base._virtualAttributes`, a name set carrying `@noRailsEquivalent CONVERGEABLE`;
RFC 0115 `retire-virtual-attribute-reconciliation` removes it with the rest of the
virtual machinery.

### Gates

`parity:api:calls` / `:args` clean, `parity:api:extra:gate` unchanged
(activerecord novel 376/376), parity deltas non-negative. 397 LOC.

Closes-story: retire-remaining-attribute-definitions-registry
