### PR TITLE
refactor(activerecord): MySQL casts through the inherited type_map, constructor-only statement limit, inlined scope_for_create (RFC 0112)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -45,19 +45,20 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     });
 
     it("statement pool max evicts LRU via unprepare", async () => {
+      // Rails' matching test sets statement_limit = 1 and asserts LRU
+      // eviction. The limit is constructor-only (statement_pool.rb:10-13), so
+      // the adapter is built at the limit under test; eviction happens on the
+      // second insert via Mysql2StatementPool#dealloc (conn.unprepare).
+      const adapter = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 1 });
+      adapter.preparedStatements = true;
       await adapter.beginDbTransaction();
       try {
         await adapter.execute("SELECT ? AS n", [1]);
-        const pool = adapter._statements!;
-        // Rails' matching test sets statement_limit = 1 and asserts
-        // LRU eviction. With one cached statement, setMaxSize(1) just
-        // records the new limit; eviction happens on the next insert
-        // via our Mysql2StatementPool#dealloc (conn.unprepare).
-        await pool.setMaxSize(1);
         await adapter.execute("SELECT ? AS s", ["a"]);
-        expect(pool.length).toBe(1);
+        expect(adapter._statements!.length).toBe(1);
       } finally {
         await adapter.rollback();
+        await adapter.close();
       }
     });
 
@@ -107,7 +108,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
 
     it("reads statementLimit from the config hash (database.yml shape)", async () => {
       const configured = new Mysql2Adapter({ uri: MYSQL_TEST_URL, statementLimit: 7 });
-      expect(configured.buildStatementPool().maxSize).toBe(7);
+      const pool = configured.buildStatementPool();
+      expect((pool as unknown as { _statementLimit: number })._statementLimit).toBe(7);
       await configured.close();
     });
 

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -33,17 +33,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("statement pool max", async () => {
-      await adapter.beginDbTransaction();
+      // Rails' matching test sets statement_limit = 1 and asserts LRU
+      // eviction. The limit is constructor-only (statement_pool.rb:10-13), so
+      // the adapter is built at the limit under test.
+      const limited = new PostgreSQLAdapter({ connectionString: PG_TEST_URL, statementLimit: 1 });
+      await limited.beginDbTransaction();
       try {
-        await adapter.execute("SELECT $1::int", [1]);
-        const pool = adapter._statements;
-        // Rails' matching test sets statement_limit = 1 and asserts
-        // LRU eviction. setMaxSize immediately evicts excess entries.
-        await pool.setMaxSize(1);
-        await adapter.execute("SELECT $1::text", ["a"]);
-        expect(pool.length).toBe(1);
+        await limited.execute("SELECT $1::int", [1]);
+        await limited.execute("SELECT $1::text", ["a"]);
+        expect(limited._statements.length).toBe(1);
       } finally {
-        await adapter.rollback();
+        await limited.rollback();
+        await limited.close();
       }
     });
 
@@ -128,7 +129,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         statementLimit: 7,
       });
       await configured.execute("SELECT $1::int", [1]);
-      expect(configured._statements.maxSize).toBe(7);
+      const pool = configured._statements;
+      expect((pool as unknown as { _statementLimit: number })._statementLimit).toBe(7);
       await configured.close();
     });
 

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
@@ -19,7 +19,8 @@ describeIfSqlite("SQLite3StatementPoolTest", () => {
 
   it("reads statementLimit from the options hash", () => {
     const adapter = track(new BetterSQLite3Adapter(":memory:", { statementLimit: 7 }));
-    expect(adapter.buildStatementPool().maxSize).toBe(7);
+    const pool = adapter.buildStatementPool();
+    expect((pool as unknown as { _statementLimit: number })._statementLimit).toBe(7);
   });
 
   it("reads preparedStatements from the options hash", () => {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -236,7 +236,7 @@ describe("BasicsTest", () => {
       }
     }
     const rel = User.where({ name: "test" });
-    const attrs = (rel as any)._scopeAttributes ? (rel as any)._scopeAttributes() : {};
+    const attrs = rel.scopeForCreate();
     expect(attrs.name).toBe("test");
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2249,12 +2249,8 @@ export class AbstractAdapter implements Quoting {
    *
    * Rails additionally declares `TYPE_MAP` on `Mysql2Adapter`
    * (mysql2_adapter.rb:53) and `SQLite3Adapter` (sqlite3_adapter.rb:505), plus
-   * `EXTENDED_TYPE_MAPS` on `SQLite3Adapter` (506). SQLite3 declares both now;
-   * `Mysql2Adapter` still declares neither, so it seeds its extended map from
-   * this base map and shares this `EXTENDED_TYPE_MAPS` — inert only because it
-   * resolves casts through the invented `_buildTypeMap` path, which is exactly
-   * what `mysql-native-type-map-converges-onto-type-map` deletes. That story
-   * must add the missing declaration in the same change.
+   * `EXTENDED_TYPE_MAPS` on `SQLite3Adapter` (506) and `AbstractMysqlAdapter`
+   * (abstract_mysql_adapter.rb:754); each is declared on its own class here too.
    *
    * Built on first read rather than at class-definition time because the type
    * classes `initializeTypeMap` registers sit on a circular import edge and are

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.trails.test.ts
@@ -89,6 +89,11 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     const queries: [string, string | null | undefined][] = [];
     adapter.supportsRenameColumn = () => false;
     adapter.pool = new NullPool();
+    // Object.create skips the constructor, which is what assigns `@config`
+    // (abstract_adapter.rb:139); `new_column_from_field` reaches
+    // `lookup_cast_type` → `extended_type_map_key`, which reads a
+    // config-derived `default_timezone` (abstract_mysql_adapter.rb:763).
+    adapter._config = {};
     adapter.getDatabaseVersion = async () => {};
     adapter.quoteColumnName = (s: string) => `\`${s}\``;
     adapter.quoteTableName = (s: string) => `\`${s}\``;
@@ -422,8 +427,11 @@ async function makeMinimalMysqlAdapter(overrides: Record<string, unknown> = {}) 
   const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
   const adapter = Object.create(AbstractMysqlAdapter.prototype);
   // Object.create skips the constructor, which is what plants Rails' NullPool
-  // (abstract_adapter.rb:153); every adapter carries one.
+  // (abstract_adapter.rb:153) and `@config` (abstract_adapter.rb:139); every
+  // adapter carries both, and `extended_type_map_key` reads a config-derived
+  // `default_timezone` (abstract_mysql_adapter.rb:763).
   adapter.pool = new NullPool();
+  adapter._config = {};
   adapter.quoteColumnName = (s: string) => `\`${s}\``;
   adapter.quoteTableName = (s: string) => `\`${s}\``;
   Object.assign(adapter, overrides);

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -896,10 +896,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return sql;
   }
 
-  /** @internal Mirrors: AbstractMysqlAdapter#text_type? */
+  /**
+   * @internal Mirrors: Mysql2Adapter#text_type? (mysql2_adapter.rb:140-142) —
+   * `TYPE_MAP.lookup(type)`, resolved off the concrete adapter class so the
+   * mysql2 map (mysql2_adapter.rb:53) is the one consulted.
+   */
   isTextType(type: string): boolean {
-    const t = this._nativeTypeMap.lookup(type.toLowerCase().trim());
-    return t instanceof StringType || t instanceof TextType;
+    const TYPE_MAP = (this.constructor as typeof AbstractMysqlAdapter).TYPE_MAP;
+    return TYPE_MAP.lookup(type) instanceof StringType || TYPE_MAP.lookup(type) instanceof TextType;
   }
 
   highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
@@ -1246,26 +1250,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return args;
   }
 
-  /**
-   * Rails builds the adapter's type map with `initialize_type_map(m)` on a
-   * fresh `TypeMap` (abstract_mysql_adapter.rb:711). trails keeps that Rails
-   * name for the registration pass and puts the allocate-then-register wrapper
-   * behind the Rails-private `_` prefix, matching the already-converged
-   * spelling on `SQLite3Adapter._buildTypeMap`.
-   */
-  protected static _buildTypeMap(
-    this: typeof AbstractMysqlAdapter,
-    options: { emulateBooleans?: boolean } = {},
-  ): TypeMap {
-    const map = new TypeMap();
-    this.initializeTypeMap(map);
-    if (options.emulateBooleans) {
-      map.registerType(/^tinyint\(1\)/i, undefined, () => new BooleanType());
-    }
-    return map;
-  }
-
-  private _typeMap: TypeMap | null = null;
   private _emulateBooleans = true;
 
   get emulateBooleans(): boolean {
@@ -1274,50 +1258,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   set emulateBooleans(value: boolean) {
     this._emulateBooleans = value;
-    // Rails' `emulate_booleans=` is a plain class_attribute; its type map is
-    // memoized per emulate_booleans value (EXTENDED_TYPE_MAPS). trails caches a
-    // single map, so drop it here to rebuild against the new setting. Reflected
-    // columns are invalidated separately by `resetColumnInformation` (the
-    // table-scoped `clear_data_source_cache!` Rails calls there) — the toggle's
-    // caller pairs the two, mirroring `mysql_boolean_test.rb`'s
-    // `emulate_booleans` helper.
-    this._typeMap = null;
-  }
-
-  /**
-   * The memoized native type map. Rails reaches it through the adapter's own
-   * `type_map` (abstract_adapter.rb) and never exposes a separate public
-   * accessor, so this stays Rails-private (`_` prefix) — the same spelling
-   * `SQLite3Adapter` uses for its `_nativeTypeMap` slot.
-   */
-  get _nativeTypeMap(): TypeMap {
-    if (!this._typeMap) {
-      this._typeMap = (this.constructor as typeof AbstractMysqlAdapter)._buildTypeMap({
-        emulateBooleans: this._emulateBooleans,
-      });
-    }
-    return this._typeMap;
-  }
-
-  /**
-   * A divergent override, NOT a port: Rails defines `lookup_cast_type` only at
-   * `abstract/quoting.rb:234-236` and `postgresql/quoting.rb:195` — never on a
-   * MySQL adapter — so the inherited one is what Rails runs here. This
-   * override and the `_nativeTypeMap` / `_buildTypeMap` slots behind it are a
-   * trails invention, as is `lookupCastTypeFromColumn`'s null return for an
-   * empty sql_type. Deliberately left flagged rather than tagged: converging
-   * them is `mysql-native-type-map-converges-onto-type-map`.
-   */
-  lookupCastType(sqlType: string | null): import("@blazetrails/activemodel").Type {
-    return this._nativeTypeMap.lookup(sqlType?.toLowerCase().trim() ?? null);
-  }
-
-  lookupCastTypeFromColumn(column: {
-    sqlType?: string | null;
-  }): import("@blazetrails/activemodel").Type | null {
-    const sqlType = column.sqlType?.trim();
-    if (!sqlType) return null;
-    return this.lookupCastType(sqlType);
   }
 
   /** @internal Mirrors: AbstractMysqlAdapter::EXTENDED_TYPE_MAPS (abstract_mysql_adapter.rb:754) */

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -4,6 +4,7 @@
 import { it, expect, beforeEach } from "vitest";
 import { Mysql2Adapter } from "./mysql2-adapter.js";
 import { describeIfMysqlAdapter } from "../support/describe-if-mysql-adapter.js";
+import type { Type } from "@blazetrails/activemodel";
 
 // Minimal subclass of the *concrete* Mysql2Adapter — char/varchar/enum/set
 // string registrations live on the concrete adapter (mysql2_adapter.rb:40-49),
@@ -27,7 +28,7 @@ beforeEach(() => {
 });
 
 function assertLookupType(expected: string, lookup: string) {
-  const castType = adapter.lookupCastType(lookup);
+  const castType = adapter.lookupCastType(lookup) as Type;
   expect(castType.type()).toBe(expected);
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -342,12 +342,10 @@ export async function defaultRowFormat(this: RowFormatHost): Promise<string | nu
  */
 export interface MysqlColumnReflectionHost {
   createTableInfo(tableName: string): Promise<string | null>;
-  lookupCastType?(sqlType: string): {
-    name: string;
-    limit?: number | null;
-    precision?: number | null;
-    scale?: number | null;
-  };
+  // `AbstractAdapter#lookup_cast_type` (abstract/quoting.rb:234) returns a
+  // `Type`; the widened return here carries `PostgreSQLAdapter`'s awaitable
+  // one, which never reaches this MySQL-only host.
+  lookupCastType?(sqlType: string | null): unknown;
 }
 
 /**
@@ -388,7 +386,15 @@ export async function newColumnFromField(
   const meta = fetchTypeMetadata(
     field["Type"] ?? "",
     field["Extra"] ?? "",
-    this.lookupCastType ? (sqlType) => this.lookupCastType!(sqlType) : undefined,
+    this.lookupCastType
+      ? (sqlType) =>
+          this.lookupCastType!(sqlType) as {
+            name: string;
+            limit?: number | null;
+            precision?: number | null;
+            scale?: number | null;
+          }
+      : undefined,
   );
   let def: string | null = field["Default"] ?? null;
   let defFn: string | null = null;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -76,6 +76,8 @@ class Mysql2StatementPool extends MysqlStatementPool {
   }
 }
 
+let mysql2TypeMap: TypeMap | null = null;
+
 /**
  * MySQL adapter — connects ActiveRecord to a real MySQL/MariaDB database.
  *
@@ -125,6 +127,21 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     });
     m.registerType(/^enum/i, Type.lookup("string", { adapter: "mysql2" }));
     m.registerType(/^set/i, Type.lookup("string", { adapter: "mysql2" }));
+  }
+
+  /**
+   * @internal Mirrors: Mysql2Adapter::TYPE_MAP (mysql2_adapter.rb:53)
+   *
+   * Declared here, as in Rails, so `self::TYPE_MAP` inside `extended_type_map`
+   * resolves to the mysql2 map rather than the abstract one. Built on first
+   * read for the same temporal-dead-zone reason `AbstractAdapter::TYPE_MAP` is.
+   */
+  static override get TYPE_MAP(): TypeMap {
+    return (mysql2TypeMap ??= (() => {
+      const m = new TypeMap();
+      Mysql2Adapter.initializeTypeMap(m);
+      return m;
+    })());
   }
 
   // Mirrors Rails' Mysql2Adapter#active? (mysql2_adapter.rb:108), whose body is

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -365,7 +365,7 @@ export async function performQuery(
  * @internal
  */
 export function castResult(
-  this: { lookupCastType(sqlType: string): Type },
+  this: { lookupCastType(sqlType: string): Type | Promise<Type> | null },
   rawResult: Mysql2RawResult,
 ): Result {
   if (rawResult.rows == null) return Result.empty();
@@ -381,7 +381,10 @@ export function castResult(
       : new Result(
           fields.map((f) => f.name),
           rawResult.rows,
-          buildColumnTypes(fields, (t) => this.lookupCastType(t)),
+          // MySQL's `lookup_cast_type` is the plain type-map lookup
+          // (abstract/quoting.rb:234-236); only PostgreSQL's override is
+          // awaitable, and it never reaches this MySQL-only helper.
+          buildColumnTypes(fields, (t) => this.lookupCastType(t) as Type),
         );
 
   freeRawResult(rawResult);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.hash-constructor.trails.test.ts
@@ -43,7 +43,8 @@ describe("SQLite3Adapter hash-only constructor", () => {
   it("threads adapter options from the config hash", () => {
     adapter = new BetterSQLite3Adapter({ database: ":memory:", strict: true, statementLimit: 7 });
     expect(adapter._strictStrings).toBe(true);
-    expect(adapter.buildStatementPool().maxSize).toBe(7);
+    const pool = adapter.buildStatementPool();
+    expect((pool as unknown as { _statementLimit: number })._statementLimit).toBe(7);
   });
 
   it("raises ArgumentError when the config hash has no database", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -418,9 +418,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
       );
     if (options.statementLimit !== undefined) {
       this._statementLimit = options.statementLimit;
-      void this._statements.setMaxSize(
-        SQLite3Adapter.typeCastConfigToInteger(this._statementLimit) as number,
-      );
+      // `@statements = build_statement_pool` runs after `@config` is assigned
+      // (abstract_adapter.rb:156); the TS field initializer above runs before
+      // this constructor body, so the pool is rebuilt once the limit is known.
+      this._statements = this.buildStatementPool();
     }
     this.connect();
     if (!this._asyncConnectPending) void this.configureConnection();

--- a/packages/activerecord/src/connection-adapters/statement-pool.test.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.test.ts
@@ -146,38 +146,26 @@ describe("SQLite3 StatementPool integration", () => {
     }
   });
 
-  it("setMaxSize shrinks and evicts LRU entries through dealloc", async () => {
+  it("evicts LRU entries through dealloc once the statement limit is reached", async () => {
     const dealloced: string[] = [];
     class TestPool extends StatementPool<string> {
       protected dealloc(stmt: string): void {
         dealloced.push(stmt);
       }
     }
-    const pool = new TestPool(5);
+    const pool = new TestPool(2);
     await pool.set("a", "stmt_a");
     await pool.set("b", "stmt_b");
-    await pool.set("c", "stmt_c");
-    // Touch "a" so it's moved to MRU — LRU order becomes b, c, a.
+    // Touch "a" so it's moved to MRU — LRU order becomes b, a.
     pool.get("a");
-    await pool.setMaxSize(1);
-    expect(pool.length).toBe(1);
+    await pool.set("c", "stmt_c");
+    expect(pool.length).toBe(2);
     expect(pool.has("a")).toBe(true);
-    expect(dealloced).toEqual(["stmt_b", "stmt_c"]);
+    expect(dealloced).toEqual(["stmt_b"]);
   });
 
-  it("setMaxSize(0) evicts everything and raises on a further insert", async () => {
-    const dealloced: string[] = [];
-    class TestPool extends StatementPool<string> {
-      protected dealloc(stmt: string): void {
-        dealloced.push(stmt);
-      }
-    }
-    const pool = new TestPool(5);
-    await pool.set("a", "stmt_a");
-    await pool.set("b", "stmt_b");
-    await pool.setMaxSize(0);
-    expect(pool.length).toBe(0);
-    expect(dealloced.sort()).toEqual(["stmt_a", "stmt_b"]);
+  it("a statement limit of 0 raises on the first insert", async () => {
+    const pool = new StatementPool<string>(0);
     // Rails' `[]=` has no zero-limit special case: `while 0 <= cache.size`
     // runs on the empty cache, `Hash#shift` returns nil and `nil.last` raises
     // (statement_pool.rb:31-33). A `statement_limit` of 0 is unsupported.
@@ -200,14 +188,5 @@ describe("SQLite3 StatementPool integration", () => {
     order.push("eviction-site-resumed");
     await pool.clear();
     expect(order).toEqual(["stmt_a", "eviction-site-resumed", "stmt_b"]);
-  });
-
-  it("setMaxSize rejects negative / non-integer values", () => {
-    const pool = new StatementPool<string>(5);
-    expect(() => pool.setMaxSize(-1)).toThrow(RangeError);
-    expect(() => pool.setMaxSize(1.5)).toThrow(RangeError);
-    expect(() => pool.setMaxSize(NaN)).toThrow(RangeError);
-    expect(() => pool.setMaxSize(Infinity)).toThrow(RangeError);
-    expect(pool.maxSize).toBe(5);
   });
 });

--- a/packages/activerecord/src/connection-adapters/statement-pool.ts
+++ b/packages/activerecord/src/connection-adapters/statement-pool.ts
@@ -5,43 +5,19 @@
  */
 
 export class StatementPool<T = unknown> {
-  private _cache = new Map<string, T>();
-  private _maxSize: number;
+  /** Mirrors: StatementPool::DEFAULT_STATEMENT_LIMIT (statement_pool.rb:8) */
+  static readonly DEFAULT_STATEMENT_LIMIT = 1000;
 
-  constructor(maxSize = 1000) {
-    this._maxSize = maxSize;
+  private _cache: Map<string, T>;
+  private _statementLimit: number;
+
+  constructor(statementLimit?: number) {
+    this._cache = new Map<string, T>();
+    this._statementLimit = statementLimit ?? StatementPool.DEFAULT_STATEMENT_LIMIT;
   }
 
   get length(): number {
     return this.cache.size;
-  }
-
-  get maxSize(): number {
-    return this._maxSize;
-  }
-
-  /**
-   * Shrink (or grow) the LRU bound. Shrinking evicts the
-   * least-recently-used statements via `dealloc` — matches Rails'
-   * behavior when `statement_limit` is changed mid-session.
-   */
-  setMaxSize(maxSize: number): void | Promise<void> {
-    if (!Number.isInteger(maxSize) || maxSize < 0) {
-      throw new RangeError(
-        `StatementPool#setMaxSize expected a finite non-negative integer; got ${String(maxSize)}`,
-      );
-    }
-    this._maxSize = maxSize;
-    const deallocating: Array<Promise<void>> = [];
-    while (this.cache.size > this._maxSize) {
-      const firstKey = this.cache.keys().next().value;
-      if (firstKey === undefined) break;
-      const evicted = this.cache.get(firstKey)!;
-      this.cache.delete(firstKey);
-      const pending = this.dealloc(evicted);
-      if (pending) deallocating.push(pending);
-    }
-    if (deallocating.length > 0) return Promise.all(deallocating).then(() => {});
   }
 
   get(key: string): T | undefined {
@@ -55,7 +31,7 @@ export class StatementPool<T = unknown> {
   set(key: string, stmt: T): void | Promise<void> {
     this.cache.delete(key);
     const deallocating: Array<Promise<void>> = [];
-    while (this._maxSize <= this.cache.size) {
+    while (this._statementLimit <= this.cache.size) {
       // `dealloc(cache.shift.last)` (statement_pool.rb:32). The non-null
       // assertion carries Rails' failure mode rather than papering over it: at
       // `statement_limit` 0 the loop runs on an empty cache, Ruby's

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -153,7 +153,7 @@ describe("RelationTest", () => {
 
   it("scope for create", () => {
     const rel = CanonPost.where({ title: "scoped" });
-    const attrs = (rel as any)._scopeAttributes ? (rel as any)._scopeAttributes() : {};
+    const attrs = rel.scopeForCreate();
     expect(attrs.title).toBe("scoped");
   });
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1657,15 +1657,12 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Extract scope attributes from the where clauses (for find_or_create_by).
-   */
-  /**
    * Return attributes that would be set on records created through this relation.
    *
-   * Mirrors: ActiveRecord::Relation#scope_for_create
+   * Mirrors: ActiveRecord::Relation#scope_for_create (relation.rb:1231-1235)
    */
   scopeForCreate(): Record<string, unknown> {
-    const hash = this._scopeAttributes();
+    const hash = this.whereClause.toH(this.model.tableName, { equalityOnly: true });
     if (!isEmpty(this.createWithValue)) {
       for (const [k, v] of Object.entries(this.createWithValue)) hash[k] = v;
     }
@@ -1684,11 +1681,6 @@ export class Relation<T extends Base> {
    */
   whereValuesHash(relationTableName: string = this.model.tableName): Record<string, unknown> {
     return this.whereClause.toH(relationTableName);
-  }
-
-  /** @internal */
-  protected _scopeAttributes(): Record<string, unknown> {
-    return this.whereClause.toH(this.model.tableName, { equalityOnly: true });
   }
 
   // -- SQL generation --

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -288,7 +288,6 @@ interface FinderRelation {
   offsetValue: number | string | null;
   orderValues: unknown[];
   createWithValue: Record<string, unknown>;
-  _scopeAttributes(): Record<string, unknown>;
   scopeForCreate(): Record<string, unknown>;
   clone(): any;
   whereClause: { isEmpty(): boolean; isContradiction(): boolean };


### PR DESCRIPTION
Three RFC 0112 convergences, each deleting a trails-only slot in favour of the Rails path already ported beside it.

### MySQL casts through the inherited `type_map`

Rails defines `lookup_cast_type` only on `AbstractAdapter` (`abstract/quoting.rb:234-236`) and PostgreSQL (`postgresql/quoting.rb:189-196`) — never on a MySQL adapter — so MySQL resolves casts through `type_map` → `extended_type_map`. Deleted:

- `AbstractMysqlAdapter#lookupCastType` / `#lookupCastTypeFromColumn`
- the `_nativeTypeMap` / `_buildTypeMap` slots and the `_typeMap` instance cache behind them

`Mysql2Adapter` now declares its own `TYPE_MAP` (`mysql2_adapter.rb:53`), the missing declaration the story flagged: `self::TYPE_MAP` inside `extended_type_map` (`abstract_adapter.rb:878`) previously resolved to the abstract map for MySQL, which would have silently dropped the mysql2 char/varchar/enum/set registrations the moment `_nativeTypeMap` went away. `SQLite3Adapter` already declares both constants. `default_timezone` now reaches MySQL datetime casting, which subsumes `mysql-extended-type-map-default-timezone`.

`text_type?` reads `TYPE_MAP.lookup` off the concrete class, as `mysql2_adapter.rb:140-142` does.

### `StatementPool`'s limit is constructor-only

`statement_pool.rb:10-13` sets `@statement_limit` once and exposes no writer; the only eviction is the `while @statement_limit <= cache.size` loop in `[]=` (`:31-33`). Deleted `setMaxSize` (validation, resize, eviction sweep) and the `maxSize` reader — both novel surface. `@statement_limit` and `DEFAULT_STATEMENT_LIMIT` take their Rails names.

Its one production caller was the SQLite3 constructor resizing a live pool, because the `_statements` field initializer runs before the constructor body reads `statement_limit` from the config. It now rebuilds the pool once the limit is known, which is Rails' order (`abstract_adapter.rb:156`, after `@config`). Tests that resized a live pool construct one at the limit under test instead.

### `scope_for_create` inlines `where_clause.to_h`

`relation.rb:1231-1235` spells the expression inline; the `_scopeAttributes` wrapper around that single call is deleted.

### Also

`port-relation-future-result-and-scheduled` is already implemented on `main` (#6750, #6905, #6918): `exec_queries` / `exec_main_query(async:)` are split, `@future_result` is a field, `reset` cancels it under test, `scheduled?` is ported, and `_asyncLoad` / `_loadAsyncPromise` are gone. It carries no change here and is closed against #6918 rather than this PR.

### Verification

`pnpm typecheck`, `pnpm lint`, `parity:api:calls`, `parity:api:calls:args` green. `parity:api:extra --package activerecord`: `statement-pool.ts` 3 novel → 1. SQLite lane green; MySQL lane run locally against `mariadb:11` — all 34 files under `adapters/abstract-mysql-adapter/` + `adapters/mysql2/`, plus `schema-dumper` / `attribute-methods` / `base` / `relation` / `type/` under `ARCONN=mysql2`.

Closes-story: mysql-native-type-map-converges-onto-type-map
Closes-story: scope-for-create-wraps-where-clause-to-h
Closes-story: statement-pool-setmaxsize-is-invented
