### PR TITLE
fix(activemodel): ImmutableString#serialize leaves a leading colon on a String

### DIFF
--- a/packages/activemodel/src/type/immutable-string.trails.test.ts
+++ b/packages/activemodel/src/type/immutable-string.trails.test.ts
@@ -14,12 +14,14 @@ describe("ImmutableStringType (trails)", () => {
     expect(type.serialize(array)).toBe(array);
   });
 
-  it("serialize strips a Symbol's leading colon but leaves a String alone", () => {
-    // immutable_string.rb:53 sends ::Symbol through `to_s`, and `:bob.to_s` is
-    // "bob". A trails Symbol carries its colon, so the colon is what separates
-    // that arm from the `else` (identity) one a String takes.
+  it("serialize leaves a String alone, leading colon and all", () => {
+    // immutable_string.rb:56 sends a String to `super` — identity. There is no
+    // trails arm for `when ::Symbol` (immutable_string.rb:53): that arm is a
+    // type test a String cannot satisfy, and trails spells a Symbol as a
+    // `":name"` string, so keying it off the colon corrupts String data.
     const type = new ImmutableStringType();
-    expect(type.serialize(":bob")).toBe("bob");
+    expect(type.serialize("::Alpha")).toBe("::Alpha");
+    expect(type.serialize(":bob")).toBe(":bob");
     expect(type.serialize("bob")).toBe("bob");
   });
 

--- a/packages/activemodel/src/type/immutable-string.ts
+++ b/packages/activemodel/src/type/immutable-string.ts
@@ -36,16 +36,20 @@ export class ImmutableStringType extends ValueType<string> {
    *   end
    *
    * `super` is Value#serialize — identity — so an Object, an Array or a Hash
-   * comes straight back out (string_test.rb:17-23 pins that). A Ruby Symbol is
-   * a `":name"` string in trails, and the leading colon is the discriminator
-   * the `when ::Symbol` arm gets from the type: `:bob.to_s` is `"bob"`, so the
-   * Symbol arm is `.slice(1)` while a String falls through to `super`
-   * unchanged.
+   * comes straight back out (string_test.rb:17-23 pins that), and so does a
+   * String.
+   *
+   * The `when ::Symbol` arm has no trails arm. Ruby reaches it on the *type*
+   * of the value, which a String can never satisfy; trails spells a Symbol as
+   * a `":name"` string, so keying that arm off a leading colon fires on
+   * ordinary String data as well and eats one colon per write (`"::Alpha"` was
+   * stored as `":Alpha"`). Attribute values here are data, not the API-argument
+   * positions where the colon is a real discriminator, so the String arm —
+   * verbatim identity — is the one that governs.
    */
   serialize(value: unknown): unknown {
     if (typeof value === "number" || typeof value === "bigint") return String(value);
     if (value instanceof BigDecimal || value instanceof Duration) return String(value);
-    if (typeof value === "string" && value.startsWith(":")) return value.slice(1);
     if (value === true) return this.true;
     if (value === false) return this.false;
     return super.serialize(value);

--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -1,0 +1,60 @@
+/**
+ * TS-only regression coverage: a string whose first character is a colon must
+ * round-trip verbatim through every write path, before and after the model's
+ * attribute types are loaded.
+ *
+ * `ActiveModel::Type::ImmutableString#serialize`
+ * (activemodel/lib/active_model/type/immutable_string.rb:52-58) routes
+ * `::Symbol` through `to_s`. A trails Symbol is a `":name"` string, so keying
+ * that arm off a leading colon made it fire on ordinary String data too and
+ * ate one colon per write — but only once `type_for_attribute` had a real
+ * string type to serialize through, which is why the `find_by` below comes
+ * first.
+ */
+import { describe, it, expect } from "vitest";
+import { fixtures } from "../test-fixtures.js";
+import { Topic } from "../test-helpers/models/topic.js";
+
+const CASES: [string, string][] = [
+  ["::Alpha", "::Alpha"],
+  [":Alpha", ":Alpha"],
+  [":::Alpha", ":::Alpha"],
+  ["Alpha::Beta", "Alpha::Beta"],
+];
+
+describe("leading-colon string writes", () => {
+  fixtures({ topics: [Topic, {}] });
+
+  it("update_all stores a leading colon verbatim once the types are loaded", async () => {
+    const topic = await Topic.create({ title: "seed" });
+    await Topic.findBy({ id: topic.id });
+    for (const [sent, stored] of CASES) {
+      await Topic.where({ id: topic.id }).updateAll({ title: sent });
+      expect((await Topic.find(topic.id)).title).toBe(stored);
+    }
+  });
+
+  it("save stores a leading colon verbatim once the types are loaded", async () => {
+    const seed = await Topic.create({ title: "seed" });
+    await Topic.findBy({ id: seed.id });
+    for (const [sent, stored] of CASES) {
+      const topic = await Topic.find(seed.id);
+      topic.title = sent;
+      await topic.save();
+      expect((await Topic.find(seed.id)).title).toBe(stored);
+    }
+  });
+
+  it("create and insert_all store a leading colon verbatim", async () => {
+    await Topic.create({ title: "seed" });
+    for (const [sent, stored] of CASES) {
+      const created = await Topic.create({ title: sent });
+      expect((await Topic.find(created.id)).title).toBe(stored);
+
+      await Topic.insertAll([{ title: sent, author_name: "colon" }]);
+      const inserted = await Topic.where({ author_name: "colon" }).first();
+      expect(inserted!.title).toBe(stored);
+      await Topic.where({ author_name: "colon" }).deleteAll();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Once a model's attribute types were loaded, `update_all` dropped exactly one
leading colon from a string value: `"::Alpha"` was stored as `":Alpha"`,
`":Alpha"` as `"Alpha"`. Mid-string colons were unaffected.

## Cause

`ImmutableStringType#serialize` carried an arm for Rails'
`when ::Symbol then value.to_s`
(`activemodel/lib/active_model/type/immutable_string.rb:53`), implemented as
"a string starting with `:` gets `.slice(1)`". But that Ruby arm is a **type**
test, which a String can never satisfy — a String takes the `else super`
identity arm at `:56`. Since trails spells a Symbol as a `":name"` string, the
colon heuristic fired on ordinary String data too.

Only `update_all` was lossy: it reaches the database value through
`QueryAttribute#value_for_database` → `serialize`, while `save` / `create` /
`insert_all` route through `serialize_cast_value` (identity,
`immutable_string.rb:60-62`), which is why the two disagreed. The fix is in the
caster, so all four paths are covered. The layer is adapter-independent; the
PG/MySQL/MariaDB lanes cover the other adapters.

## Change

Drop the Symbol arm. Attribute values here are data, not the API-argument
positions (validation `:type`, enum keys, `references`) where a leading colon
is a real discriminator per CLAUDE.md.

## Tests

- `packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts`
  — the full table from the story (`::Alpha`, `:Alpha`, `:::Alpha`,
  `Alpha::Beta`) across `update_all`, `save`, and `create`/`insert_all`, with
  the `find_by`-first ordering that arms the bug. The `update_all` case fails on
  baseline.
- The trails unit test that enshrined the strip now pins verbatim identity.

## Follow-up (other repo)

The tasks repo's `fixLeadingColon` workaround in `src/ingest.ts` can be deleted
once this ships in a released trails.

Closes-story: leading-colon-stripped-from-string-writes-after-type-load
