### PR TITLE
fix(trailties): name and annotate Application's executor/reloader class expressions

### DIFF
--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -37,12 +37,15 @@ export class Application extends Engine {
   private _credentials?: EncryptedFile;
   private _app?: RackApp;
   /** Rails: `@executor = Class.new(ActiveSupport::Executor)` (`application.rb:122`);
-   * `@reloader.executor = @executor` (`application.rb:124`) is the constructor. */
-  readonly executor = class extends Executor {};
+   * `@reloader.executor = @executor` (`application.rb:124`) is the constructor.
+   * The `typeof Executor` annotation is declaration-emit only: TypeScript
+   * cannot write a `.d.ts` for an anonymous class type inheriting `#private`
+   * fields (TS4094). */
+  readonly executor: typeof Executor = class extends Executor {};
   /** Rails: `@reloader = Class.new(ActiveSupport::Reloader)` (`application.rb:123`) —
    * a per-application subclass so one app's prepare callbacks don't leak into
-   * another's. */
-  readonly reloader = class extends Reloader {};
+   * another's. Annotated for the same declaration-emit reason as `executor`. */
+  readonly reloader: typeof Reloader = class extends Reloader {};
   logger: Logger | null = null;
   cache: CacheStore | null = null;
 

--- a/packages/trailties/src/application/executor-seam.trails.test.ts
+++ b/packages/trailties/src/application/executor-seam.trails.test.ts
@@ -122,3 +122,33 @@ describe("ActionDispatch::Executor around a request (trails)", () => {
     expect(() => Base.asynchronousQueriesSession()).toThrow(SESSION_ERROR);
   });
 });
+
+// `Class.new(ActiveSupport::Executor)` / `Class.new(ActiveSupport::Reloader)`
+// (`application.rb:122-123`). Rails gets the per-app isolation for free from
+// `Class.new` and has no test for it; trails' properties carry a written type,
+// which a plain `Executor` would also satisfy.
+describe("Rails::Application#executor and #reloader are per-application (trails)", () => {
+  class TestApplication extends Application {}
+
+  it("does not share callbacks between two applications", () => {
+    const one = new TestApplication();
+    const two = new TestApplication();
+
+    expect(one.executor).not.toBe(two.executor);
+    expect(one.reloader).not.toBe(two.reloader);
+
+    const ran: string[] = [];
+    one.executor.toRun(() => ran.push("one"));
+    two.executor.wrap(() => {});
+
+    expect(ran).toEqual([]);
+    one.executor.wrap(() => {});
+    expect(ran).toEqual(["one"]);
+  });
+
+  it("wires the reloader's executor to the application's own executor", () => {
+    const app = new TestApplication();
+
+    expect(app.reloader.executor).toBe(app.executor);
+  });
+});


### PR DESCRIPTION
`Application#executor` and `#reloader` are anonymous class expressions mirroring Rails' `@executor = Class.new(ActiveSupport::Executor)` / `@reloader = Class.new(ActiveSupport::Reloader)` (`railties/lib/rails/application.rb:122-123`). TypeScript 7.0.2 refuses to emit a `.d.ts` for an exported anonymous class type inheriting `#private` fields:

```
packages/trailties/src/application.ts(41,12): error TS4094: Property '#private' of exported anonymous class type may not be private or protected.
packages/trailties/src/application.ts(45,12): error TS4094: …
```

Fix: annotate each property as `typeof Executor` / `typeof Reloader`, so the emitter has a nameable type to write. The `Class.new` shape itself is untouched — the class expressions stay anonymous, exactly as in Ruby — so the per-application prepare-callback isolation is unchanged, and the Rails-citation JSDoc is kept (extended with the declaration-emit reason, per "justify deviations at the call site").

A written type is weaker than an inferred one, though: `readonly executor: typeof Executor = Executor` would now typecheck and would silently collapse the two applications onto one shared `Executor`. `executor-seam.trails.test.ts` gains a runtime guard for that; it fails on exactly that degraded shape (verified) and Rails has no counterpart test, since `Class.new` gives it the isolation for free.

Verified:
- `node <ts7>/bin/tsc -b packages/trailties --force` → zero diagnostics on this branch; the same command on `main` reproduces both TS4094 errors.
- `pnpm build` / `pnpm typecheck` green on the pinned `typescript@5.9.3`.
- `application.d.ts` now reads `readonly executor: typeof Executor;` in place of an unnameable anonymous class type.
- `application.test.ts` + `application/executor-seam.trails.test.ts`: 47 passed.

Closes-story: fix-anonymous-class-declaration-emit