### PR TITLE
fix(activerecord): drop the landed story citation and dead null arm from lookupCastType

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2750,14 +2750,12 @@ export class AbstractAdapter implements Quoting {
    *
    * The `Promise<Type>` arm is not Rails: `PostgreSQLAdapter#lookupCastType`
    * resolves a sql_type with a live regtype query, so its override is async
-   * (tracked by `pg-lookup-cast-type-async-divergence`). The `null` arm is
-   * `AbstractMysqlAdapter`'s early return for an empty sql_type, which
-   * `mysql-native-type-map-converges-onto-type-map` deletes. Both are spelled
-   * out rather than erased behind `unknown`, so a caller cannot silently
-   * duck-type past them.
+   * (tracked by `pg-lookup-cast-type-async-divergence`). It is spelled out
+   * rather than erased behind `unknown`, so a caller cannot silently
+   * duck-type past it.
    * @internal
    */
-  lookupCastType(sqlType: string | null): Type | Promise<Type> | null {
+  lookupCastType(sqlType: string | null): Type | Promise<Type> {
     // The quoting helper constrains its receiver to a `TypeMap`-bearing host;
     // the base `typeMap` getter is `unknown` because PostgreSQL's override
     // returns a `HashLookupTypeMap`, which is a separate class in Rails too
@@ -2766,7 +2764,7 @@ export class AbstractAdapter implements Quoting {
   }
 
   /** @internal Mirrors: AbstractAdapter#lookup_cast_type_from_column */
-  lookupCastTypeFromColumn(column: { sqlType: string | null }): Type | Promise<Type> | null {
+  lookupCastTypeFromColumn(column: { sqlType: string | null }): Type | Promise<Type> {
     return this.lookupCastType(column.sqlType);
   }
 }


### PR DESCRIPTION
## Root cause

`a8e658cb` (#7077) closed `mysql-native-type-map-converges-onto-type-map`, which
deleted `AbstractMysqlAdapter#lookupCastType`. But `abstract-adapter.ts:2746`
still cited that slug in prose ("... which `mysql-native-type-map-converges-onto-type-map`
deletes"), and `scripts/stale-story-references.test.ts` gates on no comment in
the tree naming a story that has already landed — so `Unit Tests` went red on
main with:

```
packages/activerecord/src/connection-adapters/abstract-adapter.ts:2746 mysql-native-type-map-converges-onto-type-map
```

## Fix

The citation described the `null` arm of `lookupCastType`'s return type, whose
only producer was the MySQL early return that #7077 deleted. Rails'
`AbstractAdapter#lookup_cast_type` (`abstract/quoting.rb:234-236`) returns
`type_map.lookup(...)`; PostgreSQL's override (`postgresql/quoting.rb:189-196`)
is the only other definition. So the arm is dead: dropped it from
`lookupCastType` / `lookupCastTypeFromColumn` and removed the stale sentence.
No new skip, disable, or baseline row.

`pnpm typecheck` clean; `scripts/stale-story-references.test.ts` and
`scripts/api-compare` green locally.

Closes-story: red-a8e658cb
