### PR TITLE
refactor(activerecord): pass ActiveModel::Attribute values to Arel directly; drop dead SQLite _baseColumnType (RFC 0112)

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2419,9 +2419,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
           columnOptions.stored = column.isVirtualStored();
           columnOptions.type = column.type;
         } else if (column.hasDefault) {
-          const type = (await this.lookupCastTypeFromColumn(
-            column,
-          )) as import("@blazetrails/activemodel").Type;
+          const type = await this.lookupCastTypeFromColumn(column);
           let defaultValue: unknown = type.deserialize(column.default);
           if (defaultValue == null) defaultValue = () => column.defaultFunction;
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1890,12 +1890,6 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     }
   }
 
-  private _baseColumnType(type: string, options?: Record<string, unknown>): string {
-    const opts = (options ?? {}) as ColumnOptions;
-    if (type !== "virtual") return this.typeToSql(type as ColumnType, opts);
-    return options?.type ? this.typeToSql(String(options.type) as ColumnType, opts) : "";
-  }
-
   /**
    * Parse FK constraint names from CREATE TABLE SQL. PRAGMA
    * foreign_key_list doesn't expose names, but the DDL does when

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -10,13 +10,7 @@ import type { Base } from "./base.js";
 import type { CounterCacheCounters } from "./counter-cache.js";
 import { ArgumentError, SerializeCastValue } from "@blazetrails/activemodel";
 import { runCallbacks } from "@blazetrails/activesupport";
-import {
-  InsertManager,
-  UpdateManager,
-  DeleteManager,
-  Nodes,
-  Table as ArelTable,
-} from "@blazetrails/arel";
+import { InsertManager, UpdateManager, DeleteManager, Table as ArelTable } from "@blazetrails/arel";
 import {
   ActiveRecordError,
   ReadOnlyRecord,
@@ -259,12 +253,9 @@ export async function _insertRecord(
 
   const entries = Object.entries(values);
   if (entries.length > 0) {
-    // Rails: `im.insert(values.transform_keys { |name| arel_table[name] })` —
-    // the values are `ActiveModel::Attribute`s, which Rails' Arel visitor binds
-    // via `visit_ActiveModel_Attribute`. trails' visitor binds through
-    // `BindParam`, which unwraps `valueForDatabase` on the same seam, so the
-    // wrap is where the transform is and nothing else changes.
-    im.insert(entries.map(([col, val]) => [arelTable.get(col), new Nodes.BindParam(val)]));
+    // Rails: `im.insert(values.transform_keys { |name| arel_table[name] })`
+    // (persistence.rb:247).
+    im.insert(entries.map(([col, val]) => [arelTable.get(col), val]));
   }
 
   if (typeof connection.insert === "function") {
@@ -325,10 +316,8 @@ export async function _updateRecord(
   const arelTable: ArelTable = (this as any).arelTable;
   const um = new UpdateManager();
   um.table(arelTable);
-  // Rails: `um.set(values.transform_keys { |name| arel_table[name] })` — the
-  // values are `ActiveModel::Attribute`s bound through Arel, as in
-  // `_insertRecord` above.
-  um.set(setEntries.map(([col, val]) => [arelTable.get(col), new Nodes.BindParam(val)]));
+  // Rails: `um.set(values.transform_keys { |name| arel_table[name] })`.
+  um.set(setEntries.map(([col, val]) => [arelTable.get(col), val]));
 
   for (const [col, val] of Object.entries(constraints)) {
     um.where(arelTable.get(col).eq(val));


### PR DESCRIPTION
Two of the four bundled stories were already converged on `main`; the other two
reduce to removing the residual trails-only surface each one describes.

### `visit-activemodel-attribute-in-tosql-visitor`

`Arel::Visitors::ToSql#visitActiveModelAttribute` (to-sql.ts:1049) already exists
and binds via `collector.addBind(o, bindBlock())`, mirroring `to_sql.rb:756`, and
both `visitArelNodesValuesList` (`to_sql.rb:106-114`) and
`visitArelNodesAssignment` (`to_sql.rb:630-641`) already dispatch an
`ActiveModel::Attribute` right-hand side through `visit`. So `_insertRecord` and
`_updateRecord` no longer need their `new Nodes.BindParam(val)` wraps: they now
pass the `attributes_with_values` map straight to `im.insert` / `um.set`, line for
line with `persistence.rb:247` and `persistence.rb:~330`. The `Nodes` import in
`persistence.ts` had no other user and is dropped.

Behaviour-neutral on both bind paths: `visitArelNodesBindParam` was unwrapping to
`o.value` (the same Attribute) before handing it to the collector, so the prepared
(`compileWithBinds`) and unprepared (`SubstituteBinds`) collectors see exactly what
they saw before.

### `sqlite-add-column-delegate-to-super`

`SQLite3Adapter#addColumn` already keeps only the `isInvalidAlterTableType` branch
and otherwise calls `super` (`sqlite3_adapter.rb:338-347`); the hand-rolled
`COLLATE`/`GENERATED ALWAYS AS`/`NOT NULL`/`DEFAULT` concatenation is gone. What
survived it was `_baseColumnType`, which had no callers left anywhere in the repo
and no Rails counterpart. Deleted.

### Already on `main` — no code in this PR

- `mysql2-handle-warnings-report-arm` — #7055 took the deeper convergence the story
  flagged: the symbol → behaviour mapping now resolves once in
  `ActiveRecord.dbWarningsAction=` (`ar-config.ts:234`, mirroring
  `active_record.rb:236-252`), `"report"` included, and
  `AbstractMysqlAdapter#handleWarnings` just calls the resolved action. Marked done
  against #7055.
- `route-apply-join-dependency-through-distinct-relation-for-primary-key` — #6634
  collapsed the four call sites onto `applyJoinDependency`, which now delegates to
  `c.distinctRelationForPrimaryKey(relation)` (`finder_methods.rb:473-477`), and the
  composite-PK `NotImplementedError` is gone. The one remaining
  `_materializeLimitedIds` caller is `_materializeDistinctPkIds`, the subquery site
  owned by `converge-relation-subquery-distinct-pk-materialization`. Marked done
  against #6634.

Gates: `parity:api:calls` OK (357 baselined, no new rows), `parity:api:calls:args`
OK, `parity:api:extra --package activerecord` clean, typecheck green,
persistence / to-sql / casted / sqlite3 adapter suites green.

Closes-story: sqlite-add-column-delegate-to-super
Closes-story: visit-activemodel-attribute-in-tosql-visitor
