### PR TITLE
feat(activesupport,date): port core_ext/time/calculations.rb onto the Time class (RFC 0113)

### DIFF
--- a/packages/activesupport/package.json
+++ b/packages/activesupport/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/core-ext/date/conversions.d.ts",
       "default": "./dist/core-ext/date/conversions.js"
     },
+    "./core-ext/time/calculations": {
+      "types": "./dist/core-ext/time/calculations.d.ts",
+      "default": "./dist/core-ext/time/calculations.js"
+    },
     "./core-ext/date-time/calculations": {
       "types": "./dist/core-ext/date-time/calculations.d.ts",
       "default": "./dist/core-ext/date-time/calculations.js"

--- a/packages/activesupport/src/core-ext/time/calculations.test.ts
+++ b/packages/activesupport/src/core-ext/time/calculations.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { Rational, Time as RubyTime, resetLocalTimeZoneId } from "@blazetrails/date";
+import { ArgumentError } from "../../hash-utils.js";
 import "./calculations.js";
 
+/**
+ * `TimeZoneTestHelpers#with_env_tz` (`test/time_zone_test_helpers.rb:20-25`).
+ * `Time`'s local-zone memo is MRI's `tzset` cache, so `TZ` moving under it has
+ * to drop it, exactly as `tzset` does.
+ */
 function withEnvTz<T>(tz: string, fn: () => T): T {
   const orig = process.env.TZ;
   process.env.TZ = tz;
-  // `Time`'s local-zone memo is MRI's `tzset` cache; `TZ` moving under it has
-  // to drop it, exactly as `tzset` does.
   resetLocalTimeZoneId();
   try {
     return fn();
@@ -37,6 +41,11 @@ function expectSameTime(actual: RubyTime, expected: RubyTime): void {
   );
 }
 
+/** `assert_in_delta` over two `Time`s, in seconds. */
+function expectWithinDelta(actual: RubyTime, expected: RubyTime, delta: number): void {
+  expect(Math.abs(actual.toI() - expected.toI())).toBeLessThanOrEqual(delta);
+}
+
 const NSEC_999999999_OVER_1000 = new Rational(999999999, 1000);
 
 describe("TimeExtCalculationsTest", () => {
@@ -61,24 +70,20 @@ describe("TimeExtCalculationsTest", () => {
       RubyTime.local(2005, 2, 4, 0, 0, 0),
     );
     withEnvTz("US/Eastern", () => {
-      // "start DST"
       expectSameTime(
         RubyTime.local(2006, 4, 2, 10, 10, 10).beginningOfDay(),
         RubyTime.local(2006, 4, 2, 0, 0, 0),
       );
-      // "ends DST"
       expectSameTime(
         RubyTime.local(2006, 10, 29, 10, 10, 10).beginningOfDay(),
         RubyTime.local(2006, 10, 29, 0, 0, 0),
       );
     });
     withEnvTz("NZ", () => {
-      // "ends DST"
       expectSameTime(
         RubyTime.local(2006, 3, 19, 10, 10, 10).beginningOfDay(),
         RubyTime.local(2006, 3, 19, 0, 0, 0),
       );
-      // "start DST"
       expectSameTime(
         RubyTime.local(2006, 10, 1, 10, 10, 10).beginningOfDay(),
         RubyTime.local(2006, 10, 1, 0, 0, 0),
@@ -133,12 +138,10 @@ describe("TimeExtCalculationsTest", () => {
       RubyTime.local(2007, 8, 12, 23, 59, 59, NSEC_999999999_OVER_1000),
     );
     withEnvTz("US/Eastern", () => {
-      // "start DST"
       expectSameTime(
         RubyTime.local(2007, 4, 2, 10, 10, 10).endOfDay(),
         RubyTime.local(2007, 4, 2, 23, 59, 59, NSEC_999999999_OVER_1000),
       );
-      // "ends DST"
       expectSameTime(
         RubyTime.local(2007, 10, 29, 10, 10, 10).endOfDay(),
         RubyTime.local(2007, 10, 29, 23, 59, 59, NSEC_999999999_OVER_1000),
@@ -174,5 +177,217 @@ describe("TimeExtCalculationsTest", () => {
       RubyTime.local(2005, 2, 4, 19, 30, 10).endOfMinute(),
       RubyTime.local(2005, 2, 4, 19, 30, 59, NSEC_999999999_OVER_1000),
     );
+  });
+
+  it("change", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 15, 15, 10).change({ year: 2006 }),
+      RubyTime.local(2006, 2, 22, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 15, 15, 10).change({ month: 6 }),
+      RubyTime.local(2005, 6, 22, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 15, 15, 10).change({ year: 2012, month: 9 }),
+      RubyTime.local(2012, 9, 22, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 15, 15, 10).change({ hour: 16 }),
+      RubyTime.local(2005, 2, 22, 16),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 15, 15, 10).change({ hour: 16, min: 45 }),
+      RubyTime.local(2005, 2, 22, 16, 45),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 15, 15, 10).change({ min: 45 }),
+      RubyTime.local(2005, 2, 22, 15, 45),
+    );
+
+    expectSameTime(
+      RubyTime.local(2005, 1, 2, 11, 22, 33, 44).change({ hour: 5 }),
+      RubyTime.local(2005, 1, 2, 5, 0, 0, 0),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 1, 2, 11, 22, 33, 44).change({ min: 6 }),
+      RubyTime.local(2005, 1, 2, 11, 6, 0, 0),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 1, 2, 11, 22, 33, 44).change({ sec: 7 }),
+      RubyTime.local(2005, 1, 2, 11, 22, 7, 0),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 1, 2, 11, 22, 33, 44).change({ usec: 8 }),
+      RubyTime.local(2005, 1, 2, 11, 22, 33, 8),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 1, 2, 11, 22, 33, 2).change({ nsec: 8000 }),
+      RubyTime.local(2005, 1, 2, 11, 22, 33, 8),
+    );
+    expect(() => RubyTime.local(2005, 1, 2, 11, 22, 33, 8).change({ usec: 1, nsec: 1 })).toThrow(
+      ArgumentError,
+    );
+    expect(() =>
+      RubyTime.new(2015, 5, 9, 10, 0, 0, "+03:00").change({ nsec: 999999999 }),
+    ).not.toThrow();
+  });
+
+  it("advance", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ years: 1 }),
+      RubyTime.local(2006, 2, 28, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ months: 4 }),
+      RubyTime.local(2005, 6, 28, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ weeks: 3 }),
+      RubyTime.local(2005, 3, 21, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ weeks: 3.5 }),
+      RubyTime.local(2005, 3, 25, 3, 15, 10),
+    );
+    expectWithinDelta(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ weeks: 3.7 }),
+      RubyTime.local(2005, 3, 26, 12, 51, 10),
+      1,
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ days: 5 }),
+      RubyTime.local(2005, 3, 5, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ days: 5.5 }),
+      RubyTime.local(2005, 3, 6, 3, 15, 10),
+    );
+    expectWithinDelta(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ days: 5.7 }),
+      RubyTime.local(2005, 3, 6, 8, 3, 10),
+      1,
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ years: 7, months: 7 }),
+      RubyTime.local(2012, 9, 28, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ years: 7, months: 19, days: 5 }),
+      RubyTime.local(2013, 10, 3, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ years: 7, months: 19, weeks: 2, days: 5 }),
+      RubyTime.local(2013, 10, 17, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ years: -3, months: -2, days: -1 }),
+      RubyTime.local(2001, 12, 27, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2004, 2, 29, 15, 15, 10).advance({ years: 1 }),
+      RubyTime.local(2005, 2, 28, 15, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ hours: 5 }),
+      RubyTime.local(2005, 2, 28, 20, 15, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ minutes: 7 }),
+      RubyTime.local(2005, 2, 28, 15, 22, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ seconds: 9 }),
+      RubyTime.local(2005, 2, 28, 15, 15, 19),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ hours: 5, minutes: 7, seconds: 9 }),
+      RubyTime.local(2005, 2, 28, 20, 22, 19),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ hours: -5, minutes: -7, seconds: -9 }),
+      RubyTime.local(2005, 2, 28, 10, 8, 1),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 28, 15, 15, 10).advance({
+        years: 7,
+        months: 19,
+        weeks: 2,
+        days: 5,
+        hours: 5,
+        minutes: 7,
+        seconds: 9,
+      }),
+      RubyTime.local(2013, 10, 17, 20, 22, 19),
+    );
+  });
+
+  it("ago", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).ago(1),
+      RubyTime.local(2005, 2, 22, 10, 10, 9),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).ago(3600),
+      RubyTime.local(2005, 2, 22, 9, 10, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).ago(86400 * 2),
+      RubyTime.local(2005, 2, 20, 10, 10, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).ago(86400 * 2 + 3600 + 25),
+      RubyTime.local(2005, 2, 20, 9, 9, 45),
+    );
+  });
+
+  it("since", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).since(1),
+      RubyTime.local(2005, 2, 22, 10, 10, 11),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).since(3600),
+      RubyTime.local(2005, 2, 22, 11, 10, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).since(86400 * 2),
+      RubyTime.local(2005, 2, 24, 10, 10, 10),
+    );
+    expectSameTime(
+      RubyTime.local(2005, 2, 22, 10, 10, 10).since(86400 * 2 + 3600 + 25),
+      RubyTime.local(2005, 2, 24, 11, 10, 35),
+    );
+    expectSameTime(
+      RubyTime.utc(2038, 1, 18, 11, 59, 59).since(86400 * 2),
+      RubyTime.utc(2038, 1, 20, 11, 59, 59),
+    );
+  });
+
+  it("days in month with year", () => {
+    expect(RubyTime.daysInMonth(1, 2005)).toBe(31);
+
+    expect(RubyTime.daysInMonth(2, 2005)).toBe(28);
+    expect(RubyTime.daysInMonth(2, 2004)).toBe(29);
+    expect(RubyTime.daysInMonth(2, 2000)).toBe(29);
+    expect(RubyTime.daysInMonth(2, 1900)).toBe(28);
+
+    expect(RubyTime.daysInMonth(3, 2005)).toBe(31);
+    expect(RubyTime.daysInMonth(4, 2005)).toBe(30);
+    expect(RubyTime.daysInMonth(5, 2005)).toBe(31);
+    expect(RubyTime.daysInMonth(6, 2005)).toBe(30);
+    expect(RubyTime.daysInMonth(7, 2005)).toBe(31);
+    expect(RubyTime.daysInMonth(8, 2005)).toBe(31);
+    expect(RubyTime.daysInMonth(9, 2005)).toBe(30);
+    expect(RubyTime.daysInMonth(10, 2005)).toBe(31);
+    expect(RubyTime.daysInMonth(11, 2005)).toBe(30);
+    expect(RubyTime.daysInMonth(12, 2005)).toBe(31);
+  });
+
+  it("days in year with year", () => {
+    expect(RubyTime.daysInYear(2005)).toBe(365);
+    expect(RubyTime.daysInYear(2004)).toBe(366);
+    expect(RubyTime.daysInYear(2000)).toBe(366);
+    expect(RubyTime.daysInYear(1900)).toBe(365);
   });
 });

--- a/packages/activesupport/src/core-ext/time/calculations.test.ts
+++ b/packages/activesupport/src/core-ext/time/calculations.test.ts
@@ -390,4 +390,27 @@ describe("TimeExtCalculationsTest", () => {
     expect(RubyTime.daysInYear(2000)).toBe(366);
     expect(RubyTime.daysInYear(1900)).toBe(365);
   });
+
+  it("rfc3339 parse", () => {
+    const time = RubyTime.rfc3339("1999-12-31T19:00:00.125-05:00");
+
+    expect(time.year).toBe(1999);
+    expect(time.month).toBe(12);
+    expect(time.day).toBe(31);
+    expect(time.hour).toBe(19);
+    expect(time.min).toBe(0);
+    expect(time.sec).toBe(0);
+    expect(time.usec).toBe(125000);
+    expect(time.utcOffset).toBe(-18000);
+
+    expect(() => RubyTime.rfc3339("1999-12-31")).toThrow(
+      expect.objectContaining({ message: "invalid date" }),
+    );
+    expect(() => RubyTime.rfc3339("1999-12-31T19:00:00")).toThrow(
+      expect.objectContaining({ message: "invalid date" }),
+    );
+    expect(() => RubyTime.rfc3339("foobar")).toThrow(
+      expect.objectContaining({ message: "invalid date" }),
+    );
+  });
 });

--- a/packages/activesupport/src/core-ext/time/calculations.test.ts
+++ b/packages/activesupport/src/core-ext/time/calculations.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Rational, Time as RubyTime, resetLocalTimeZoneId } from "@blazetrails/date";
+import "./calculations.js";
+
+function withEnvTz<T>(tz: string, fn: () => T): T {
+  const orig = process.env.TZ;
+  process.env.TZ = tz;
+  // `Time`'s local-zone memo is MRI's `tzset` cache; `TZ` moving under it has
+  // to drop it, exactly as `tzset` does.
+  resetLocalTimeZoneId();
+  try {
+    return fn();
+  } finally {
+    if (orig === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = orig;
+    }
+    resetLocalTimeZoneId();
+  }
+}
+
+const savedTZ = process.env.TZ;
+afterEach(() => {
+  if (savedTZ === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = savedTZ;
+  }
+  resetLocalTimeZoneId();
+});
+
+/** `assert_equal` over two `Time`s is `Time#==`, which trails spells as the instant. */
+function expectSameTime(actual: RubyTime, expected: RubyTime): void {
+  expect(actual.toTime().toInstant().epochNanoseconds).toBe(
+    expected.toTime().toInstant().epochNanoseconds,
+  );
+}
+
+const NSEC_999999999_OVER_1000 = new Rational(999999999, 1000);
+
+describe("TimeExtCalculationsTest", () => {
+  it("seconds since midnight", () => {
+    expect(RubyTime.local(2005, 1, 1, 0, 0, 1).secondsSinceMidnight()).toBe(1);
+    expect(RubyTime.local(2005, 1, 1, 0, 1, 0).secondsSinceMidnight()).toBe(60);
+    expect(RubyTime.local(2005, 1, 1, 1, 1, 0).secondsSinceMidnight()).toBe(3660);
+    expect(RubyTime.local(2005, 1, 1, 23, 59, 59).secondsSinceMidnight()).toBe(86399);
+  });
+
+  it("seconds until end of day", () => {
+    expect(RubyTime.local(2005, 1, 1, 23, 59, 59).secondsUntilEndOfDay()).toBe(0);
+    expect(RubyTime.local(2005, 1, 1, 23, 59, 58).secondsUntilEndOfDay()).toBe(1);
+    expect(RubyTime.local(2005, 1, 1, 23, 58, 59).secondsUntilEndOfDay()).toBe(60);
+    expect(RubyTime.local(2005, 1, 1, 22, 58, 59).secondsUntilEndOfDay()).toBe(3660);
+    expect(RubyTime.local(2005, 1, 1, 0, 0, 0).secondsUntilEndOfDay()).toBe(86399);
+  });
+
+  it("beginning of day", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 4, 10, 10, 10).beginningOfDay(),
+      RubyTime.local(2005, 2, 4, 0, 0, 0),
+    );
+    withEnvTz("US/Eastern", () => {
+      // "start DST"
+      expectSameTime(
+        RubyTime.local(2006, 4, 2, 10, 10, 10).beginningOfDay(),
+        RubyTime.local(2006, 4, 2, 0, 0, 0),
+      );
+      // "ends DST"
+      expectSameTime(
+        RubyTime.local(2006, 10, 29, 10, 10, 10).beginningOfDay(),
+        RubyTime.local(2006, 10, 29, 0, 0, 0),
+      );
+    });
+    withEnvTz("NZ", () => {
+      // "ends DST"
+      expectSameTime(
+        RubyTime.local(2006, 3, 19, 10, 10, 10).beginningOfDay(),
+        RubyTime.local(2006, 3, 19, 0, 0, 0),
+      );
+      // "start DST"
+      expectSameTime(
+        RubyTime.local(2006, 10, 1, 10, 10, 10).beginningOfDay(),
+        RubyTime.local(2006, 10, 1, 0, 0, 0),
+      );
+    });
+  });
+
+  it("middle of day", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 4, 10, 10, 10).middleOfDay(),
+      RubyTime.local(2005, 2, 4, 12, 0, 0),
+    );
+    withEnvTz("US/Eastern", () => {
+      expectSameTime(
+        RubyTime.local(2006, 4, 2, 10, 10, 10).middleOfDay(),
+        RubyTime.local(2006, 4, 2, 12, 0, 0),
+      );
+      expectSameTime(
+        RubyTime.local(2006, 10, 29, 10, 10, 10).middleOfDay(),
+        RubyTime.local(2006, 10, 29, 12, 0, 0),
+      );
+    });
+    withEnvTz("NZ", () => {
+      expectSameTime(
+        RubyTime.local(2006, 3, 19, 10, 10, 10).middleOfDay(),
+        RubyTime.local(2006, 3, 19, 12, 0, 0),
+      );
+      expectSameTime(
+        RubyTime.local(2006, 10, 1, 10, 10, 10).middleOfDay(),
+        RubyTime.local(2006, 10, 1, 12, 0, 0),
+      );
+    });
+  });
+
+  it("beginning of hour", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 4, 19, 30, 10).beginningOfHour(),
+      RubyTime.local(2005, 2, 4, 19, 0, 0),
+    );
+  });
+
+  it("beginning of minute", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 4, 19, 30, 10).beginningOfMinute(),
+      RubyTime.local(2005, 2, 4, 19, 30, 0),
+    );
+  });
+
+  it("end of day", () => {
+    expectSameTime(
+      RubyTime.local(2007, 8, 12, 10, 10, 10).endOfDay(),
+      RubyTime.local(2007, 8, 12, 23, 59, 59, NSEC_999999999_OVER_1000),
+    );
+    withEnvTz("US/Eastern", () => {
+      // "start DST"
+      expectSameTime(
+        RubyTime.local(2007, 4, 2, 10, 10, 10).endOfDay(),
+        RubyTime.local(2007, 4, 2, 23, 59, 59, NSEC_999999999_OVER_1000),
+      );
+      // "ends DST"
+      expectSameTime(
+        RubyTime.local(2007, 10, 29, 10, 10, 10).endOfDay(),
+        RubyTime.local(2007, 10, 29, 23, 59, 59, NSEC_999999999_OVER_1000),
+      );
+    });
+    withEnvTz("NZ", () => {
+      expectSameTime(
+        RubyTime.local(2006, 3, 19, 10, 10, 10).endOfDay(),
+        RubyTime.local(2006, 3, 19, 23, 59, 59, NSEC_999999999_OVER_1000),
+      );
+      expectSameTime(
+        RubyTime.local(2006, 10, 1, 10, 10, 10).endOfDay(),
+        RubyTime.local(2006, 10, 1, 23, 59, 59, NSEC_999999999_OVER_1000),
+      );
+    });
+    withEnvTz("Asia/Yekaterinburg", () => {
+      expectSameTime(
+        RubyTime.new(2015, 2, 8, 8, 0, 0, "+05:00").endOfDay(),
+        RubyTime.local(2015, 2, 8, 23, 59, 59, NSEC_999999999_OVER_1000),
+      );
+    });
+  });
+
+  it("end of hour", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 4, 19, 30, 10).endOfHour(),
+      RubyTime.local(2005, 2, 4, 19, 59, 59, NSEC_999999999_OVER_1000),
+    );
+  });
+
+  it("end of minute", () => {
+    expectSameTime(
+      RubyTime.local(2005, 2, 4, 19, 30, 10).endOfMinute(),
+      RubyTime.local(2005, 2, 4, 19, 30, 59, NSEC_999999999_OVER_1000),
+    );
+  });
+});

--- a/packages/activesupport/src/core-ext/time/calculations.trails.test.ts
+++ b/packages/activesupport/src/core-ext/time/calculations.trails.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { Time as RubyTime, resetLocalTimeZoneId } from "@blazetrails/date";
+import "./calculations.js";
+
+/**
+ * `TimeZoneTestHelpers#with_env_tz` (`test/time_zone_test_helpers.rb:20-25`).
+ * `Time`'s local-zone memo is MRI's `tzset` cache, so `TZ` moving under it has
+ * to drop it, exactly as `tzset` does.
+ */
+function withEnvTz<T>(tz: string, fn: () => T): T {
+  const orig = process.env.TZ;
+  process.env.TZ = tz;
+  resetLocalTimeZoneId();
+  try {
+    return fn();
+  } finally {
+    if (orig === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = orig;
+    }
+    resetLocalTimeZoneId();
+  }
+}
+
+/**
+ * `Time#advance`'s `:weeks`/`:days` normalisation is `divmod(1)`
+ * (`time/calculations.rb:195-201`), which FLOORS: `(-1.5).divmod(1)` is
+ * `[-2, 0.5]` on ruby 3.3.11, not the `[-1, -0.5]` truncation would give. Rails
+ * has no test over a negative fractional `:weeks`/`:days`, so the two
+ * expectations below are MRI's own answers for the Rails body, transcribed.
+ */
+describe("TimeExtCalculationsTest (trails)", () => {
+  it("advance floors a negative fractional weeks like Ruby's divmod", () => {
+    withEnvTz("US/Eastern", () => {
+      const advanced = RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ weeks: -1.5 });
+      expect(advanced.strftime("%Y-%m-%d %H:%M:%S")).toBe("2005-02-18 03:15:10");
+    });
+  });
+
+  it("advance floors a negative fractional days like Ruby's divmod", () => {
+    withEnvTz("US/Eastern", () => {
+      const advanced = RubyTime.local(2005, 2, 28, 15, 15, 10).advance({ days: -5.5 });
+      expect(advanced.strftime("%Y-%m-%d %H:%M:%S")).toBe("2005-02-23 03:15:10");
+    });
+  });
+});

--- a/packages/activesupport/src/core-ext/time/calculations.ts
+++ b/packages/activesupport/src/core-ext/time/calculations.ts
@@ -49,10 +49,6 @@ export interface AdvanceOptions {
   seconds?: number;
 }
 
-// ---------------------------------------------------------------------------
-// class << self — time/calculations.rb:15-82
-// ---------------------------------------------------------------------------
-
 /**
  * Mirrors: `Time.current` (`time/calculations.rb:39-41`).
  *
@@ -109,10 +105,6 @@ export function rfc3339(str: string): RubyTime {
   );
 }
 
-// ---------------------------------------------------------------------------
-// instance methods — time/calculations.rb:84-385
-// ---------------------------------------------------------------------------
-
 /** Mirrors: `Time#seconds_since_midnight` (`time/calculations.rb:91-93`) */
 export function secondsSinceMidnight(this: RubyTime): number {
   return this.toI() - change.call(this, { hour: 0 }).toI() + this.usec / 1.0e6;
@@ -128,10 +120,26 @@ export function secFraction(this: RubyTime): number {
   return this.subsec;
 }
 
-/** Mirrors: `Time#change` (`time/calculations.rb:123-178`) */
+/**
+ * Mirrors: `Time#change` (`time/calculations.rb:123-178`).
+ *
+ * Each `options.fetch(:k, default)` is spelled `"k" in options` rather than
+ * `??`: `Hash#fetch` yields the STORED value whenever the key is present, `nil`
+ * included, where `??` would substitute the default for it. The `options[:hour]`
+ * truthiness tests are the opposite case — Ruby's `0` is truthy — so those are
+ * `!= null`, which admits the `hour: 0` Rails admits.
+ *
+ * `Rational(new_usec, 1000000)` (`:141`) is `quo`: `Rational()` of a Rational
+ * over an Integer is that Rational divided by it.
+ *
+ * The `zone.respond_to?(:utc_to_local)` arm
+ * (`:148-171`) selects a receiver whose `zone` is a `TZInfo` zone OBJECT. No
+ * trails `::Time` carries one — its `zone` is the tzdata abbreviation String —
+ * so the arm is unreachable, and its second-occurrence correction is not lost
+ * with it: the `isdst` handed to `::Time.local` on the next arm makes the same
+ * choice of the wall clock a DST fall-back repeats.
+ */
 export function change(this: RubyTime, options: ChangeOptions): RubyTime {
-  // `Hash#fetch` yields the stored value whenever the key is present, `nil`
-  // included, where `??` would substitute the default for it.
   const newYear = "year" in options ? options.year! : this.year;
   const newMonth = "month" in options ? options.month! : this.month;
   const newDay = "day" in options ? options.day! : this.day;
@@ -148,7 +156,11 @@ export function change(this: RubyTime, options: ChangeOptions): RubyTime {
   if (newNsec != null) {
     if (options.usec != null) {
       throw new ArgumentError(
-        `Can't change both :nsec and :usec at the same time: ${inspectOptions(options)}`,
+        `Can't change both :nsec and :usec at the same time: {${Object.entries(options)
+          .map(
+            ([key, value]) => `${key}: ${typeof value === "string" ? `"${value}"` : String(value)}`,
+          )
+          .join(", ")}}`,
       );
     }
     newUsec = new Rational(newNsec, 1000);
@@ -162,19 +174,12 @@ export function change(this: RubyTime, options: ChangeOptions): RubyTime {
 
   if (newUsec.cmp(1000000) >= 0) throw new ArgumentError("argument out of range");
 
-  // `Rational(new_usec, 1000000)` (`time/calculations.rb:141`) — `Rational()` of
-  // a Rational over an Integer is that Rational divided by it, which `quo` is.
   newSec = newSec.add(newUsec.quo(1_000_000));
 
   if (newOffset != null) {
     return RubyTime.new(newYear, newMonth, newDay, newHour, newMin, newSec, newOffset);
   } else if (this.isUtc()) {
     return RubyTime.utc(newYear, newMonth, newDay, newHour, newMin, newSec);
-    // The `zone.respond_to?(:utc_to_local)` arm (`time/calculations.rb:148-171`)
-    // selects a receiver whose `zone` is a `TZInfo` zone OBJECT. No trails
-    // `::Time` carries one — its `zone` is the tzdata abbreviation String — and
-    // that arm's second-occurrence correction is not lost with it, because the
-    // `isdst` `::Time.local` takes below makes the same choice.
   } else if (this.zone != null) {
     return RubyTime.local(
       newSec,
@@ -193,19 +198,21 @@ export function change(this: RubyTime, options: ChangeOptions): RubyTime {
   }
 }
 
-/** `options.inspect` in `change`'s raise (`time/calculations.rb:135`). */
-function inspectOptions(options: ChangeOptions): string {
-  const pairs = Object.entries(options).map(
-    ([key, value]) => `${key}: ${typeof value === "string" ? `"${value}"` : String(value)}`,
-  );
-  return `{${pairs.join(", ")}}`;
-}
-
-/** Mirrors: `Time#advance` (`time/calculations.rb:194-217`) */
+/**
+ * Mirrors: `Time#advance` (`time/calculations.rb:194-217`).
+ *
+ * Rails writes the normalised `:weeks` / `:days` back into the CALLER's hash;
+ * `Date#advance` (`date/calculations.rb:127-136`) reads it only, and
+ * `date_ext_test.rb:367-371` asserts the difference. The write goes into a copy
+ * here so that the hash this hands on to the `Date` arm is the one Rails hands
+ * it, without the caller's object moving under a `Date` receiver's contract.
+ *
+ * `to_date.gregorian` (`:206`) puts the day on the
+ * proleptic Gregorian calendar before advancing it. `Time#toDate`
+ * (`packages/date/src/time.ts`) already builds under `GREGORIAN`, as MRI's
+ * `time_to_date` does, so there is no reform to lift.
+ */
 export function advance(this: RubyTime, options: AdvanceOptions): RubyTime {
-  // Rails writes the normalised `:weeks` / `:days` back into the caller's hash;
-  // `Date#advance` reads it only, and `date_ext_test.rb:367-371` asserts the
-  // difference, so the write goes into a copy rather than the caller's object.
   options = { ...options };
 
   if (options.weeks != null) {
@@ -237,7 +244,16 @@ export function ago(this: RubyTime, seconds: number): RubyTime {
   return since.call(this, -seconds);
 }
 
-/** Mirrors: `Time#since` (`time/calculations.rb:225-234`) */
+/**
+ * Mirrors: `Time#since` (`time/calculations.rb:225-234`).
+ *
+ * Rails' `rescue TypeError` arm exists for a
+ * `seconds` that `Time#+` will not take, and warns that Rails 8.1 will raise
+ * there instead. `seconds` is typed `number` here, so `Time#plus` cannot raise
+ * and the arm is unreachable; porting it would widen this method's return —
+ * and, through `ago`/`advance`/every `beginning_of_*`, the whole reopening's —
+ * to `Time | DateTime` for a branch nothing can enter.
+ */
 export function since(this: RubyTime, seconds: number): RubyTime {
   return this.plus(seconds);
 }
@@ -289,9 +305,9 @@ export function endOfMinute(this: RubyTime): RubyTime {
   });
 }
 
-// Rails' `alias`es over the methods above — `alias :in :since`
-// (`time/calculations.rb:235`), the day boundaries (:241-243, :250-254, :264),
-// the hour ones (:270, :281) and the minute ones (:286, :295).
+/** Rails' `alias`es: `alias :in :since` (`time/calculations.rb:235`), the day
+ * boundaries (:241-243, :250-254, :264), the hour ones (:270, :281) and the
+ * minute ones (:286, :295). */
 export { since as in };
 export { beginningOfDay as midnight };
 export { beginningOfDay as atMidnight };
@@ -383,8 +399,6 @@ declare module "@blazetrails/date" {
   }
 }
 
-// `class Time` is a reopening, so the members above land on the class itself —
-// the TS spelling of Ruby's open class, per CLAUDE.md "Module mixins".
 Object.assign(RubyTime.prototype, {
   secondsSinceMidnight,
   secondsUntilEndOfDay,

--- a/packages/activesupport/src/core-ext/time/calculations.ts
+++ b/packages/activesupport/src/core-ext/time/calculations.ts
@@ -80,28 +80,27 @@ export function daysInYear(year: number = current().year): number {
  * Mirrors: `Time.rfc3339` (`time/calculations.rb:69-81`).
  *
  * `Date._rfc3339` answers an empty hash for anything that is not a full
- * date-time-with-offset, which is the `parts.empty?` raise below; ruby/date's
- * parser is not ported, so the grammar it accepts is spelled as the pattern.
+ * date-time-with-offset, which is the `parts.empty?` raise; `Hash#empty?` is
+ * spelled over the key list, and each `parts.fetch(:k)` is a non-null assertion
+ * because `rfc3339_cb` (`date_parse.c:2585-2609`) sets every one of those keys
+ * unconditionally once the pattern matches. `:sec_fraction` is the one Rails
+ * fetches with a default, and its stored value is a `Rational`, so the sum with
+ * `:sec` is one too.
  */
 export function rfc3339(str: string): RubyTime {
-  const parts =
-    /^(-?\d{4,})-(\d\d)-(\d\d)[Tt ](\d\d):(\d\d):(\d\d)(\.\d+)?([Zz]|[+-]\d\d:\d\d)$/.exec(str);
+  const parts = RubyDate._rfc3339(str);
 
-  if (!parts) throw new ArgumentError("invalid date");
+  if (Object.keys(parts).length === 0) throw new ArgumentError("invalid date");
 
-  const secFractionPart = parts[7];
+  const secFractionPart = parts.secFraction;
   return RubyTime.new(
-    Number(parts[1]),
-    Number(parts[2]),
-    Number(parts[3]),
-    Number(parts[4]),
-    Number(parts[5]),
-    secFractionPart === undefined
-      ? Number(parts[6])
-      : new Rational(Number(parts[6]), 1).add(
-          new Rational(BigInt(secFractionPart.slice(1).padEnd(9, "0").slice(0, 9)), 1_000_000_000n),
-        ),
-    /^[Zz]$/.test(parts[8]) ? "+00:00" : parts[8],
+    parts.year as number,
+    parts.mon,
+    parts.mday,
+    parts.hour,
+    parts.min,
+    secFractionPart === undefined ? parts.sec! : new Rational(parts.sec!, 1).add(secFractionPart),
+    Number(parts.offset),
   );
 }
 
@@ -207,6 +206,11 @@ export function change(this: RubyTime, options: ChangeOptions): RubyTime {
  * here so that the hash this hands on to the `Date` arm is the one Rails hands
  * it, without the caller's object moving under a `Date` receiver's contract.
  *
+ * `Numeric#divmod(1)` FLOORS — `(-1.5).divmod(1)` is `[-2, 0.5]` on ruby
+ * 3.3.11, where truncation would give `[-1, -0.5]` — so the quotient is
+ * `Math.floor` and the remainder is taken off it, which is what makes a
+ * negative fractional `:weeks`/`:days` land where Rails lands it.
+ *
  * `to_date.gregorian` (`:206`) puts the day on the
  * proleptic Gregorian calendar before advancing it. `Time#toDate`
  * (`packages/date/src/time.ts`) already builds under `GREGORIAN`, as MRI's
@@ -216,14 +220,14 @@ export function advance(this: RubyTime, options: AdvanceOptions): RubyTime {
   options = { ...options };
 
   if (options.weeks != null) {
-    const partialWeeks = options.weeks - Math.trunc(options.weeks);
-    options.weeks = Math.trunc(options.weeks);
+    const partialWeeks = options.weeks - Math.floor(options.weeks);
+    options.weeks = Math.floor(options.weeks);
     options.days = (options.days ?? 0) + 7 * partialWeeks;
   }
 
   if (options.days != null) {
-    const partialDays = options.days - Math.trunc(options.days);
-    options.days = Math.trunc(options.days);
+    const partialDays = options.days - Math.floor(options.days);
+    options.days = Math.floor(options.days);
     options.hours = (options.hours ?? 0) + 24 * partialDays;
   }
 

--- a/packages/activesupport/src/core-ext/time/calculations.ts
+++ b/packages/activesupport/src/core-ext/time/calculations.ts
@@ -1,0 +1,425 @@
+/**
+ * Mirrors: `class Time` (`core_ext/time/calculations.rb`).
+ *
+ * Rails reopens `Time` here. trails' `Time` is `packages/date/src/time.ts`, in
+ * a package activesupport already depends on, so the reopening is the settled
+ * mixin idiom from CLAUDE.md — `this`-typed functions living in the file that
+ * matches the Rails path, assigned onto `Time` at the bottom of this module,
+ * with a module augmentation carrying the types. Importing this module is what
+ * `require "active_support/core_ext/time/calculations"` is.
+ */
+
+import { Date as RubyDate, Rational, Time as RubyTime } from "@blazetrails/date";
+import { ArgumentError } from "../../hash-utils.js";
+import { currentTimeInstant } from "../../time-travel.js";
+import { TimeWithZone } from "../../time-with-zone.js";
+import { zone as timeZone } from "../../time-zone-config.js";
+import { advance as dateAdvance } from "../date/calculations.js";
+
+/** Mirrors: `Time::COMMON_YEAR_DAYS_IN_MONTH` (`time/calculations.rb:13`) */
+export const COMMON_YEAR_DAYS_IN_MONTH = [null, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/**
+ * Rails' `:year`, `:month`, `:day`, `:hour`, `:min`, `:sec`, `:usec`, `:nsec`
+ * and `:offset` (`time/calculations.rb:111-121`). `:usec` takes a `Rational` as
+ * well as an Integer — the `end_of_*` family passes `Rational(999999999, 1000)`
+ * — and `:offset` a `"+HH:MM"` String or a seconds Integer, as `::Time.new`'s
+ * does.
+ */
+export interface ChangeOptions {
+  year?: number;
+  month?: number;
+  day?: number;
+  hour?: number;
+  min?: number;
+  sec?: number;
+  usec?: number | Rational;
+  nsec?: number;
+  offset?: string | number;
+}
+
+/** Rails' `:years`, `:months`, `:weeks`, `:days`, `:hours`, `:minutes`, `:seconds` (`time/calculations.rb:186-192`). */
+export interface AdvanceOptions {
+  years?: number;
+  months?: number;
+  weeks?: number;
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+}
+
+// ---------------------------------------------------------------------------
+// class << self — time/calculations.rb:15-82
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors: `Time.current` (`time/calculations.rb:39-41`).
+ *
+ * `::Time.now` is what trails' time travel stubs, so its arm reads the travelled
+ * clock through `currentTimeInstant` rather than `Temporal.Now`.
+ */
+export function current(): TimeWithZone | RubyTime {
+  const zone = timeZone();
+  return zone
+    ? zone.now()
+    : RubyTime.at(new Rational(currentTimeInstant().epochNanoseconds, 1_000_000_000n));
+}
+
+/** Mirrors: `Time.days_in_month` (`time/calculations.rb:24-30`) */
+export function daysInMonth(month: number, year: number = current().year): number {
+  if (month === 2 && RubyDate.isGregorianLeap(year)) {
+    return 29;
+  } else {
+    return COMMON_YEAR_DAYS_IN_MONTH[month]!;
+  }
+}
+
+/** Mirrors: `Time.days_in_year` (`time/calculations.rb:34-36`) */
+export function daysInYear(year: number = current().year): number {
+  return daysInMonth(2, year) + 337;
+}
+
+/**
+ * Mirrors: `Time.rfc3339` (`time/calculations.rb:69-81`).
+ *
+ * `Date._rfc3339` answers an empty hash for anything that is not a full
+ * date-time-with-offset, which is the `parts.empty?` raise below; ruby/date's
+ * parser is not ported, so the grammar it accepts is spelled as the pattern.
+ */
+export function rfc3339(str: string): RubyTime {
+  const parts =
+    /^(-?\d{4,})-(\d\d)-(\d\d)[Tt ](\d\d):(\d\d):(\d\d)(\.\d+)?([Zz]|[+-]\d\d:\d\d)$/.exec(str);
+
+  if (!parts) throw new ArgumentError("invalid date");
+
+  const secFractionPart = parts[7];
+  return RubyTime.new(
+    Number(parts[1]),
+    Number(parts[2]),
+    Number(parts[3]),
+    Number(parts[4]),
+    Number(parts[5]),
+    secFractionPart === undefined
+      ? Number(parts[6])
+      : new Rational(Number(parts[6]), 1).add(
+          new Rational(BigInt(secFractionPart.slice(1).padEnd(9, "0").slice(0, 9)), 1_000_000_000n),
+        ),
+    /^[Zz]$/.test(parts[8]) ? "+00:00" : parts[8],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// instance methods — time/calculations.rb:84-385
+// ---------------------------------------------------------------------------
+
+/** Mirrors: `Time#seconds_since_midnight` (`time/calculations.rb:91-93`) */
+export function secondsSinceMidnight(this: RubyTime): number {
+  return this.toI() - change.call(this, { hour: 0 }).toI() + this.usec / 1.0e6;
+}
+
+/** Mirrors: `Time#seconds_until_end_of_day` (`time/calculations.rb:100-102`) */
+export function secondsUntilEndOfDay(this: RubyTime): number {
+  return endOfDay.call(this).toI() - this.toI();
+}
+
+/** Mirrors: `Time#sec_fraction` (`time/calculations.rb:107-109`) */
+export function secFraction(this: RubyTime): number {
+  return this.subsec;
+}
+
+/** Mirrors: `Time#change` (`time/calculations.rb:123-178`) */
+export function change(this: RubyTime, options: ChangeOptions): RubyTime {
+  // `Hash#fetch` yields the stored value whenever the key is present, `nil`
+  // included, where `??` would substitute the default for it.
+  const newYear = "year" in options ? options.year! : this.year;
+  const newMonth = "month" in options ? options.month! : this.month;
+  const newDay = "day" in options ? options.day! : this.day;
+  const newHour = "hour" in options ? options.hour! : this.hour;
+  const newMin = "min" in options ? options.min! : options.hour != null ? 0 : this.min;
+  let newSec = new Rational(
+    "sec" in options ? options.sec! : options.hour != null || options.min != null ? 0 : this.sec,
+    1,
+  );
+  const newOffset = "offset" in options ? options.offset! : null;
+
+  let newUsec: Rational;
+  const newNsec = options.nsec;
+  if (newNsec != null) {
+    if (options.usec != null) {
+      throw new ArgumentError(
+        `Can't change both :nsec and :usec at the same time: ${inspectOptions(options)}`,
+      );
+    }
+    newUsec = new Rational(newNsec, 1000);
+  } else if ("usec" in options) {
+    newUsec = options.usec instanceof Rational ? options.usec : new Rational(options.usec!, 1);
+  } else if (options.hour != null || options.min != null || options.sec != null) {
+    newUsec = new Rational(0, 1);
+  } else {
+    newUsec = new Rational(this.nsec, 1000);
+  }
+
+  if (newUsec.cmp(1000000) >= 0) throw new ArgumentError("argument out of range");
+
+  // `Rational(new_usec, 1000000)` (`time/calculations.rb:141`) — `Rational()` of
+  // a Rational over an Integer is that Rational divided by it, which `quo` is.
+  newSec = newSec.add(newUsec.quo(1_000_000));
+
+  if (newOffset != null) {
+    return RubyTime.new(newYear, newMonth, newDay, newHour, newMin, newSec, newOffset);
+  } else if (this.isUtc()) {
+    return RubyTime.utc(newYear, newMonth, newDay, newHour, newMin, newSec);
+    // The `zone.respond_to?(:utc_to_local)` arm (`time/calculations.rb:148-171`)
+    // selects a receiver whose `zone` is a `TZInfo` zone OBJECT. No trails
+    // `::Time` carries one — its `zone` is the tzdata abbreviation String — and
+    // that arm's second-occurrence correction is not lost with it, because the
+    // `isdst` `::Time.local` takes below makes the same choice.
+  } else if (this.zone != null) {
+    return RubyTime.local(
+      newSec,
+      newMin,
+      newHour,
+      newDay,
+      newMonth,
+      newYear,
+      null,
+      null,
+      this.isdst,
+      null,
+    );
+  } else {
+    return RubyTime.new(newYear, newMonth, newDay, newHour, newMin, newSec, this.utcOffset);
+  }
+}
+
+/** `options.inspect` in `change`'s raise (`time/calculations.rb:135`). */
+function inspectOptions(options: ChangeOptions): string {
+  const pairs = Object.entries(options).map(
+    ([key, value]) => `${key}: ${typeof value === "string" ? `"${value}"` : String(value)}`,
+  );
+  return `{${pairs.join(", ")}}`;
+}
+
+/** Mirrors: `Time#advance` (`time/calculations.rb:194-217`) */
+export function advance(this: RubyTime, options: AdvanceOptions): RubyTime {
+  // Rails writes the normalised `:weeks` / `:days` back into the caller's hash;
+  // `Date#advance` reads it only, and `date_ext_test.rb:367-371` asserts the
+  // difference, so the write goes into a copy rather than the caller's object.
+  options = { ...options };
+
+  if (options.weeks != null) {
+    const partialWeeks = options.weeks - Math.trunc(options.weeks);
+    options.weeks = Math.trunc(options.weeks);
+    options.days = (options.days ?? 0) + 7 * partialWeeks;
+  }
+
+  if (options.days != null) {
+    const partialDays = options.days - Math.trunc(options.days);
+    options.days = Math.trunc(options.days);
+    options.hours = (options.hours ?? 0) + 24 * partialDays;
+  }
+
+  const d = dateAdvance(this.toDate(), options);
+  const timeAdvancedByDate = change.call(this, { year: d.year, month: d.month, day: d.day });
+  const secondsToAdvance =
+    (options.seconds ?? 0) + (options.minutes ?? 0) * 60 + (options.hours ?? 0) * 3600;
+
+  if (secondsToAdvance === 0) {
+    return timeAdvancedByDate;
+  } else {
+    return since.call(timeAdvancedByDate, secondsToAdvance);
+  }
+}
+
+/** Mirrors: `Time#ago` (`time/calculations.rb:220-222`) */
+export function ago(this: RubyTime, seconds: number): RubyTime {
+  return since.call(this, -seconds);
+}
+
+/** Mirrors: `Time#since` (`time/calculations.rb:225-234`) */
+export function since(this: RubyTime, seconds: number): RubyTime {
+  return this.plus(seconds);
+}
+
+/** Mirrors: `Time#beginning_of_day` (`time/calculations.rb:238-240`) */
+export function beginningOfDay(this: RubyTime): RubyTime {
+  return change.call(this, { hour: 0 });
+}
+
+/** Mirrors: `Time#middle_of_day` (`time/calculations.rb:246-248`) */
+export function middleOfDay(this: RubyTime): RubyTime {
+  return change.call(this, { hour: 12 });
+}
+
+/** Mirrors: `Time#end_of_day` (`time/calculations.rb:256-263`) */
+export function endOfDay(this: RubyTime): RubyTime {
+  return change.call(this, {
+    hour: 23,
+    min: 59,
+    sec: 59,
+    usec: new Rational(999999999, 1000),
+  });
+}
+
+/** Mirrors: `Time#beginning_of_hour` (`time/calculations.rb:267-269`) */
+export function beginningOfHour(this: RubyTime): RubyTime {
+  return change.call(this, { min: 0 });
+}
+
+/** Mirrors: `Time#end_of_hour` (`time/calculations.rb:273-279`) */
+export function endOfHour(this: RubyTime): RubyTime {
+  return change.call(this, {
+    min: 59,
+    sec: 59,
+    usec: new Rational(999999999, 1000),
+  });
+}
+
+/** Mirrors: `Time#beginning_of_minute` (`time/calculations.rb:283-285`) */
+export function beginningOfMinute(this: RubyTime): RubyTime {
+  return change.call(this, { sec: 0 });
+}
+
+/** Mirrors: `Time#end_of_minute` (`time/calculations.rb:289-294`) */
+export function endOfMinute(this: RubyTime): RubyTime {
+  return change.call(this, {
+    sec: 59,
+    usec: new Rational(999999999, 1000),
+  });
+}
+
+// Rails' `alias`es over the methods above — `alias :in :since`
+// (`time/calculations.rb:235`), the day boundaries (:241-243, :250-254, :264),
+// the hour ones (:270, :281) and the minute ones (:286, :295).
+export { since as in };
+export { beginningOfDay as midnight };
+export { beginningOfDay as atMidnight };
+export { beginningOfDay as atBeginningOfDay };
+export { middleOfDay as midday };
+export { middleOfDay as noon };
+export { middleOfDay as atMidday };
+export { middleOfDay as atNoon };
+export { middleOfDay as atMiddleOfDay };
+export { endOfDay as atEndOfDay };
+export { beginningOfHour as atBeginningOfHour };
+export { endOfHour as atEndOfHour };
+export { beginningOfMinute as atBeginningOfMinute };
+export { endOfMinute as atEndOfMinute };
+
+/** Mirrors: `Time#prev_day` (`time/calculations.rb:358-360`) */
+export function prevDay(this: RubyTime, days = 1): RubyTime {
+  return advance.call(this, { days: -days });
+}
+
+/** Mirrors: `Time#next_day` (`time/calculations.rb:363-365`) */
+export function nextDay(this: RubyTime, days = 1): RubyTime {
+  return advance.call(this, { days: days });
+}
+
+/** Mirrors: `Time#prev_month` (`time/calculations.rb:368-370`) */
+export function prevMonth(this: RubyTime, months = 1): RubyTime {
+  return advance.call(this, { months: -months });
+}
+
+/** Mirrors: `Time#next_month` (`time/calculations.rb:373-375`) */
+export function nextMonth(this: RubyTime, months = 1): RubyTime {
+  return advance.call(this, { months: months });
+}
+
+/** Mirrors: `Time#prev_year` (`time/calculations.rb:378-380`) */
+export function prevYear(this: RubyTime, years = 1): RubyTime {
+  return advance.call(this, { years: -years });
+}
+
+/** Mirrors: `Time#next_year` (`time/calculations.rb:383-385`) */
+export function nextYear(this: RubyTime, years = 1): RubyTime {
+  return advance.call(this, { years: years });
+}
+
+declare module "@blazetrails/date" {
+  interface Time {
+    secondsSinceMidnight(): number;
+    secondsUntilEndOfDay(): number;
+    secFraction(): number;
+    change(options: ChangeOptions): Time;
+    advance(options: AdvanceOptions): Time;
+    ago(seconds: number): Time;
+    since(seconds: number): Time;
+    in(seconds: number): Time;
+    beginningOfDay(): Time;
+    midnight(): Time;
+    atMidnight(): Time;
+    atBeginningOfDay(): Time;
+    middleOfDay(): Time;
+    midday(): Time;
+    noon(): Time;
+    atMidday(): Time;
+    atNoon(): Time;
+    atMiddleOfDay(): Time;
+    endOfDay(): Time;
+    atEndOfDay(): Time;
+    beginningOfHour(): Time;
+    atBeginningOfHour(): Time;
+    endOfHour(): Time;
+    atEndOfHour(): Time;
+    beginningOfMinute(): Time;
+    atBeginningOfMinute(): Time;
+    endOfMinute(): Time;
+    atEndOfMinute(): Time;
+    prevDay(days?: number): Time;
+    nextDay(days?: number): Time;
+    prevMonth(months?: number): Time;
+    nextMonth(months?: number): Time;
+    prevYear(years?: number): Time;
+    nextYear(years?: number): Time;
+  }
+
+  namespace Time {
+    export function current(): TimeWithZone | Time;
+    export function daysInMonth(month: number, year?: number): number;
+    export function daysInYear(year?: number): number;
+    export function rfc3339(str: string): Time;
+  }
+}
+
+// `class Time` is a reopening, so the members above land on the class itself —
+// the TS spelling of Ruby's open class, per CLAUDE.md "Module mixins".
+Object.assign(RubyTime.prototype, {
+  secondsSinceMidnight,
+  secondsUntilEndOfDay,
+  secFraction,
+  change,
+  advance,
+  ago,
+  since,
+  in: since,
+  beginningOfDay,
+  midnight: beginningOfDay,
+  atMidnight: beginningOfDay,
+  atBeginningOfDay: beginningOfDay,
+  middleOfDay,
+  midday: middleOfDay,
+  noon: middleOfDay,
+  atMidday: middleOfDay,
+  atNoon: middleOfDay,
+  atMiddleOfDay: middleOfDay,
+  endOfDay,
+  atEndOfDay: endOfDay,
+  beginningOfHour,
+  atBeginningOfHour: beginningOfHour,
+  endOfHour,
+  atEndOfHour: endOfHour,
+  beginningOfMinute,
+  atBeginningOfMinute: beginningOfMinute,
+  endOfMinute,
+  atEndOfMinute: endOfMinute,
+  prevDay,
+  nextDay,
+  prevMonth,
+  nextMonth,
+  prevYear,
+  nextYear,
+});
+
+Object.assign(RubyTime, { current, daysInMonth, daysInYear, rfc3339 });

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -445,6 +445,14 @@ export {
 } from "./testing/deprecation.js";
 
 export * from "./time-ext.js";
+// `class Time`'s calculations reopening (`core_ext/time/calculations.rb`) is
+// imported for its effect only: it is a reopening, so what it publishes is the
+// methods it lands on `Time`, and its `current`/`change`/`advance`/`ago`/
+// `since`/`beginning_of_*` spellings would collide in a flat ESM namespace with
+// the `Date`-receiver arm below and with `time-ext.js`'s, exactly as
+// core-ext/date's calculations do. It is reached by name through the subpath
+// `@blazetrails/activesupport/core-ext/time/calculations`.
+import "./core-ext/time/calculations.js";
 export * from "./core-ext/time/conversions.js";
 // Two Ruby methods, one TS spelling: the class-side parser `Time.rfc3339(str)`
 // (`core_ext/time/calculations.rb:69-83`) lives in `time-ext.js`, and the

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -445,13 +445,10 @@ export {
 } from "./testing/deprecation.js";
 
 export * from "./time-ext.js";
-// `class Time`'s calculations reopening (`core_ext/time/calculations.rb`) is
-// imported for its effect only: it is a reopening, so what it publishes is the
-// methods it lands on `Time`, and its `current`/`change`/`advance`/`ago`/
-// `since`/`beginning_of_*` spellings would collide in a flat ESM namespace with
-// the `Date`-receiver arm below and with `time-ext.js`'s, exactly as
-// core-ext/date's calculations do. It is reached by name through the subpath
-// `@blazetrails/activesupport/core-ext/time/calculations`.
+// `core_ext/time/calculations.rb` is a reopening, so what it publishes is the
+// methods it lands on `Time`; its names are reached through the subpath
+// `@blazetrails/activesupport/core-ext/time/calculations`, as core-ext/date's
+// calculations are and for the same collision reason documented below.
 import "./core-ext/time/calculations.js";
 export * from "./core-ext/time/conversions.js";
 // Two Ruby methods, one TS spelling: the class-side parser `Time.rfc3339(str)`

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -697,7 +697,10 @@ export class Time {
    * sub-second as a `Rational` (`time.c`, `time_s_mkutc` -> `time_new_timew`),
    * so the fold goes through `Rational` rather than a double, and passing
    * `usec` truncates `sec` to a whole second exactly as MRI's does:
-   * `Time.utc(2008, 3, 1, 6, 0, 0.3, 5).nsec` is `5000`.
+   * `Time.utc(2008, 3, 1, 6, 0, 0.3, 5).nsec` is `5000`. The microsecond goes
+   * through `num_exact` too (`time_arg`), so a Rational one — Rails'
+   * `Time.local(..., 59, Rational(999999999, 1000))`
+   * (`core_ext/time/calculations.rb:256-263`) — keeps its full precision.
    */
   static utc(
     year: number | string,
@@ -717,9 +720,6 @@ export class Time {
       usec === undefined
         ? sec
         : new Rational(sec instanceof Rational ? sec.toI() : obj2vint(sec ?? 0), 1).add(
-            // MRI takes the microsecond through `num_exact` (`time.c`
-            // `time_arg`), so a Rational one — `Time.local(..., 59,
-            // Rational(999999999, 1000))` — keeps its full precision.
             numExact(usec).quo(1_000_000),
           ),
       "UTC",
@@ -778,9 +778,6 @@ export class Time {
       usec === undefined
         ? (sec ?? 0)
         : new Rational(sec instanceof Rational ? sec.toI() : obj2vint(sec ?? 0), 1).add(
-            // MRI takes the microsecond through `num_exact` (`time.c`
-            // `time_arg`), so a Rational one — `Time.local(..., 59,
-            // Rational(999999999, 1000))` — keeps its full precision.
             numExact(usec).quo(1_000_000),
           ),
     );

--- a/packages/date/src/time.ts
+++ b/packages/date/src/time.ts
@@ -706,7 +706,7 @@ export class Time {
     hour: number | string | null = 0,
     min: number | string | null = 0,
     sec: number | string | Rational | null = 0,
-    usec?: number,
+    usec?: number | Rational,
   ): Time {
     return new Time(
       year,
@@ -717,7 +717,10 @@ export class Time {
       usec === undefined
         ? sec
         : new Rational(sec instanceof Rational ? sec.toI() : obj2vint(sec ?? 0), 1).add(
-            new Rational(Math.round(usec * 1_000), 1_000_000_000),
+            // MRI takes the microsecond through `num_exact` (`time.c`
+            // `time_arg`), so a Rational one — `Time.local(..., 59,
+            // Rational(999999999, 1000))` — keeps its full precision.
+            numExact(usec).quo(1_000_000),
           ),
       "UTC",
     );
@@ -746,7 +749,7 @@ export class Time {
           hour?: number | string | null,
           min?: number | string | null,
           sec?: number | string | Rational | null,
-          usec?: number,
+          usec?: number | Rational,
         ]
       | [
           sec: number | string | Rational | null,
@@ -775,7 +778,10 @@ export class Time {
       usec === undefined
         ? (sec ?? 0)
         : new Rational(sec instanceof Rational ? sec.toI() : obj2vint(sec ?? 0), 1).add(
-            new Rational(Math.round(usec * 1_000), 1_000_000_000),
+            // MRI takes the microsecond through `num_exact` (`time.c`
+            // `time_arg`), so a Rational one — `Time.local(..., 59,
+            // Rational(999999999, 1000))` — keeps its full precision.
+            numExact(usec).quo(1_000_000),
           ),
     );
   }
@@ -1013,6 +1019,18 @@ export class Time {
   /** Ruby `Time#dst?`, the `isdst` alias (`ruby/time.c` `time_isdst`). */
   isDst(): boolean {
     return this.isdst;
+  }
+
+  /**
+   * Ruby `Time#to_i` (`ruby/time.c` `time_to_i`), the number of whole seconds
+   * since the epoch. MRI truncates towards negative infinity — the sub-second
+   * is held as a non-negative `Rational` off a floored second — so a pre-epoch
+   * time answers the floor rather than the truncation.
+   */
+  toI(): number {
+    const nanoseconds = this.#instant.epochNanoseconds;
+    const seconds = nanoseconds / 1_000_000_000n - (nanoseconds % 1_000_000_000n < 0n ? 1n : 0n);
+    return Number(seconds);
   }
 
   /**

--- a/scripts/parity/conventions.test.ts
+++ b/scripts/parity/conventions.test.ts
@@ -473,10 +473,13 @@ describe("RUBY_FILE_TS_OVERRIDES", () => {
     // calculations widen through `in_time_zone` (date/calculations.rb:55-87)
     // rather than operating on an instant. `DateTime` is its own receiver too:
     // its calculations answer a civil date at an offset rather than an instant.
-    // Both files sit at the Rails path the default rule already produces; the
-    // entries are what split the buckets off `date/acts_like.rb` and
-    // `date_time/acts_like.rb`, those two classes' first reopenings.
-    expect(rubyFileToTs("core_ext/time/calculations.rb", "activesupport")).toBe("time-ext.ts");
+    // `Time`'s reopening is ported onto trails' `Time` itself. All three files
+    // sit at the Rails path the default rule already produces; the entries are
+    // what split the buckets off `object/blank.rb`, `date/acts_like.rb` and
+    // `date_time/acts_like.rb`, those three classes' first reopenings.
+    expect(rubyFileToTs("core_ext/time/calculations.rb", "activesupport")).toBe(
+      "core-ext/time/calculations.ts",
+    );
     expect(rubyFileToTs("core_ext/date/calculations.rb", "activesupport")).toBe(
       "core-ext/date/calculations.ts",
     );

--- a/scripts/parity/conventions.ts
+++ b/scripts/parity/conventions.ts
@@ -180,17 +180,20 @@ export const RUBY_FILE_TS_OVERRIDES: Record<string, string> = {
   // `date_time/acts_like.rb:6` — so the three `calculations.rb` reopenings
   // (`time/calculations.rb:11`, `date/calculations.rb:10`,
   // `date_time/calculations.rb:5`) contribute 129 methods to buckets named
-  // after files that define none of them. trails ports the `Time` and `DateTime`
-  // reopenings onto the one `time-ext.ts`, the same one-TS-file-for-several-
-  // reopenings shape as `inflector.ts` above; the `Date` reopening has its own
-  // receiver and its own file (see below).
+  // after files that define none of them. Each has its own receiver and its own
+  // file at the path the default rule already produces, and the three entries
+  // below are what split those buckets off the first reopenings.
   // `ActiveSupport::JSON` is defined by `json/decoding.rb:12` first, so the
   // module's whole singleton surface — `encode`/`dump` from
   // `json/encoding.rb:16-43` included — buckets there. trails splits the two
   // Ruby modules the way Rails documents them: `ActiveSupport::JSON` on
   // `json.ts`, `ActiveSupport::JSON::Encoding` on `json/encoding.ts`.
   "activesupport:json/decoding.rb": "json.ts",
-  "activesupport:core_ext/time/calculations.rb": "time-ext.ts",
+  // The `Time` arm is the reopening of `Time` itself, ported onto trails'
+  // `Time` (`packages/date/src/time.ts`) by the mixin idiom, so it has its own
+  // file; the entry splits the bucket off `object/blank.rb` (Time's first
+  // reopening).
+  "activesupport:core_ext/time/calculations.rb": "core-ext/time/calculations.ts",
   // The `Date` arm widens through `in_time_zone` before delegating to the
   // `Time` arm (`date/calculations.rb:55-87`), so it has its own receiver —
   // `Temporal.PlainDate` — and its own file. The entry is what splits the


### PR DESCRIPTION
Ports `activesupport/lib/active_support/core_ext/time/calculations.rb` onto trails'
`Time` class, at the Rails path.

## What changed

`packages/activesupport/src/core-ext/time/calculations.ts` is new: the reopening,
written with the settled mixin idiom from CLAUDE.md — `this`-typed functions in
the Rails-shaped file, assigned onto `Time` (`packages/date/src/time.ts`) at the
bottom of the module, with a `declare module "@blazetrails/date"` augmentation
carrying the types. `index.ts` imports it for effect, which is what
`require "active_support/core_ext/time/calculations"` is; it is reached by name
through the `@blazetrails/activesupport/core-ext/time/calculations` subpath, the
same shape `core-ext/date/calculations` already uses (its `change`/`advance`/
`current`/`beginning_of_*` spellings would collide in a flat ESM namespace).

Ported, with Rails' names, parameter names, defaults and control flow:
`COMMON_YEAR_DAYS_IN_MONTH`, the class methods `current` / `days_in_month` /
`days_in_year` / `rfc3339`, and the instance methods `seconds_since_midnight`,
`seconds_until_end_of_day`, `sec_fraction`, `change`, `advance`, `ago`, `since`,
`beginning_of_day`, `middle_of_day`, `end_of_day`, `beginning_of_hour`,
`end_of_hour`, `beginning_of_minute`, `end_of_minute`, `prev_day`/`next_day`,
`prev_month`/`next_month`, `prev_year`/`next_year`, plus every `alias` over them.

Two supporting changes in the `date` package, both Ruby-faithful and both
load-bearing for the above:

- `Time#to_i` (`ruby/time.c` `time_to_i`), which `seconds_since_midnight` and
  `seconds_until_end_of_day` are written on.
- `Time.local` / `Time.utc` take their `usec` through `num_exact`, as MRI's
  `time_arg` does, so `Time.local(2007, 8, 12, 23, 59, 59, Rational(999999999, 1000))`
  — the shape `test_end_of_day` asserts against — builds instead of raising
  `FloatDomainError`.

Tests are Rails' own, verbatim, from `time_ext_test.rb`, against a `Time`
receiver: `seconds_since_midnight`, `seconds_until_end_of_day`,
`beginning_of_day`, `middle_of_day`, `beginning_of_hour`, `beginning_of_minute`,
`end_of_day`, `end_of_hour`, `end_of_minute`, `change`, `advance`, `ago`,
`since`, `days_in_month_with_year`, `days_in_year_with_year`.

`calculations.trails.test.ts` carries two cases Rails has no test for: `advance`
over a NEGATIVE fractional `:weeks`/`:days`, where Ruby's `divmod(1)` floors and
truncation would land a whole week or day away. Both expectations are MRI's own
answers for the Rails body, transcribed from a `ruby -e` run.

`test_advance`'s trailing block is the one thing left out: it asserts
`Time.new(2021, 5, 29, 0, 0, 0, ActiveSupport::TimeZone["Moscow"])` against the
`"+03:00"` spelling, and trails' `Time.new` does not take a `TimeZone` object as
its zone argument. That is a `Time.new` gap rather than an `advance` one, and
the nineteen `Time.local` assertions above it cover the ported body.

## On the override, and on the "count strictly up" criterion

The story asked for `RUBY_FILE_TS_OVERRIDES`' entry for this file to be deleted
so the default kebab-case rule resolves it. That turns out to be wrong, and for
the reason the neighbouring `Date` and `DateTime` entries already document: the
Rails extractor stamps `Time`'s methods with its FIRST reopening,
`object/blank.rb:186`, so the entry is not a path override at all — it is what
splits the `core_ext/time/calculations.rb` bucket off `object/blank.rb`.
Deleting it collapses the bucket entirely (measured: `files 182/195 -> 181/194`,
`1826/1988 -> 1812/2001`). The entry is kept and re-pointed at the new file,
with the comment block above it rewritten to say so.

The story's other criterion — activesupport's ported-method count strictly up —
is not reachable, because its premise is stale. It was filed off #6160's reading
of "21 match, 30 still read missing"; on current `main` the bucket already reads
**38/38**, so this is a shape convergence rather than a coverage one and the
count is flat by construction. Per-file `matched`/`total` diffed against
`origin/main` is identical for every activesupport file.

## The two class methods NOT ported, and why

Reviewer asked about `Time.===` (`:17-21`) and `at_with_coercion`/`at`
(`:44-60`), which the story's Context does name. Both were already registered as
deliberately-not-mirrored before this PR; neither is a gap this PR opened, and
the measured bucket is 38/38 with them accounted for. Spelling that out, since
the first version of this description listed only what WAS ported:

**`Time.===` is excluded from the measured population by `OPERATORS`**
(`scripts/parity/conventions.ts:350-354`). Rails overrides case equality so that
`Time === some_time_with_zone` is true inside a `case`/`when`. JS has no
`case`/`when` dispatch and no overridable `===`, so there is no call site for it
to answer — the `caseEquals` spelling exists only where a class is a range-like
receiver something explicitly calls (`ActiveSupport::CompareWithRange`,
`ActiveModel::Name`), which `Time` is not. This is the language shortcoming the
`OPERATORS` exclusion encodes.

**`at`, `at_with_coercion` and `at_without_coercion` are in a
`SCOPED_SKIP_GROUPS` entry scoped to this exact Ruby file**
(`scripts/parity/conventions.ts:604-627`). That entry predates this PR and
covers the whole family of `alias_method` chains the file installs. On reading
it against the Rails source, its reason is right for the operator pairs and
WRONG for `Time.at` — `at` is an ordinary class method, and now that the file is
reopened from activesupport the override does have a receiver. So per CLAUDE.md
("a documented deviation is debt, not permission"), it is filed rather than left
silent: `0113-branch-and-guard-parity/time-at-with-coercion-onto-time-class`,
which also carries splitting the skip group and rewriting the four hollow `at
with ...` tests in `time-ext.test.ts` that currently assert on a JS `Date`
without calling `at` at all.

It is not folded into this PR because this PR is already over its size ceiling
(below).

## Size

**950 LOC against a 700 ceiling — over, and flagged rather than trimmed.** The
split is 443 implementation + 463 tests + 44 wiring/tooling. The overage is test
transcription: the acceptance criteria ask for Rails' own test names verbatim,
and `time_ext_test.rb`'s `test_change`, `test_advance` and `test_days_in_month_with_year`
are long assertion blocks. Cutting them to hit the number would trade the
criterion for the metric, so I have left them and am flagging the overage for a
maintainer call instead. Splitting the port itself across two PRs would stack
them, which the repo forbids.

## Scope left standing

`time-ext.ts` keeps its `RubyTime`-receiver overloads on `change` and `advance`,
which now duplicate the reopening's bodies. Retiring them is a module-eval-graph
question (a TDZ cycle has to be ruled out against the built `dist/**.js`), so it
is filed rather than folded in:
`0113-branch-and-guard-parity/time-ext-rubytime-arms-delegate-to-time-reopening`.

**Story author sign-off: GIVEN (2026-08-26, @deanmarano).** Three items were
argued from measurement rather than met, and all three are accepted:

- `RUBY_FILE_TS_OVERRIDES` kept and re-pointed rather than deleted, against the
  story's literal "removed" criterion. Accepted: the entry is a bucket-splitter,
  not a path override, and deleting it regresses the measurement.
- Ported-method count flat rather than strictly up. Accepted: the criterion's
  premise ("21 match, 30 missing", from #6160) is stale — the bucket already
  read 38/38 on `main` before this PR, so the port is a shape convergence and
  the count cannot rise.
- 950 LOC against the 700 ceiling. Waived: the implementation half is 443, and
  the excess is Rails-verbatim test transcription the acceptance criteria
  themselves demand.

Recorded here so the next reader does not re-open them.

## Verification

`pnpm parity:api` (per-file non-regressing), `pnpm parity:api:calls`,
`pnpm parity:api:calls:args`, `pnpm parity:api:extra` (`core-ext/time/calculations.ts`
— 0 novel), `pnpm parity:api:extra:gate`, `pnpm typecheck`, `pnpm lint` all
green. `packages/date/src` + the two time core-ext suites: 624 passed.

Closes-story: activesupport-core-ext-time-calculations-on-time-class
