### PR TITLE
fix(activerecord): drop now-unnecessary type assertions on lookupCastTypeFromColumn

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2425,9 +2425,7 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
           columnOptions.stored = column.isVirtualStored();
           columnOptions.type = column.type;
         } else if (column.hasDefault) {
-          const type = (await this.lookupCastTypeFromColumn(
-            column,
-          )) as import("@blazetrails/activemodel").Type;
+          const type = await this.lookupCastTypeFromColumn(column);
           let defaultValue: unknown = type.deserialize(column.default);
           if (defaultValue == null) defaultValue = () => column.defaultFunction;
 

--- a/packages/activerecord/src/migration/change-schema.test.ts
+++ b/packages/activerecord/src/migration/change-schema.test.ts
@@ -128,8 +128,8 @@ describe("Migration", () => {
       const five = mysql ? undefined : detect(columns, "five");
 
       expect(one.default).toBe("hello");
-      expect((await connection.lookupCastTypeFromColumn(two))!.deserialize(two.default)).toBe(true);
-      expect((await connection.lookupCastTypeFromColumn(three))!.deserialize(three.default)).toBe(
+      expect((await connection.lookupCastTypeFromColumn(two)).deserialize(two.default)).toBe(true);
+      expect((await connection.lookupCastTypeFromColumn(three)).deserialize(three.default)).toBe(
         false,
       );
       expect(four.default).toBe("1");


### PR DESCRIPTION
## Root cause

#7083 dropped the dead null arm from `lookupCastType`, making `lookupCastType` / `lookupCastTypeFromColumn` return a non-nullable `Type`. Three call sites still carried assertions that were only needed while the return was nullable, so `@typescript-eslint/no-unnecessary-type-assertion` went red on main at d9c50416:

- `sqlite3-adapter.ts:2428` — `as import("@blazetrails/activemodel").Type`
- `change-schema.test.ts:131,132` — `!` after `await connection.lookupCastTypeFromColumn(...)`

## Fix

Remove the three assertions. No behavior change; `pnpm typecheck` and eslint on both files are clean.

Closes-story: red-d9c50416