### PR TITLE
fix(activesupport): annotate yaml re-exports so yaml.d.ts emits (RFC 0125)

### DIFF
--- a/packages/activesupport/src/yaml.ts
+++ b/packages/activesupport/src/yaml.ts
@@ -20,8 +20,8 @@ const yaml = await import("yaml").catch(() => {
   return { parse: missing, stringify: missing } as unknown as typeof import("yaml");
 });
 
-// The annotations are load-bearing, not decoration: inferring these types from
-// `yaml` names `yaml/dist/parse/cst` through a non-portable `node_modules` path,
-// which TS2883 rejects outright and 5.9.3 emitted into `yaml.d.ts` anyway.
+// The annotations are load-bearing: inferred, these types name
+// `yaml/dist/parse/cst` through a non-portable `node_modules` path, and TS2883
+// then suppresses `yaml.d.ts` entirely.
 export const parse: typeof import("yaml").parse = yaml.parse;
 export const stringify: typeof import("yaml").stringify = yaml.stringify;

--- a/packages/activesupport/src/yaml.ts
+++ b/packages/activesupport/src/yaml.ts
@@ -20,4 +20,8 @@ const yaml = await import("yaml").catch(() => {
   return { parse: missing, stringify: missing } as unknown as typeof import("yaml");
 });
 
-export const { parse, stringify } = yaml;
+// The annotations are load-bearing, not decoration: inferring these types from
+// `yaml` names `yaml/dist/parse/cst` through a non-portable `node_modules` path,
+// which TS2883 rejects outright and 5.9.3 emitted into `yaml.d.ts` anyway.
+export const parse: typeof import("yaml").parse = yaml.parse;
+export const stringify: typeof import("yaml").stringify = yaml.stringify;


### PR DESCRIPTION
`packages/activesupport/src/yaml.ts` ended with a destructured re-export,
`export const { parse, stringify } = yaml;`. Its inferred type can only be
named through `yaml/dist/parse/cst` — a `node_modules` path — which is not
portable. Under `typescript@7.1.0-dev.20260825.1` that is `TS2883`, and the
error suppressed `activesupport/dist/yaml.d.ts` entirely, cascading into 7
further diagnostics (5× `TS7016`, 2× `TS7006`) across actionview, activemodel
and activerecord. Under 5.9.3 it was silent: the emit simply embedded the
non-portable reference, so every consumer of `@blazetrails/activesupport/yaml`
was typed by accident.

The remedy the diagnostic names: an explicit annotation on each export.

Verified:

- `pnpm build` + `pnpm typecheck` green on the repo's `typescript@5.9.3`.
- `packages/activesupport/dist/yaml.d.ts` now exists and reads
  `export declare const parse: typeof import("yaml").parse;` (and `stringify`);
  `grep -c node_modules` on it is `0`.
- Full `tsc --build --force` under the 7.1 pin: only the `TS4094` pair in
  `trailties/src/application.ts` remains — the 8 yaml-rooted diagnostics are
  gone, with no `@ts-expect-error`, `any`, or `eslint-disable` at any consumer.

Closes-story: fix-yaml-inferred-type-portability
