### PR TITLE
fix(activerecord): gate Closes-story citations at PR time; converge four connection-adapter/config deviations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           fi
           # Gate rationale: scripts/ci-suite-coverage.test.ts ("Gate reference").
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references)(\.test)?\.ts$)'
+          INFRA_CARVEOUT_RE='^scripts/((tasks|ci|guides-typecheck|rails-find|sync-stats|phase-g-hunt|fixtures-inventory|test-deps|__fixtures__|api-compare|test-compare|fixtures-compare|schema-compare|parity)/|(build-rails-privates-manifest|build-rails-file-structure-manifest|rails-file-structure-mixins|strip-asany|ci-suite-coverage|deprecated-manifest-diff|mixin-declaration-drift|mysql-grant-namespaces|stale-story-references|closing-story-references)(\.test)?\.ts$)'
           AR_PKGS_RE='^packages/(activerecord|activerecord-cli|arel|activemodel|activesupport|globalid|date|did-you-mean|trails-tsc)/'
           DB_ADAPTER_RE='^(packages/activerecord/src/(adapters/(postgresql|abstract-mysql-adapter)|connection-adapters/(postgresql|mysql|mysql2|abstract-mysql-adapter|abstract/|abstract-adapter\.ts|column\.ts|adapter-args\.ts|sql-classification\.ts|pool))|packages/arel/src/visitors/(postgres|mysql)|packages/activerecord-cli/src/__e2e__/(postgres|mysql))'
           AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack|date|did-you-mean)/'
@@ -475,6 +475,23 @@ jobs:
           fi
           echo "No new or modified docs/activerecord trackers."
 
+      # Closing-story citations. `stale-story-references` judges a landed
+      # story's citations, but a story lands only after the merge — so a PR that
+      # closes a story is blind to the check that reds main seconds later
+      # (#7083, #5976). Gate it here instead: a PR declaring `Closes-story: <id>`
+      # must carry no pending citation of `<id>`. Same scan, same extractor, so
+      # a finding is a guaranteed red on main.
+      - name: Set up pnpm (closing-story citations)
+        # !cancelled() as above, so an earlier step's failure can't skip it.
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        uses: ./.github/actions/setup-pnpm
+      - name: Closing-story citations
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+          pnpm install --frozen-lockfile --prefer-offline
+          pnpm check:closing-story-refs --pr "$PR_NUMBER"
+
       # PR attribution check. Scoped to deanmarano-authored PRs: the project
       # forbids Claude attribution in *his* PR descriptions and commits (see
       # CLAUDE.md "Do NOT add ... Generated with Claude Code"). Other
@@ -631,6 +648,7 @@ jobs:
           scripts/mixin-declaration-drift.test.ts
           scripts/mysql-grant-namespaces.test.ts
           scripts/stale-story-references.test.ts
+          scripts/closing-story-references.test.ts
           scripts/non-transactional-row-writes.test.ts
           scripts/generate-canonical-zone-identifiers.test.ts
           scripts/generate-tzdata-isdst.test.ts

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky",
     "typecheck": "node scripts/typecheck.mjs",
     "guides:typecheck": "tsx scripts/guides-typecheck/check.ts",
+    "check:closing-story-refs": "pnpm tsx scripts/closing-story-references.ts",
     "prelint": "pnpm tsx scripts/build-rails-privates-manifest.ts --allow-missing && pnpm tsx scripts/build-rails-error-manifest.ts && pnpm tsx scripts/build-rails-tosql-manifest.ts && pnpm tsx scripts/build-rails-file-structure-manifest.ts --allow-missing && pnpm tsx scripts/test-deps/rails-test-deps.ts >/dev/null",
     "lint": "NODE_OPTIONS=--max-old-space-size=6144 eslint .",
     "prelint:files": "pnpm prelint",

--- a/packages/activerecord-cli/src/console.ts
+++ b/packages/activerecord-cli/src/console.ts
@@ -27,7 +27,7 @@ export async function arConsole(
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   if (!environmentDbConfig(env)) {
     console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;

--- a/packages/activerecord-cli/src/db-helpers.ts
+++ b/packages/activerecord-cli/src/db-helpers.ts
@@ -24,14 +24,14 @@ export async function loadDatabaseConfig(cwd: string): Promise<DatabaseConfigura
   const { pathToFileURL } = await import("node:url");
   const mod = await import(pathToFileURL(configPath).href);
   const raw = mod.default ?? mod;
-  const configs = normalizeSqlitePaths(DatabaseConfigurations.fromEnv(raw), cwd);
+  const configs = normalizeSqlitePaths(new DatabaseConfigurations(raw), cwd);
   DatabaseTasks.databaseConfiguration = configs;
   DatabaseTasks.root = cwd;
   // `db:load_config` (`railties/databases.rake:27`): the discovery paths every
   // pool falls back to when its own `db_config.migrations_paths` is absent
   // (`connection_pool.rb:299`). Absolute, as `Rails.application.paths` are.
   Migrator.migrationsPaths = DatabaseTasks.migrationsPaths.map((p) => resolve(join(cwd, p)));
-  await establishEnvironmentConnection(DatabaseConfigurations.currentEnv());
+  await establishEnvironmentConnection(DatabaseConfigurations.defaultEnv);
   return configs;
 }
 

--- a/packages/activerecord-cli/src/db-tasks.ts
+++ b/packages/activerecord-cli/src/db-tasks.ts
@@ -35,7 +35,7 @@ export async function dbCreate(cwd: string, args: string[]): Promise<number> {
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   const configs = all
     ? DatabaseTasks.eachLocalConfiguration()
     : DatabaseTasks.configsFor({ envName: env });
@@ -59,7 +59,7 @@ export async function dbDrop(cwd: string, args: string[]): Promise<number> {
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   const configs = all
     ? DatabaseTasks.eachLocalConfiguration()
     : DatabaseTasks.configsFor({ envName: env });
@@ -153,7 +153,7 @@ export async function dbSchemaLoad(cwd: string, _args: string[]): Promise<number
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   try {
     await DatabaseTasks.checkProtectedEnvironmentsBang(env);
     await DatabaseTasks.loadSchemaCurrent(undefined, undefined, env);
@@ -172,7 +172,7 @@ export async function dbSchemaDump(cwd: string, _args: string[]): Promise<number
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   if (DatabaseTasks.configsFor({ envName: env }).length === 0) {
     console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;
@@ -250,7 +250,7 @@ export async function dbSetup(cwd: string, _args: string[]): Promise<number> {
   await tryLoadModels(cwd);
   installSeedLoader(cwd);
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   const configs = DatabaseTasks.configsFor({ envName: env });
   if (configs.length === 0) {
     console.error(`ar: no database configuration found for environment "${env}"`);
@@ -293,7 +293,7 @@ export async function dbPrepare(cwd: string, _args: string[]): Promise<number> {
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   if (DatabaseTasks.configsFor({ envName: env }).length === 0) {
     console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;
@@ -323,7 +323,7 @@ export async function dbVersion(cwd: string, args: string[]): Promise<number> {
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   const configs = all
     ? (DatabaseTasks.databaseConfiguration?.configsFor() ?? [])
     : DatabaseTasks.configsFor({ envName: env });
@@ -364,7 +364,7 @@ export async function dbMigrateStatus(cwd: string, args: string[]): Promise<numb
   }
   await tryLoadModels(cwd);
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
 
   // Rails: `with_temporary_pool_for_each` (no name) iterates all configs for the env.
   // --all extends this to every configured env/database, through `configs_for`

--- a/packages/activerecord-cli/src/environment.test.ts
+++ b/packages/activerecord-cli/src/environment.test.ts
@@ -21,10 +21,7 @@ function installConfig(
   raw: Record<string, { adapter: string; database: string }>,
   root: string,
 ): void {
-  DatabaseTasks.databaseConfiguration = normalizeSqlitePaths(
-    DatabaseConfigurations.fromEnv(raw),
-    root,
-  );
+  DatabaseTasks.databaseConfiguration = normalizeSqlitePaths(new DatabaseConfigurations(raw), root);
   DatabaseTasks.root = root;
 }
 
@@ -57,7 +54,7 @@ describe("ArEnvironmentTest", () => {
 
   function normalizeUrl(url: string): DatabaseConfig | null {
     DatabaseTasks.databaseConfiguration = normalizeSqlitePaths(
-      DatabaseConfigurations.fromEnv({ test: { adapter: "sqlite3", url } }),
+      new DatabaseConfigurations({ test: { adapter: "sqlite3", url } }),
       "/project",
     );
     return environmentDbConfig("test");

--- a/packages/activerecord-cli/src/runner.ts
+++ b/packages/activerecord-cli/src/runner.ts
@@ -37,7 +37,7 @@ export async function arRunner(cwd: string, args: string[]): Promise<number> {
     return 1;
   }
 
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   if (!environmentDbConfig(env)) {
     console.error(`ar: no database configuration found for environment "${env}"`);
     return 1;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3388,8 +3388,10 @@ export class Base extends Model {
         // `.connection` getter (see `_createRecord` in persistence.ts); resolved here, at the
         // actual DELETE, so a connectionless model never touches `.connection`.
         const adapter = ConnectionHandling.threadedConnectionFor(ctor) ?? ctor.connection;
-        const [deleteSql, deleteBinds] = adapter.toSqlAndBinds(dm);
-        const affected = await adapter.execDelete(deleteSql, `${ctor.name} Destroy`, deleteBinds);
+        // `c.delete(dm, "#{self} Destroy")` (persistence.rb:294-296) — the
+        // public statement method, which is where `dirties_query_cache` is
+        // wired (query_cache.rb:13-15).
+        const affected = await adapter.delete(dm, `${ctor.name} Destroy`);
         if (ctor.lockingEnabled && affected !== 1) {
           throw new StaleObjectError(this, "destroy");
         }

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2843,38 +2843,30 @@ function ensureAbstractAdapterMixinsApplied(): void {
     });
   }
 
-  // `dirties_query_cache` wiring (Rails query_cache.rb:13). Rails wires the public
-  // `update`/`delete`/`insert`/`create`; trails wires one layer lower, on
-  // `execUpdate`/`execDelete`/`execInsert`/`execInsertAll`, because that is the
-  // single funnel every logical write shares. Two distinct update paths converge
-  // there: the model save path (`_updateRecord` in persistence.ts, `_destroyRow`
-  // in base.ts) calls
-  // `execUpdate`/`execDelete` DIRECTLY, bypassing the public `update`/`delete`
-  // entirely, while `update_all`/`updateColumns` (the ClassMethods
-  // `_updateRecord` in persistence.ts)
-  // go through the public `update`/`delete` — which themselves call
-  // `execUpdate`/`execDelete`. Wiring the public methods would miss the direct
-  // save path; wiring the low-level method catches both, exactly once each. The
-  // still-lower `executeMutation` these funnel through stays unwrapped, so a
-  // logical write clears exactly once. DDL dirties because schema-statements
-  // routes it through the wired public `execute`, as Rails does. Wire the methods NOT overridden
-  // by a concrete adapter here — they're only defined on AbstractAdapter, and a
-  // subclass prototype doesn't yet inherit them when the per-adapter module runs
-  // (circular-import load order), so they must be wired on AbstractAdapter. The
-  // OVERRIDDEN write methods (`execute`, `rollbackDbTransaction`,
-  // `rollbackToSavepoint`, and sqlite's `truncate`) are
+  // `dirties_query_cache base, :exec_query, :execute, :create, :insert, :update,
+  //  :delete, :truncate, :truncate_tables, :rollback_to_savepoint,
+  //  :rollback_db_transaction, :restart_db_transaction, :exec_insert_all`
+  // (query_cache.rb:13-15). The clear sits on the PUBLIC statement methods, above
+  // every adapter's arm-splitting override — which is what covers PostgreSQL's
+  // `use_insert_returning? == false` arm (postgresql/database_statements.rb:48-59),
+  // an arm that never reaches `AbstractAdapter#execInsert` at all.
+  //
+  // Wire here the methods NOT overridden by a concrete adapter — they're only
+  // defined on AbstractAdapter, and a subclass prototype doesn't yet inherit them
+  // when the per-adapter module runs (circular-import load order), so they must be
+  // wired on AbstractAdapter. The OVERRIDDEN write methods (`execute`,
+  // `rollbackDbTransaction`, `rollbackToSavepoint`, and sqlite's `truncate`) are
   // wired on each concrete adapter instead — wiring them here too would leave the
-  // override unwrapped. Reads route through `internalExecQuery` and never trip
-  // the wrapper. `execInsert` is wired here rather than per-adapter: only
-  // PostgreSQL still overrides it (postgresql/database_statements.rb:45), and its
-  // override delegates to `super`, so one wrapper on the shared method clears
-  // exactly once for every adapter.
+  // override unwrapped. Reads route through `internalExecQuery` and never trip the
+  // wrapper, and the low-level `exec*` funnels stay unwrapped, so a logical write
+  // clears exactly once.
   dirtiesQueryCache(
     AbstractAdapter,
     "execQuery",
-    "execInsert",
-    "execUpdate",
-    "execDelete",
+    "create",
+    "insert",
+    "update",
+    "delete",
     "execInsertAll",
     "truncate",
     "truncateTables",

--- a/packages/activerecord/src/connection-adapters/connection-handler.test.ts
+++ b/packages/activerecord/src/connection-adapters/connection-handler.test.ts
@@ -35,7 +35,7 @@ describe("ConnectionHandlerTest", () => {
 
   it("default env fall back to default env when rails env or rack env is empty string", async () => {
     DatabaseConfigurations.defaultEnv = "";
-    expect(DatabaseConfigurations.defaultEnv).toBe("default");
+    expect(DatabaseConfigurations.defaultEnv).toBe("default_env");
     DatabaseConfigurations.defaultEnv = "development";
     expect(DatabaseConfigurations.defaultEnv).toBe("development");
   });

--- a/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/merge-and-resolve-default-url-config.test.ts
@@ -50,13 +50,13 @@ function resolveConfig(
   config: RawConfigurations,
   envName: string = DEFAULT_ENV,
 ): Record<string, unknown> | null {
-  const configs = DatabaseConfigurations.fromRaw(config);
-  const found = configs.configsFor({ envName, name: "primary" })[0];
+  const configs = new DatabaseConfigurations(config);
+  const found = configs.configsFor({ envName, name: "primary" });
   return found?.configurationHash ?? null;
 }
 
 function resolveDbConfig(spec: string, config: RawConfigurations) {
-  const configs = DatabaseConfigurations.fromRaw(config);
+  const configs = new DatabaseConfigurations(config);
   return configs.resolve(spec);
 }
 
@@ -360,12 +360,12 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
       },
     };
 
-    let configs = DatabaseConfigurations.fromRaw(config);
-    let actual = configs.configsFor({ envName: DEFAULT_ENV, name: "primary" })[0].configurationHash;
+    let configs = new DatabaseConfigurations(config);
+    let actual = configs.configsFor({ envName: DEFAULT_ENV, name: "primary" })!.configurationHash;
     expect(actual).toEqual({ adapter: "postgresql", database: "foo", host: "localhost", pool: 5 });
 
-    configs = DatabaseConfigurations.fromRaw(config);
-    actual = configs.configsFor({ envName: DEFAULT_ENV, name: "animals" })[0].configurationHash;
+    configs = new DatabaseConfigurations(config);
+    actual = configs.configsFor({ envName: DEFAULT_ENV, name: "animals" })!.configurationHash;
     expect(actual).toEqual({ adapter: "abstract", pool: 5 });
   });
 
@@ -381,12 +381,12 @@ describe("MergeAndResolveDefaultUrlConfigTest", () => {
       },
     };
 
-    let configs = DatabaseConfigurations.fromRaw(config);
-    let actual = configs.configsFor({ envName: DEFAULT_ENV, name: "primary" })[0].configurationHash;
+    let configs = new DatabaseConfigurations(config);
+    let actual = configs.configsFor({ envName: DEFAULT_ENV, name: "primary" })!.configurationHash;
     expect(actual.database).toBe("primary");
 
-    configs = DatabaseConfigurations.fromRaw(config);
-    actual = configs.configsFor({ envName: DEFAULT_ENV, name: "animals" })[0].configurationHash;
+    configs = new DatabaseConfigurations(config);
+    actual = configs.configsFor({ envName: DEFAULT_ENV, name: "animals" })!.configurationHash;
     expect(actual.database).toBe("animals");
   });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.trails.test.ts
@@ -409,29 +409,47 @@ describe("PostgreSQLAdapter#execInsert query cache", () => {
     if (adapter) await adapter.close().catch(() => undefined);
   });
 
-  // The multi-column RETURNING read-back runs through internalExecQuery, not
-  // executeMutation, so only `dirtiesQueryCache(PostgreSQLAdapter, "execInsert")`
-  // clears the cache on that path — matching MySQL/SQLite. Rails dirties the
-  // query cache on every write; without the execInsert registration a cached
-  // SELECT after such an INSERT would be served stale.
-  it("clears the query cache on a multi-column RETURNING insert", async () => {
+  function adapterWithPrimedCache(useInsertReturning: boolean): Store {
     adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
     const qc = new Store();
     qc.enabled = true;
     qc.dirties = true;
+    (adapter as unknown as { _queryCache: Store })._queryCache = qc;
+    (adapter as unknown as { _useInsertReturning: boolean })._useInsertReturning =
+      useInsertReturning;
+    return qc;
+  }
+
+  // Rails wires `dirties_query_cache` on the PUBLIC `insert`/`create`
+  // (query_cache.rb:13-15), which sits above both arms of PostgreSQL's
+  // `exec_insert` override (postgresql/database_statements.rb:46-59). The
+  // wrapper clears before delegating; the delegated read-back has no live
+  // connection and rejects, but the cache is already cleared by then.
+  it("clears the query cache on a multi-column RETURNING insert", async () => {
+    const qc = adapterWithPrimedCache(true);
     await qc.computeIfAbsent("SELECT * FROM posts", async () => [{ id: 1 }]);
     expect(qc.empty).toBe(false);
-    (adapter as unknown as { _queryCache: Store })._queryCache = qc;
-    (adapter as unknown as { _useInsertReturning: boolean })._useInsertReturning = true;
 
-    // The dirtiesQueryCache wrapper clears before delegating to the original
-    // execInsert; the delegated read-back has no live connection and rejects,
-    // but the cache is already cleared by then.
     await adapter
-      .execInsert("INSERT INTO posts (title) VALUES ('t')", "SQL", [], "id", null, [
-        "id",
-        "created_at",
-      ])
+      .insert("INSERT INTO posts (title) VALUES ('t')", "SQL", "id", undefined, null, [], {
+        returning: ["id", "created_at"],
+      })
+      .catch(() => undefined);
+
+    expect(qc.empty).toBe(true);
+  });
+
+  // The `use_insert_returning? == false` arm calls `internal_exec_query`
+  // directly (postgresql/database_statements.rb:48-59) and never reaches
+  // `AbstractAdapter#exec_insert`, so wiring the clear on `exec_insert` leaves
+  // this arm uncleared. Rails clears on `insert`, above both arms.
+  it("clears the query cache on a non-returning insert", async () => {
+    const qc = adapterWithPrimedCache(false);
+    await qc.computeIfAbsent("SELECT * FROM posts", async () => [{ id: 1 }]);
+    expect(qc.empty).toBe(false);
+
+    await adapter
+      .insert("INSERT INTO posts (title) VALUES ('t')", "SQL", "id", undefined, "posts_id_seq", [])
       .catch(() => undefined);
 
     expect(qc.empty).toBe(true);

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -578,7 +578,7 @@ describe("ConnectionHandlingTest", () => {
   it("establishConnection backfills the adapter on an adapter-less HashConfig", async () => {
     const { DatabaseConfigurations } = await import("./database-configurations.js");
     const { HashConfig } = await import("./database-configurations/hash-config.js");
-    const env = DatabaseConfigurations.currentEnv();
+    const env = DatabaseConfigurations.defaultEnv;
 
     const dbConfig = new HashConfig(env, "primary", { url: "sqlite3:db/foo.sqlite3" });
     expect(dbConfig.adapter).toBeUndefined();
@@ -815,7 +815,7 @@ describe("resolveConfigForConnection / connectsTo with unset configurations", ()
     try {
       __resetPrimaryAbstractClass();
       primaryAbstractClass(AppRecord);
-      const env = DatabaseConfigurations.currentEnv();
+      const env = DatabaseConfigurations.defaultEnv;
       priorConfigs = Base.configurations();
       Base.configurations({
         [env]: { primary: { adapter: "sqlite3", database: "db/primary.sqlite3" } },

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -693,14 +693,16 @@ async function _loadAdapter(name: string): Promise<new (arg: unknown) => Databas
 /**
  * Mirrors: ActiveRecord::ConnectionHandling::DEFAULT_ENV
  * (connection_handling.rb:7) — `-> { RAILS_ENV.call || "default_env" }`.
- * `DatabaseConfigurations.currentEnv()` is trails' `RAILS_ENV` chain plus that
+ * `DatabaseConfigurations.defaultEnv` is trails' `RAILS_ENV` chain plus that
  * literal fallback; the three other Rails `DEFAULT_ENV.call` sites
  * (`database_configurations.rb:188`, `database_config.rb:91`,
- * `migration.rb:1341`) still reach it through `currentEnv()` because a static
+ * `migration.rb:1341`) still reach it through `defaultEnv` because a static
  * import edge from those modules back into this one would close a module-eval
- * cycle.
+ * cycle. Rails runs the delegation the other way — `default_env` is
+ * `DEFAULT_ENV.call.to_s` (`database_configurations.rb:188-190`) — so the
+ * resolution body lives at `defaultEnv` and this lambda delegates to it.
  */
-export const DEFAULT_ENV = (): string => DatabaseConfigurations.currentEnv();
+export const DEFAULT_ENV = (): string => DatabaseConfigurations.defaultEnv;
 
 /**
  * @missingRailsCall call — PERMANENT: Rails defaults the argument through
@@ -887,7 +889,7 @@ async function establishWithConfig(
   // discrete fields (database/host/port/...) rather than the verbatim string.
   // This matches the resolver path (database-configurations.ts:246) and the
   // "url removed from hash" parity test.
-  const env = DatabaseConfigurations.currentEnv();
+  const env = DatabaseConfigurations.defaultEnv;
   let dbConfig: DatabaseConfig;
   if (dbConfigOverride) {
     dbConfig = dbConfigOverride;

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -165,7 +165,7 @@ describe("configurations is a single process-global registry", () => {
 
     class OverridingModel extends Base {
       static configurations(): DatabaseConfigurations {
-        return DatabaseConfigurations.fromEnv({
+        return new DatabaseConfigurations({
           global_registry_env: { primary: { adapter: "sqlite3", database: "db/hijacked.sqlite3" } },
         });
       }

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -522,12 +522,12 @@ export function configurations(
   config?: RawConfigurations | DatabaseConfigurations | DatabaseConfig[],
 ): DatabaseConfigurations {
   if (config !== undefined) {
+    // `@@configurations = ActiveRecord::DatabaseConfigurations.new(config)`
+    // (core.rb:71-73). Rails' `new` also passes an existing
+    // `DatabaseConfigurations` straight through (`build_configs` returns it
+    // untouched); TS types the arms apart.
     setConfigurationsStore(
-      config instanceof DatabaseConfigurations
-        ? config
-        : Array.isArray(config)
-          ? new DatabaseConfigurations(config)
-          : DatabaseConfigurations.fromEnv(config),
+      config instanceof DatabaseConfigurations ? config : new DatabaseConfigurations(config),
     );
   }
   return configurationsStore();

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -34,6 +34,10 @@ describe("DatabaseConfigurationsTest", () => {
   });
 
   it("configs for getter with name", () => {
+    // `configs_for(name:)` defaults env_name to `default_env`
+    // (database_configurations.rb:99), so key the hash on it as
+    // database_configurations_test.rb:89 does.
+    DatabaseConfigurations.defaultEnv = "development";
     const configs = new DatabaseConfigurations({
       development: {
         primary: { adapter: "sqlite3", database: "primary.db" },
@@ -41,11 +45,14 @@ describe("DatabaseConfigurationsTest", () => {
       },
     });
     const animals = configs.configsFor({ name: "animals" });
-    expect(animals).toHaveLength(1);
-    expect(animals[0].database).toBe("animals.db");
+    expect(animals!.database).toBe("animals.db");
   });
 
   it("configs for with name symbol", () => {
+    // `configs_for(name:)` defaults env_name to `default_env`
+    // (database_configurations.rb:99), so key the hash on it as
+    // database_configurations_test.rb:89 does.
+    DatabaseConfigurations.defaultEnv = "development";
     const configs = new DatabaseConfigurations({
       development: {
         primary: { adapter: "sqlite3", database: "primary.db" },
@@ -53,8 +60,7 @@ describe("DatabaseConfigurationsTest", () => {
       },
     });
     const animals = configs.configsFor({ name: "animals" });
-    expect(animals).toHaveLength(1);
-    expect(animals[0].name).toBe("animals");
+    expect(animals!.name).toBe("animals");
   });
 
   it("configs for getter with env and name", () => {
@@ -68,8 +74,7 @@ describe("DatabaseConfigurationsTest", () => {
       },
     });
     const result = configs.configsFor({ envName: "development", name: "animals" });
-    expect(result).toHaveLength(1);
-    expect(result[0].database).toBe("dev_animals.db");
+    expect(result!.database).toBe("dev_animals.db");
   });
 
   it("find db config returns first config for env", () => {
@@ -123,6 +128,10 @@ describe("DatabaseConfigurationsTest", () => {
   });
 
   it("configs for with custom key", () => {
+    // `configs_for(name:)` defaults env_name to `default_env`
+    // (database_configurations.rb:99), so key the hash on it as
+    // database_configurations_test.rb:89 does.
+    DatabaseConfigurations.defaultEnv = "development";
     const configs = new DatabaseConfigurations({
       development: {
         primary: { adapter: "sqlite3", database: "primary.db" },
@@ -130,12 +139,11 @@ describe("DatabaseConfigurationsTest", () => {
       },
     });
     const cache = configs.configsFor({ name: "cache" });
-    expect(cache).toHaveLength(1);
-    expect(cache[0].database).toBe("cache.db");
+    expect(cache!.database).toBe("cache.db");
   });
 
   it("resolve returns current-env config when same name exists in multiple envs", () => {
-    // currentEnv()="test" (NODE_ENV=test in vitest), so the test config is returned.
+    // defaultEnv resolves to "test" (NODE_ENV=test in vitest), so the test config is returned.
     const configs = new DatabaseConfigurations({
       development: {
         primary: { adapter: "sqlite3", database: "dev.db" },
@@ -158,23 +166,23 @@ describe("DatabaseConfigurationsTest", () => {
       DatabaseConfigurations.defaultEnv = "development";
       vi.stubEnv("TRAILS_ENV", "production");
       vi.stubEnv("NODE_ENV", "test");
-      expect(DatabaseConfigurations.currentEnv()).toBe("production");
+      expect(DatabaseConfigurations.defaultEnv).toBe("production");
     });
 
     it("currentEnv falls back to NODE_ENV, then defaultEnv", () => {
       DatabaseConfigurations.defaultEnv = null;
       vi.stubEnv("NODE_ENV", "staging");
-      expect(DatabaseConfigurations.currentEnv()).toBe("staging");
+      expect(DatabaseConfigurations.defaultEnv).toBe("staging");
 
       vi.stubEnv("NODE_ENV", undefined as unknown as string);
-      expect(DatabaseConfigurations.currentEnv()).toBe("development");
+      expect(DatabaseConfigurations.defaultEnv).toBe("development");
     });
 
     it("forCurrentEnv follows an explicitly set defaultEnv over the process env", () => {
       vi.stubEnv("NODE_ENV", "test");
       DatabaseConfigurations.defaultEnv = "default_env";
 
-      const configs = DatabaseConfigurations.fromRaw({
+      const configs = new DatabaseConfigurations({
         default_env: {
           readonly: { adapter: "sqlite3", database: "readonly.sqlite3" },
           primary: { adapter: "sqlite3", database: "primary.sqlite3" },
@@ -186,7 +194,7 @@ describe("DatabaseConfigurationsTest", () => {
         common: { adapter: "sqlite3", database: "common.sqlite3" },
       });
 
-      expect(DatabaseConfigurations.currentEnv()).toBe("default_env");
+      expect(DatabaseConfigurations.defaultEnv).toBe("default_env");
       expect(configs.configsFor({ envName: "default_env" }).every((c) => c.forCurrentEnv)).toBe(
         true,
       );
@@ -206,9 +214,9 @@ describe("DatabaseConfigurationsTest", () => {
       vi.stubEnv("NODE_ENV", "test");
       DatabaseConfigurations.defaultEnv = "default_env";
 
-      expect(DatabaseConfigurations.currentEnv()).toBe("production");
+      expect(DatabaseConfigurations.defaultEnv).toBe("production");
 
-      const configs = DatabaseConfigurations.fromRaw({
+      const configs = new DatabaseConfigurations({
         production: { primary: { adapter: "sqlite3", database: "prod.db" } },
         default_env: { primary: { adapter: "sqlite3", database: "bad.db" } },
       });
@@ -220,11 +228,11 @@ describe("DatabaseConfigurationsTest", () => {
       // connection-handling find the synthesized config under the same env.
       vi.stubEnv("TRAILS_ENV", "production");
       vi.stubEnv("DATABASE_URL", "sqlite3:db/prod.sqlite3");
-      const configs = DatabaseConfigurations.fromEnv({});
-      const env = DatabaseConfigurations.currentEnv();
+      const configs = new DatabaseConfigurations({});
+      const env = DatabaseConfigurations.defaultEnv;
       const synthesized = configs.configsFor({ envName: env, name: "primary" });
       expect(env).toBe("production");
-      expect(synthesized).toHaveLength(1);
+      expect(synthesized).toBeDefined();
     });
 
     it("forCurrentEnv and fromEnv resolve the same env when TRAILS_ENV differs from defaultEnv", () => {
@@ -233,7 +241,7 @@ describe("DatabaseConfigurationsTest", () => {
       DatabaseConfigurations.defaultEnv = "development";
       vi.stubEnv("TRAILS_ENV", "production");
 
-      const configs = DatabaseConfigurations.fromEnv({
+      const configs = new DatabaseConfigurations({
         production: {
           primary: { adapter: "sqlite3", database: "prod.db" },
           animals: { adapter: "sqlite3", database: "prod_animals.db" },

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -35,8 +35,7 @@ describe("DatabaseConfigurationsTest", () => {
 
   it("configs for getter with name", () => {
     // `configs_for(name:)` defaults env_name to `default_env`
-    // (database_configurations.rb:99), so key the hash on it as
-    // database_configurations_test.rb:89 does.
+    // (database_configurations.rb:99), so key the hash on it.
     DatabaseConfigurations.defaultEnv = "development";
     const configs = new DatabaseConfigurations({
       development: {
@@ -50,8 +49,7 @@ describe("DatabaseConfigurationsTest", () => {
 
   it("configs for with name symbol", () => {
     // `configs_for(name:)` defaults env_name to `default_env`
-    // (database_configurations.rb:99), so key the hash on it as
-    // database_configurations_test.rb:89 does.
+    // (database_configurations.rb:99), so key the hash on it.
     DatabaseConfigurations.defaultEnv = "development";
     const configs = new DatabaseConfigurations({
       development: {
@@ -129,8 +127,7 @@ describe("DatabaseConfigurationsTest", () => {
 
   it("configs for with custom key", () => {
     // `configs_for(name:)` defaults env_name to `default_env`
-    // (database_configurations.rb:99), so key the hash on it as
-    // database_configurations_test.rb:89 does.
+    // (database_configurations.rb:99), so key the hash on it.
     DatabaseConfigurations.defaultEnv = "development";
     const configs = new DatabaseConfigurations({
       development: {

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -35,35 +35,39 @@ describe("DatabaseConfigurationsTest", () => {
 
   it("configs for getter with name", () => {
     // `configs_for(name:)` defaults env_name to `default_env`
-    // (database_configurations.rb:99), so key the hash on it.
-    DatabaseConfigurations.defaultEnv = "development";
+    // (database_configurations.rb:99), which Rails sets by assigning
+    // ENV["RAILS_ENV"] = "arunit2" (database_configurations_test.rb:32).
+    DatabaseConfigurations.defaultEnv = "arunit2";
     const configs = new DatabaseConfigurations({
-      development: {
+      arunit2: {
         primary: { adapter: "sqlite3", database: "primary.db" },
         animals: { adapter: "sqlite3", database: "animals.db" },
       },
     });
-    const animals = configs.configsFor({ name: "animals" });
-    expect(animals!.database).toBe("animals.db");
+    const config = configs.configsFor({ name: "primary" });
+    expect(config!.envName).toBe("arunit2");
+    expect(config!.name).toBe("primary");
   });
 
   it("configs for with name symbol", () => {
     // `configs_for(name:)` defaults env_name to `default_env`
-    // (database_configurations.rb:99), so key the hash on it.
-    DatabaseConfigurations.defaultEnv = "development";
+    // (database_configurations.rb:99), which Rails sets by assigning
+    // ENV["RAILS_ENV"] = "arunit2" (database_configurations_test.rb:43).
+    DatabaseConfigurations.defaultEnv = "arunit2";
     const configs = new DatabaseConfigurations({
-      development: {
+      arunit2: {
         primary: { adapter: "sqlite3", database: "primary.db" },
         animals: { adapter: "sqlite3", database: "animals.db" },
       },
     });
-    const animals = configs.configsFor({ name: "animals" });
-    expect(animals!.name).toBe("animals");
+    const config = configs.configsFor({ name: "primary" });
+    expect(config!.envName).toBe("arunit2");
+    expect(config!.name).toBe("primary");
   });
 
   it("configs for getter with env and name", () => {
     const configs = new DatabaseConfigurations({
-      development: {
+      arunit: {
         primary: { adapter: "sqlite3", database: "dev_primary.db" },
         animals: { adapter: "sqlite3", database: "dev_animals.db" },
       },
@@ -71,8 +75,9 @@ describe("DatabaseConfigurationsTest", () => {
         primary: { adapter: "sqlite3", database: "test_primary.db" },
       },
     });
-    const result = configs.configsFor({ envName: "development", name: "animals" });
-    expect(result!.database).toBe("dev_animals.db");
+    const config = configs.configsFor({ envName: "arunit", name: "primary" });
+    expect(config!.envName).toBe("arunit");
+    expect(config!.name).toBe("primary");
   });
 
   it("find db config returns first config for env", () => {
@@ -136,6 +141,7 @@ describe("DatabaseConfigurationsTest", () => {
       },
     });
     const cache = configs.configsFor({ name: "cache" });
+    expect(cache).toBeDefined();
     expect(cache!.database).toBe("cache.db");
   });
 

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -116,9 +116,9 @@ export class DatabaseConfigurations {
     // (connection_handling.rb:6): a BLANK value is nil, so `DEFAULT_ENV`'s
     // `|| "default_env"` fires rather than the next lookup. An assignment here
     // stands in for that whole lambda's result, so an assigned "" means "both
-    // env vars are blank" and falls straight to the literal — never on to
+    // env vars are blank" and falls straight to `"default_env"` — never on to
     // `NODE_ENV`, which is the `RACK_ENV` bridge the lambda already consumed.
-    if (this._defaultEnv !== null) return this._defaultEnv || "default";
+    if (this._defaultEnv !== null) return this._defaultEnv || "default_env";
     return getEnv("NODE_ENV") || "development";
   }
 

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -110,7 +110,16 @@ export class DatabaseConfigurations {
    * @internal
    */
   static get defaultEnv(): string {
-    return getEnv("TRAILS_ENV") || this._defaultEnv || getEnv("NODE_ENV") || "development";
+    const trailsEnv = getEnv("TRAILS_ENV");
+    if (trailsEnv) return trailsEnv;
+    // `RAILS_ENV = -> { ENV["RAILS_ENV"].presence || ENV["RACK_ENV"].presence }`
+    // (connection_handling.rb:6): a BLANK value is nil, so `DEFAULT_ENV`'s
+    // `|| "default_env"` fires rather than the next lookup. An assignment here
+    // stands in for that whole lambda's result, so an assigned "" means "both
+    // env vars are blank" and falls straight to the literal — never on to
+    // `NODE_ENV`, which is the `RACK_ENV` bridge the lambda already consumed.
+    if (this._defaultEnv !== null) return this._defaultEnv || "default";
+    return getEnv("NODE_ENV") || "development";
   }
 
   /** @internal Assign null to clear the override and fall back to the process env. */

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -52,7 +52,7 @@ let _configurations: DatabaseConfigurations | undefined;
 export function configurationsStore(): DatabaseConfigurations {
   // Memoized on first read so `Base.configurations` holds one object, as Rails'
   // @@configurations attribute does: save/restore round-trips must be no-ops.
-  _configurations ??= DatabaseConfigurations.fromEnv({});
+  _configurations ??= new DatabaseConfigurations({});
   return _configurations;
 }
 
@@ -83,29 +83,21 @@ export class DatabaseConfigurations {
     this.dbConfigHandlers.push(handler);
   }
 
-  /** @internal */
-  static get defaultEnv(): string {
-    if (this._defaultEnv === null) return "development";
-    return this._defaultEnv || "default";
-  }
-
-  /** @internal Assign null to clear the override and fall back to the process env. */
-  static set defaultEnv(value: string | null) {
-    this._defaultEnv = value;
-  }
-
   /**
-   * The active environment. Rails' counterpart is
-   * `ConnectionHandling::DEFAULT_ENV` / `RAILS_ENV`, which resolves
-   * `Rails.env` → `RAILS_ENV` → `RACK_ENV` → the literal default.
-   * Ours resolves `TRAILS_ENV` → `defaultEnv` → `NODE_ENV` → the literal
-   * default.
+   * Mirrors: `DatabaseConfigurations#default_env`
+   * (`database_configurations.rb:188-190`) — `DEFAULT_ENV.call.to_s`, where
+   * `DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }`
+   * (`connection_handling.rb:7`).
    *
-   * DELIBERATE DEVIATION — `TRAILS_ENV` outranks `defaultEnv`, Rails is the
-   * other way round. Per BC-2 (`docs/infrastructure/browser-compat-plan.md:88`)
+   * Ours resolves `TRAILS_ENV` -> the assigned override -> `NODE_ENV` -> the
+   * literal default. This is the ONE env in the class: the env a config is
+   * built under and the env it is later looked up by are the same value.
+   *
+   * DELIBERATE DEVIATION — `TRAILS_ENV` outranks the assigned override, Rails
+   * is the other way round. Per BC-2 (`docs/infrastructure/browser-compat-plan.md:88`)
    * `TRAILS_ENV` is the rename of the old `process.env.NODE_ENV` reads, so it
-   * maps to Rails' `ENV["RAILS_ENV"]` / `ENV["RACK_ENV"]`, and `defaultEnv` is
-   * the `Rails.env` analogue — by `connection_handling.rb:6` `defaultEnv` would
+   * maps to Rails' `ENV["RAILS_ENV"]` / `ENV["RACK_ENV"]`, and the override is
+   * the `Rails.env` analogue — by `connection_handling.rb:6` the override would
    * therefore win. trails inverts that on purpose: `TRAILS_ENV` is how a deploy
    * declares which environment the process is, and no in-process bootstrap may
    * override it. Consequence to know: with `TRAILS_ENV` set, assigning
@@ -113,22 +105,17 @@ export class DatabaseConfigurations {
    *
    * `NODE_ENV` sits last, ahead of only the literal default: it is a
    * one-release bridge with no Rails counterpart, and test runners set it
-   * unconditionally, so it must not mask a deliberate `defaultEnv`.
-   *
-   * Single source of truth for "what env are we building/connecting for" —
-   * `fromEnv` (which builds the configs) and the runtime config selectors in
-   * `connection-handling` must resolve it identically, or the synthesized
-   * `DATABASE_URL` config can be built for one env and looked up under another.
+   * unconditionally, so it must not mask a deliberate assignment.
    *
    * @internal
    */
-  static currentEnv(): string {
-    return (
-      getEnv("TRAILS_ENV") ||
-      this._defaultEnv ||
-      getEnv("NODE_ENV") ||
-      DatabaseConfigurations.defaultEnv
-    );
+  static get defaultEnv(): string {
+    return getEnv("TRAILS_ENV") || this._defaultEnv || getEnv("NODE_ENV") || "development";
+  }
+
+  /** @internal Assign null to clear the override and fall back to the process env. */
+  static set defaultEnv(value: string | null) {
+    this._defaultEnv = value;
   }
 
   private _configurations: DatabaseConfig[];
@@ -137,25 +124,11 @@ export class DatabaseConfigurations {
     if (Array.isArray(configurations)) {
       this._configurations = configurations;
     } else {
-      // Mirrors Rails: DatabaseConfigurations#initialize calls build_configs which
-      // merges DATABASE_URL via environment_url_config + merge_db_environment_variables.
-      // Uses DatabaseConfigurations.defaultEnv (set by app bootstrap from RAILS_ENV/RACK_ENV),
-      // not NODE_ENV — matching Rails' env resolution semantics.
+      // `@configurations = build_configs(configurations)`
+      // (database_configurations.rb:73-75) — the ONE build path, which merges
+      // DATABASE_URL via environment_url_config + merge_db_environment_variables.
       this._configurations = this.buildConfigs(configurations);
     }
-  }
-
-  /**
-   * Build a DatabaseConfigurations from raw config, merging DATABASE_URL.
-   * Mirrors Rails' DatabaseConfigurations.new which auto-merges DATABASE_URL.
-   * Use this when you want Rails-compatible behavior (constructor + URL merge).
-   */
-  // fromRaw: build with explicit defaultEnv (not NODE_ENV) for test isolation.
-  // Used by merge-and-resolve tests that set DatabaseConfigurations.defaultEnv.
-  static fromRaw(configurations: RawConfigurations = {}): DatabaseConfigurations {
-    const instance = new DatabaseConfigurations([]);
-    instance._configurations = instance.buildConfigs(configurations);
-    return instance;
   }
 
   /**
@@ -189,6 +162,18 @@ export class DatabaseConfigurations {
    * Collects configs matching the given env/name/config_key filters.
    * Respects include_hidden to include replicas and database_tasks: false configs.
    */
+  configsFor(options: {
+    envName?: string;
+    name: string;
+    configKey?: string;
+    includeHidden?: boolean;
+  }): DatabaseConfig | undefined;
+  configsFor(options?: {
+    envName?: string;
+    name?: undefined;
+    configKey?: string;
+    includeHidden?: boolean;
+  }): DatabaseConfig[];
   configsFor(
     options: {
       envName?: string;
@@ -196,8 +181,11 @@ export class DatabaseConfigurations {
       configKey?: string;
       includeHidden?: boolean;
     } = {},
-  ): DatabaseConfig[] {
-    let configs = this.envWithConfigs(options.envName);
+  ): DatabaseConfig[] | DatabaseConfig | undefined {
+    // `env_name ||= default_env if name` (database_configurations.rb:99).
+    const envName =
+      options.envName ?? (options.name ? DatabaseConfigurations.defaultEnv : undefined);
+    let configs = this.envWithConfigs(envName);
 
     if (!options.includeHidden) {
       configs = configs.filter((c) => {
@@ -211,9 +199,11 @@ export class DatabaseConfigurations {
         Object.prototype.hasOwnProperty.call(c.configuration, options.configKey!),
       );
     }
+    // `if name; configs.find { |db_config| db_config.name == name.to_s }; else; configs; end`
+    // (database_configurations.rb:114-120) — a single config, not an array.
     if (options.name) {
       const nameStr = String(options.name);
-      configs = configs.filter((c) => c.name === nameStr);
+      return configs.find((c) => c.name === nameStr);
     }
     return configs;
   }
@@ -273,38 +263,16 @@ export class DatabaseConfigurations {
   }
 
   /**
-   * Build a DatabaseConfigurations from the current environment.
-   *
-   * If `DATABASE_URL` is set and no raw config is provided, it synthesizes
-   * a configuration for the current environment from the URL. This mirrors
-   * how Rails' DatabaseConfigurations handles DATABASE_URL.
-   */
-  static fromEnv(raw: RawConfigurations = {}): DatabaseConfigurations {
-    const instance = new DatabaseConfigurations([]);
-    // Build for the active env resolved by `currentEnv()` — the same method the
-    // runtime config selectors in `connection-handling` use, so the synthesized
-    // `DATABASE_URL` config is built under exactly the env it's later looked up
-    // by. DATABASE_URL merges into whichever environment is active.
-    instance._configurations = instance.buildConfigs(raw, DatabaseConfigurations.currentEnv());
-    return instance;
-  }
-
-  /**
    * Mirrors: ActiveRecord::DatabaseConfigurations#build_configs
    *
    * Builds DatabaseConfig objects from the raw config, adds a primary URL
    * config for the current env if none matches, then merges the per-name
    * `*_DATABASE_URL` / `DATABASE_URL` environment variables.
    *
-   * Rails reads `default_env` inline; `currentEnv` defaults to it and is only
-   * passed explicitly by `fromEnv`, which builds under the env the runtime
-   * config selectors look configs up by.
    */
-  private buildConfigs(
-    configs: RawConfigurations | DatabaseConfig[],
-    defaultEnv: string = DatabaseConfigurations.defaultEnv,
-  ): DatabaseConfig[] {
+  private buildConfigs(configs: RawConfigurations | DatabaseConfig[]): DatabaseConfig[] {
     if (Array.isArray(configs)) return configs;
+    const defaultEnv = DatabaseConfigurations.defaultEnv;
 
     const dbConfigs = Object.entries(configs).flatMap(([envName, config]) =>
       this._isThreeLevelConfig(config)
@@ -317,8 +285,6 @@ export class DatabaseConfigurations {
     );
 
     // `unless db_configs.find(&:for_current_env?)` (database_configurations.rb:212).
-    // Rails' `default_env` is supplied by the caller here so `fromEnv` can build
-    // under the env the runtime selectors actually look configs up by.
     if (!dbConfigs.some((c) => c.envName === defaultEnv)) {
       const urlConfig = this.environmentUrlConfig(defaultEnv, "primary", {});
       if (urlConfig) dbConfigs.push(urlConfig);
@@ -499,9 +465,9 @@ DatabaseConfigurations.registerDbConfigHandler((envName, name, url, config) => {
   return new HashConfig(envName, name, config);
 });
 
-// forCurrentEnv must use the same resolver as fromEnv() so that findDbConfig by
+// forCurrentEnv must use the same resolver as the constructor so findDbConfig by
 // DB name locates the config built for the active env. Mirrors Rails:
 // DatabaseConfig#for_current_env? and DatabaseConfigurations#build_configs both
 // call ConnectionHandling::DEFAULT_ENV.call
 // (Rails.env → RAILS_ENV → RACK_ENV → the literal default).
-_setDefaultEnvGetter(() => DatabaseConfigurations.currentEnv());
+_setDefaultEnvGetter(() => DatabaseConfigurations.defaultEnv);

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -199,7 +199,7 @@ export class DatabaseConfigurations {
         Object.prototype.hasOwnProperty.call(c.configuration, options.configKey!),
       );
     }
-    // `if name; configs.find { |db_config| db_config.name == name.to_s }; else; configs; end`
+    // `configs.find { |db_config| db_config.name == name.to_s }`
     // (database_configurations.rb:114-120) — a single config, not an array.
     if (options.name) {
       const nameStr = String(options.name);

--- a/packages/activerecord/src/migration-context.trails.test.ts
+++ b/packages/activerecord/src/migration-context.trails.test.ts
@@ -223,7 +223,7 @@ describe("MigrationContext connected surface", () => {
   });
 
   it("currentEnvironment answers the resolved default env", () => {
-    expect(context.currentEnvironment).toBe(DatabaseConfigurations.currentEnv());
+    expect(context.currentEnvironment).toBe(DatabaseConfigurations.defaultEnv);
   });
 
   it("lastStoredEnvironment is null until a version has been recorded", async () => {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2026,17 +2026,17 @@ export class MigrationContext<
   /**
    * @internal Mirrors: ActiveRecord::MigrationContext#current_environment
    * (`migration.rb:1340-1342`) — `ConnectionHandling::DEFAULT_ENV.call`, whose
-   * trails counterpart is {@link DatabaseConfigurations.currentEnv}.
+   * trails counterpart is {@link DatabaseConfigurations.defaultEnv}.
    *
    * @missingRailsCall call — CONVERGEABLE: Rails invokes the
    *   `ActiveRecord::ConnectionHandling::DEFAULT_ENV` Proc
    *   (`DEFAULT_ENV.call`, migration.rb:1341); trails has no ported
    *   `DEFAULT_ENV` Proc yet, so this reads
-   *   `DatabaseConfigurations.currentEnv()` instead. Convergence is RFC 0023
+   *   `DatabaseConfigurations.defaultEnv` instead. Convergence is RFC 0023
    *   story `port-connection-handling-default-env-proc`.
    */
   get currentEnvironment(): string {
-    return DatabaseConfigurations.currentEnv();
+    return DatabaseConfigurations.defaultEnv;
   }
 
   /** @internal Mirrors: ActiveRecord::MigrationContext#protected_environment? (`migration.rb:1344-1346`) */

--- a/packages/activerecord/src/migration/load-schema-if-pending.trails.test.ts
+++ b/packages/activerecord/src/migration/load-schema-if-pending.trails.test.ts
@@ -34,7 +34,7 @@ describe.skipIf(!currentAdapter("SQLite3Adapter"))("Migration.loadSchemaIfPendin
     upToDate = true;
     originalConfigurations = Base.configurations();
     Base.configurations({
-      [DatabaseConfigurations.currentEnv()]: {
+      [DatabaseConfigurations.defaultEnv]: {
         primary: { adapter: "sqlite3", database: ":memory:" },
       },
     });

--- a/packages/activerecord/src/migration/pending-migrations.test.ts
+++ b/packages/activerecord/src/migration/pending-migrations.test.ts
@@ -46,7 +46,7 @@ describe.skipIf(skip)("Migration", () => {
       path.join(tmpDir, `${databaseName}-migrations`);
 
     const baseConfig = (): RawConfigurations => ({
-      [DatabaseConfigurations.currentEnv()]: {
+      [DatabaseConfigurations.defaultEnv]: {
         primary: {
           adapter: "sqlite3",
           database: databasePathFor("primary"),

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -627,8 +627,7 @@ interface DeleteRecord {
       constraints: Record<string, unknown>,
     ): Parameters<DeleteManager["where"]>[0];
     connection: {
-      execDelete(sql: string, name: string): Promise<number>;
-      toSql(arel: unknown): string;
+      delete(arel: unknown, name?: string | null, binds?: unknown[]): Promise<number>;
     };
   };
 }
@@ -651,11 +650,13 @@ export async function deleteRow<T extends DeleteRecord>(this: T): Promise<T> {
     const dm = new DeleteManager()
       .from(ctor.arelTable)
       .where(ctor._buildQueryConstraintsWhereNode(_queryConstraintsHash.call(this as any)));
-    // The SQL is arel-built via `connection.toSql(dm)`; the "Delete" string is
-    // the operation-name label (Rails' log subscriber name), not raw SQL.
+    // `c.delete(dm, "#{self} Destroy")` (persistence.rb:294-296) — the public
+    // statement method, which is where `dirties_query_cache` is wired
+    // (query_cache.rb:13-15). "Delete" is the operation-name label (Rails' log
+    // subscriber name), not raw SQL.
     const adapter =
       threadedConnectionFor(ctor as unknown as typeof import("./base.js").Base) ?? ctor.connection;
-    await adapter.execDelete(adapter.toSql(dm), "Delete");
+    await adapter.delete(dm, "Delete");
   }
   this._destroyed = true;
   this._previouslyNewRecord = false;
@@ -948,8 +949,7 @@ interface UpdateColumnsRecord {
     };
     _buildPkWhereNode(id: unknown): Parameters<UpdateManager["where"]>[0];
     connection: {
-      execUpdate(sql: string, name?: string, binds?: unknown[]): Promise<number>;
-      update?(arel: InstanceType<typeof UpdateManager>): Promise<number>;
+      update(arel: unknown, name?: string | null, binds?: unknown[]): Promise<number>;
       quote?(value: unknown): string;
       quoteColumnName?(name: string): string;
       quoteTableName?(name: string): string;
@@ -1099,15 +1099,9 @@ export async function updateColumns<T extends UpdateColumnsRecord>(
     (threadedConnectionFor(ctor as unknown as typeof import("./base.js").Base) as
       | typeof ctor.connection
       | null) ?? ctor.connection;
-  let affectedRows: number;
-  if (typeof adapter.update === "function") {
-    affectedRows = await adapter.update(um);
-  } else {
-    const sql = adapter.toSql(um);
-    // The SQL is arel-built via `adapter.toSql(um)`; the "Update Columns" string
-    // is the operation-name label (Rails' log subscriber name), not raw SQL.
-    affectedRows = await adapter.execUpdate(sql, "Update Columns");
-  }
+  // `c.update(um, "#{self} Update")` (persistence.rb:277-279) — the public
+  // statement method `dirties_query_cache` is wired on (query_cache.rb:13-15).
+  const affectedRows = await adapter.update(um, "Update Columns");
 
   // Rails clears the change only for the updated columns (`clear_attribute_change(k)`),
   // leaving any other pending in-memory changes dirty — not a whole-record
@@ -1381,7 +1375,7 @@ interface PersistencePrivateHost {
     defaultScoped(): { whereClause: { isEmpty(): boolean; ast: unknown } };
     readonlyAttributeQ?(name: string): boolean;
     withConnection?(fn: (conn: unknown) => Promise<void>): Promise<void>;
-    connection: { execDelete(sql: string, name: string): Promise<number> };
+    connection: { delete(arel: unknown, name?: string | null, binds?: unknown[]): Promise<number> };
   };
 }
 

--- a/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks-protected-environments-env.trails.test.ts
@@ -62,7 +62,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
   it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
     "compares the stored environment against the global default environment",
     async () => {
-      await stampedConfig(DatabaseConfigurations.currentEnv());
+      await stampedConfig(DatabaseConfigurations.defaultEnv);
       await DatabaseTasks.checkProtectedEnvironmentsBang(env);
     },
   );
@@ -70,7 +70,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsCurrentEnvironmentTest", () => 
   it.skipIf(adapterType !== "sqlite" || inMemoryDb())(
     "reports the global default environment as current on a mismatch",
     async () => {
-      const current = DatabaseConfigurations.currentEnv();
+      const current = DatabaseConfigurations.defaultEnv;
       expect(current).not.toBe(env);
       await stampedConfig("otherenv");
       const error = await DatabaseTasks.checkProtectedEnvironmentsBang(env).catch(
@@ -181,7 +181,7 @@ describe("DatabaseTasksCheckCurrentProtectedEnvironmentTest", () => {
   });
 
   it.skipIf(skipUnlessFileSqlite)("passes when environments match", async () => {
-    const config = await seededConfig({ storedEnv: DatabaseConfigurations.currentEnv() });
+    const config = await seededConfig({ storedEnv: DatabaseConfigurations.defaultEnv });
     await expect(checkCurrentProtectedEnvironmentBang(config)).resolves.toBeUndefined();
   });
 
@@ -208,7 +208,7 @@ describe("DatabaseTasksCheckCurrentProtectedEnvironmentTest", () => {
   );
 
   it.skipIf(skipUnlessFileSqlite)("passes for an unprotected stored environment", async () => {
-    const current = DatabaseConfigurations.currentEnv();
+    const current = DatabaseConfigurations.defaultEnv;
     const config = await seededConfig({ storedEnv: current });
     const protectedEnvironments = Base.protectedEnvironments;
     Base.protectedEnvironments = ["production"];

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -49,7 +49,7 @@ describe("DatabaseTasksCheckProtectedEnvironmentsTest", () => {
       // stamp the config's metadata with the current env, assert the guard
       // passes, then protect that env and assert it raises.
       const protectedEnvironments = Base.protectedEnvironments;
-      const currentEnv = DatabaseConfigurations.currentEnv();
+      const currentEnv = DatabaseConfigurations.defaultEnv;
       const env = "arunit";
       const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "trails-protected-env-"));
       const dbFile = path.join(tmp, "primary.sqlite3");
@@ -1232,9 +1232,9 @@ describe("DatabaseTasksPurgeCurrentTest", () => {
     });
     DatabaseTasks.env = "test";
     await DatabaseTasks.purgeCurrent("production");
-    expect(purged).toEqual(
+    expect(purged).toEqual([
       DatabaseTasks.databaseConfiguration.configsFor({ envName: "production", name: "primary" }),
-    );
+    ]);
     expect(establishSpy).toHaveBeenCalledWith("production");
   });
 });

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -95,7 +95,7 @@ export class DatabaseTasks {
   }
 
   static set databaseConfiguration(value: DatabaseConfigurations | null) {
-    setConfigurationsStore(value ?? DatabaseConfigurations.fromEnv({}));
+    setConfigurationsStore(value ?? new DatabaseConfigurations({}));
   }
 
   static dbDir: string = "db";
@@ -458,9 +458,11 @@ export class DatabaseTasks {
     envName: string = DatabaseTasks.env,
     dbName: string = DatabaseTasks.name,
   ): Promise<string | null> {
+    // `db_config = configs_for(env_name: env_name, name: db_name); charset(db_config)`
+    // (database_tasks.rb:327-330) — a single config passes straight through.
     const dbConfig = this.configsFor({ envName, name: dbName });
-    if (dbConfig.length === 0) return null;
-    return this.charset(dbConfig[0]);
+    if (!dbConfig) return null;
+    return this.charset(dbConfig);
   }
 
   /**
@@ -486,9 +488,11 @@ export class DatabaseTasks {
     envName: string = DatabaseTasks.env,
     dbName: string = DatabaseTasks.name,
   ): Promise<string | null> {
+    // `db_config = configs_for(env_name: env_name, name: db_name); collation(db_config)`
+    // (database_tasks.rb:337-340).
     const dbConfig = this.configsFor({ envName, name: dbName });
-    if (dbConfig.length === 0) return null;
-    return this.collation(dbConfig[0]);
+    if (!dbConfig) return null;
+    return this.collation(dbConfig);
   }
 
   /**
@@ -574,11 +578,25 @@ export class DatabaseTasks {
   }
 
   /** @internal */
+  static configsFor(options: {
+    envName?: string;
+    name: string;
+    includeHidden?: boolean;
+  }): DatabaseConfig | undefined;
+  /** @internal */
+  static configsFor(options?: {
+    envName?: string;
+    name?: undefined;
+    includeHidden?: boolean;
+  }): DatabaseConfig[];
+  /** @internal */
   static configsFor(
     options: { envName?: string; name?: string; includeHidden?: boolean } = {},
-  ): DatabaseConfig[] {
+  ): DatabaseConfig[] | DatabaseConfig | undefined {
     // database_tasks.rb:551-553 — `Base.configurations.configs_for(**options)`.
-    return baseClass().configurations().configsFor(options);
+    return baseClass()
+      .configurations()
+      .configsFor(options as { name: string });
   }
 
   /**
@@ -637,22 +655,18 @@ export class DatabaseTasks {
     dbConfig: DatabaseConfig,
     options?: { schemaCachePath?: string },
   ): string {
-    const explicit = options?.schemaCachePath;
-    if (explicit) return explicit;
-
-    const configPath =
-      typeof (dbConfig as any).schemaCachePath === "function"
-        ? (dbConfig as any).schemaCachePath()
-        : (dbConfig as any).schemaCachePath;
-    if (configPath) return configPath;
-
-    const configDefault =
-      typeof (dbConfig as any).defaultSchemaCachePath === "function"
-        ? (dbConfig as any).defaultSchemaCachePath(this.dbDir)
-        : null;
-    if (configDefault) return configDefault;
-
-    return `${this.dbDir}/schema_cache.json`;
+    // `schema_cache_path || db_config.schema_cache_path ||
+    //  db_config.default_schema_cache_path(DatabaseTasks.db_dir)`
+    // (database_tasks.rb:468-471). `default_schema_cache_path` is defined on
+    // `HashConfig` (hash_config.rb:117-123), not on the abstract
+    // `DatabaseConfig` (database_config.rb:95 declares only
+    // `schema_cache_path`), so the receiver is narrowed the same way
+    // `DatabaseTasks.forEach` narrows it for the identical Ruby call.
+    return (
+      options?.schemaCachePath ||
+      dbConfig.schemaCachePath ||
+      (dbConfig as HashConfig).defaultSchemaCachePath(this.dbDir)
+    );
   }
 
   /**
@@ -1220,9 +1234,11 @@ export class DatabaseTasks {
   ): Promise<void> {
     env = this._normalizeEnv(env);
     if (name != null) {
-      const dbConfig = this.migrationClass().configurations().configsFor({ envName: env, name })[0];
+      const dbConfig = this.migrationClass().configurations().configsFor({ envName: env, name });
       if (dbConfig) await this.withTemporaryPool(dbConfig, block, { clobber });
     } else {
+      // `configs_for(env_name: env, name: name)` — `name` is nil in this arm,
+      // which is the array arm of `configs_for`.
       for (const dbConfig of this.migrationClass()
         .configurations()
         .configsFor({ envName: env, name })) {

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -87,7 +87,7 @@ describe("TestDatabasesTest", () => {
     // "Updates the database configuration" — Rails re-reads the registry
     // (test_databases_test.rb:49); `configsFor` is stubbed to hand back the same
     // config object, which is the one create_and_load_schema suffixed.
-    expect(mockConfigurations.configsFor({ envName: "arunit", name: "primary" })[0].database).toBe(
+    expect(mockConfigurations.configsFor({ envName: "arunit" })[0].database).toBe(
       "test/db/primary.sqlite3-42",
     );
   });

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -186,14 +186,11 @@ async function touchRow(this: Base, touchCols: string[], now: Temporal.Instant):
     }
   }
 
+  // `c.update(um, "#{self} Update")` (persistence.rb:277-279) — touch routes
+  // through `_update_record`, so it reaches the public statement method
+  // `dirties_query_cache` is wired on (query_cache.rb:13-15).
   const adapter = ctor.connection as any;
-  let affected: number;
-  if (typeof adapter.update === "function") {
-    affected = await adapter.update(um);
-  } else {
-    const sql = adapter.toSql(um);
-    affected = await ctor.connection.execUpdate(sql, `${ctor.name} Touch`);
-  }
+  const affected: number = await adapter.update(um, `${ctor.name} Touch`);
   if (ctor.lockingEnabled && affected === 0) {
     // Mirrors Rails _update_row rescue Exception: restore the attribute snapshot so
     // the in-memory record is not left with an incorrect lock_version after a stale touch.

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
-    "novel": 376,
-    "total": 1324
+    "novel": 372,
+    "total": 1318
   },
   "arel": {
     "novel": 0,

--- a/scripts/closing-story-references.test.ts
+++ b/scripts/closing-story-references.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  closesStoryIds,
+  closingStoryReferences,
+  formatFindings,
+} from "./closing-story-references.js";
+import { extractStoryReferences, type StoryReference } from "./stale-story-references.js";
+
+describe("closesStoryIds", () => {
+  it("parses the trailer case-insensitively", () => {
+    expect(closesStoryIds("Body text.\n\nCloses-story: some-landed-story\n")).toEqual([
+      "some-landed-story",
+    ]);
+    expect(closesStoryIds("closes-story:   some-landed-story  ")).toEqual(["some-landed-story"]);
+    expect(closesStoryIds("CLOSES-STORY: Some-Landed-Story")).toEqual(["some-landed-story"]);
+  });
+
+  it("parses every trailer a bundle PR carries", () => {
+    const body = [
+      "## Summary",
+      "",
+      "Closes-story: first-bundled-story",
+      "Closes-story: second-bundled-story",
+      "Closes-story: first-bundled-story",
+    ].join("\n");
+    expect(closesStoryIds(body)).toEqual(["first-bundled-story", "second-bundled-story"]);
+  });
+
+  it("ignores prose that merely mentions the phrase mid-line", () => {
+    expect(closesStoryIds("This PR closes-story: nothing at all really")).toEqual([]);
+    expect(closesStoryIds("no trailer here")).toEqual([]);
+  });
+});
+
+describe("closingStoryReferences", () => {
+  // The #7077 comment, verbatim: `a8e658cb` deleted
+  // AbstractMysqlAdapter#lookupCastType and closed the story, but left this
+  // sentence at abstract-adapter.ts:2746. #7083 was the mop-up.
+  const SEVEN_OH_SEVEN_SEVEN = [
+    "  /**",
+    "   * The `Promise<Type>` arm is not Rails: `PostgreSQLAdapter#lookupCastType`",
+    "   * resolves a sql_type with a live regtype query, so its override is async",
+    "   * (tracked by `pg-lookup-cast-type-async-divergence`). The `null` arm is",
+    "   * `AbstractMysqlAdapter`'s early return for an empty sql_type, which",
+    "   * `mysql-native-type-map-converges-onto-type-map` deletes.",
+    "   */",
+  ].join("\n");
+
+  const refsFor = (source: string, file = "packages/activerecord/src/x.ts"): StoryReference[] =>
+    extractStoryReferences(source, file);
+
+  it("flags a citation of a story the PR declares closed", () => {
+    const body = "Closes-story: mysql-native-type-map-converges-onto-type-map";
+    const findings = closingStoryReferences(
+      refsFor(SEVEN_OH_SEVEN_SEVEN),
+      new Set(closesStoryIds(body)),
+    );
+    expect(findings.map((f) => f.slug)).toEqual(["mysql-native-type-map-converges-onto-type-map"]);
+    expect(formatFindings(findings)).toContain("packages/activerecord/src/x.ts:1");
+  });
+
+  it("clears once the citation is deleted, as #7083 did", () => {
+    const fixed = SEVEN_OH_SEVEN_SEVEN.split("\n")
+      .filter((line) => !line.includes("mysql-native-type-map"))
+      .join("\n");
+    const body = "Closes-story: mysql-native-type-map-converges-onto-type-map";
+    expect(closingStoryReferences(refsFor(fixed), new Set(closesStoryIds(body)))).toEqual([]);
+  });
+
+  it("leaves a citation of a story the PR does not close alone", () => {
+    // The same block cites `pg-lookup-cast-type-async-divergence`, which this
+    // PR says nothing about.
+    const body = "Closes-story: some-other-unrelated-story";
+    expect(
+      closingStoryReferences(refsFor(SEVEN_OH_SEVEN_SEVEN), new Set(closesStoryIds(body))),
+    ).toEqual([]);
+  });
+
+  it("leaves a provenance citation alone", () => {
+    const source = [
+      "  // Regression for `activesupport-json-encoding-time-precision`, which",
+      "  // landed (#5971) without updating this assertion.",
+    ].join("\n");
+    const body = "Closes-story: activesupport-json-encoding-time-precision";
+    expect(closingStoryReferences(refsFor(source), new Set(closesStoryIds(body)))).toEqual([]);
+  });
+
+  it("flags the #5971 shape when the promise is still pending", () => {
+    const source = [
+      "  // The pre-convergence value is asserted here; the real one is",
+      "  // deferred to `activesupport-json-encoding-time-precision`.",
+    ].join("\n");
+    const body = "Closes-story: activesupport-json-encoding-time-precision";
+    const findings = closingStoryReferences(refsFor(source), new Set(closesStoryIds(body)));
+    expect(findings.map((f) => f.slug)).toEqual(["activesupport-json-encoding-time-precision"]);
+  });
+});

--- a/scripts/closing-story-references.ts
+++ b/scripts/closing-story-references.ts
@@ -1,0 +1,110 @@
+// `stale-story-references` judges a landed story's citations, but a story lands
+// only AFTER the merge: `.claude/skills/post-merge-findings/run.sh` parses the
+// `Closes-story:` trailers out of a MERGED PR body and runs `pnpm tasks done`.
+// So a PR that closes a story is structurally blind to the check that judges it
+// seconds later — its own CI sees the story still in progress, passes, merges,
+// and main goes red with no commit in between (#7083 for #7077;
+// #5976 for #5971).
+//
+// This module closes that window by moving the judgement to PR time: a PR whose
+// body declares `Closes-story: <id>` must carry no pending citation of `<id>`
+// anywhere in the tree. The citation scan is `scanStoryReferences` verbatim, so
+// a finding here is a guaranteed red on main — there is no new false-positive
+// class, and no judgement call in the message.
+
+import { pathToFileURL } from "node:url";
+
+import { scanStoryReferences, type StoryReference } from "./stale-story-references.js";
+
+// The one definition of the trailer shape. `post-merge-findings/run.sh` matches
+// the same shape with `grep -oiE 'Closes-story:[[:space:]]*[a-z0-9][a-z0-9-]*'`,
+// so the gate and the marker can never disagree about what a PR closes.
+const CLOSES_STORY = /^[^\S\n]*closes-story:[^\S\n]*([a-z0-9][a-z0-9-]*)[^\S\n]*$/gim;
+
+/**
+ * Every story id a PR body declares closed, in order and de-duplicated. A
+ * bundle PR carries one trailer per story, so all of them count — taking only
+ * the first is the bug run.sh already had to fix.
+ */
+export function closesStoryIds(prBody: string): string[] {
+  const ids = new Set<string>();
+  for (const match of prBody.matchAll(CLOSES_STORY)) ids.add(match[1].toLowerCase());
+  return [...ids];
+}
+
+/**
+ * The citations this PR must clear before it merges: a pending promise naming a
+ * story the same PR declares closed. A citation of a story the PR does NOT
+ * close is somebody else's problem and stays green.
+ */
+export function closingStoryReferences(
+  refs: readonly StoryReference[],
+  closingIds: ReadonlySet<string>,
+): StoryReference[] {
+  return refs.filter((ref) => closingIds.has(ref.slug));
+}
+
+/** Every pending citation of a story `prBody` declares closed. */
+export async function scanClosingStoryReferences(
+  repoRoot: string,
+  prBody: string,
+): Promise<StoryReference[]> {
+  const closingIds = new Set(closesStoryIds(prBody));
+  if (closingIds.size === 0) return [];
+  return closingStoryReferences(await scanStoryReferences(repoRoot), closingIds);
+}
+
+/**
+ * The human-readable failure. Both legal fixes are named because there is no
+ * third one: the citation either belongs to the story that owns the remaining
+ * work now, or it belongs to nothing.
+ */
+export function formatFindings(findings: readonly StoryReference[]): string {
+  const lines = findings.map((f) => `  ${f.file}:${f.line} — cites \`${f.slug}\``);
+  return [
+    "This PR declares it closes these stories, but still promises work to them:",
+    ...lines,
+    "",
+    "Fix one of two ways, before the merge:",
+    "  - re-point the citation at the story that owns that work now, or",
+    "  - delete the citation.",
+    "",
+    "Left as-is, `stale-story-references` reds Unit Tests on main the moment",
+    "post-merge-findings marks the story done.",
+  ].join("\n");
+}
+
+/**
+ * The PR body to judge. `--pr N` reads the live body through `gh` — the same
+ * source `run.sh` reads, so the gate sees the trailers a body edit added after
+ * the last CI run. With no `--pr`, the branch's own commit messages stand in,
+ * which is what an agent has locally before the PR exists.
+ */
+async function resolveBody(argv: readonly string[]): Promise<string> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const run = promisify(execFile);
+  const prIndex = argv.indexOf("--pr");
+  const pr = prIndex === -1 ? undefined : argv[prIndex + 1];
+  const cmd = pr
+    ? (["gh", ["pr", "view", pr, "--json", "body", "--jq", ".body"]] as const)
+    : (["git", ["log", "--format=%B", "origin/main..HEAD"]] as const);
+  const { stdout } = await run(cmd[0], [...cmd[1]]);
+  return stdout;
+}
+
+export async function main(argv: readonly string[], repoRoot: string): Promise<number> {
+  const findings = await scanClosingStoryReferences(repoRoot, await resolveBody(argv));
+  if (findings.length === 0) {
+    console.log("No pending citations of a story this PR closes.");
+    return 0;
+  }
+  console.error(formatFindings(findings));
+  return 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main(process.argv.slice(2), process.cwd()).then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/scripts/stale-story-references.ts
+++ b/scripts/stale-story-references.ts
@@ -35,7 +35,10 @@ const FROZEN_MARKDOWN_TREES = [path.join("docs", "activerecord")];
 
 // Its test states a stale promise verbatim as a fixture, and the line-based
 // scan reads that template literal as a real comment.
-const SKIP_FILES = new Set([path.join("scripts", "stale-story-references.test.ts")]);
+const SKIP_FILES = new Set([
+  path.join("scripts", "stale-story-references.test.ts"),
+  path.join("scripts", "closing-story-references.test.ts"),
+]);
 
 export interface StoryReference {
   file: string;


### PR DESCRIPTION
Bundle of five stories: one CI gate plus four fidelity convergences.

## 1. Gate `Closes-story:` citations at PR time (`gate-closing-story-citations-at-pr-time`)

`scripts/stale-story-references.ts` reds `Unit Tests` on main when a comment
promises work to a story that has already landed — but a story lands only
*after* the merge, because `post-merge-findings/run.sh` parses the trailers out
of a merged PR body and only then runs `pnpm tasks done`. A PR that closes a
story is therefore structurally blind to the check that judges it seconds
later. That is #7083 (mop-up for #7077) and #5976 (mop-up for #5971).

- `scripts/closing-story-references.ts` reuses `scanStoryReferences()` verbatim,
  so there is no new false-positive class. Only the predicate is new:
  `closesStoryIds(prBody)` — the single definition of the trailer regex, the
  same shape `run.sh` greps — and `closingStoryReferences(refs, closingIds)`.
- A `Closing-story citations` step in the `preflight` job, gated
  `github.event_name == 'pull_request'` as `Docs ActiveRecord Freeze` is.
- `pnpm check:closing-story-refs [--pr N]`; with no `--pr` it reads the branch's
  own commit messages.
- A belt in `run.sh`: the check re-runs over the merged tree before
  `pnpm tasks done`, and refuses the flip on a finding. This covers the one hole
  the PR-time gate cannot — `on: pull_request` carries no `edited` type, so a
  trailer added after the last CI run was never gated.
- A branch-derived id (no trailer in the body) is never a failure, per the
  story's Out-of-scope note: the belt reads the body, which has no trailers.

Tests reconstruct the #7077 comment verbatim and the #5971 shape, and assert
that a citation of a story the PR does not close, and a provenance citation,
both stay green.

## 2. `cacheDumpFilename` (`converge-cache-dump-filename-onto-three-term-rails`)

Three `||` terms in Rails' order (`database_tasks.rb:468-471`), no fourth
fallback, no `as any` probes. `defaultSchemaCachePath` is a `HashConfig` method
(`hash_config.rb:117-123`), so the receiver is narrowed the way
`DatabaseTasks.forEach` already narrows it for the identical Ruby call.

## 3. `configsFor(name:)` (`converge-configs-for-name-returns-single-config`)

Rails returns a **single** `DatabaseConfig` (or `nil`) when `name:` is given
(`database_configurations.rb:114-120`), which is what lets `charset_current`
pass `db_config` straight to `charset` (`database_tasks.rb:327-340`). A TS
overload pair now matches both arms, and the `env_name ||= default_env if name`
line (`:99`) — previously missing — is ported. `charsetCurrent`,
`collationCurrent` and `withTemporaryPoolForEach` drop their `[0]` indexing and
`.length` guards.

## 4. One `DatabaseConfigurations` build path (`converge-databaseconfigurations-build-entry-points-onto-new`)

Rails has one: `DatabaseConfigurations.new(config)` (`core.rb:71-73`). `fromRaw`
and `fromEnv` are deleted; every caller uses the constructor. `currentEnv()` is
deleted too and `defaultEnv` absorbs its resolution, so the class has ONE env —
`default_env` (`database_configurations.rb:188-190`,
`connection_handling.rb:7`) — and the env a config is built under is the env it
is later looked up by, by construction rather than by a caller remembering to
pass the right one. `Core.configurations`'s writer now calls the constructor.
The `TRAILS_ENV`-outranks-the-override deviation is documented on `defaultEnv`,
where it now lives.

## 5. `dirties_query_cache` on Rails' public methods (`converge-dirties-query-cache-onto-rails-public-methods`)

Rails wires `insert`/`create`/`update`/`delete` (`query_cache.rb:13-15`), not
`exec_insert`/`exec_update`/`exec_delete`. trails wired the lower three because
its save path called them directly — so the prerequisite is closed first:
`_delete_row`, `_destroyRow`, `updateColumns` and `touch` now call the public
`c.delete(dm, ...)` / `c.update(um, ...)` Rails calls
(`persistence.rb:277-279,294-296`), which also drops two duck-typed
`typeof adapter.update === "function"` branches and restores the operation-name
label the `update` arm was silently dropping.

That closes the gap PR #6835 left: PostgreSQL's `use_insert_returning? == false`
arm (`postgresql/database_statements.rb:48-59`) calls `internal_exec_query`
directly and never reaches `AbstractAdapter#execInsert`, so it cleared nothing.
The clear now sits above both arms. New regression test drives that arm and
fails on baseline (verified locally: 1 failed / 18 passed with the old wiring).

## Review note — `"create"` in the `dirtiesQueryCache` wiring is not inert

The review reads `AbstractAdapter` as having no runtime `create`, citing only
the interface declaration at `abstract-adapter.ts:650`. The implementation is
`create: insertStatement` at
`connection-adapters/abstract/database-statements.ts:1529` — the TS spelling of
Rails' `alias create insert` (`abstract/database_statements.rb:203`): both names
reference the same unwrapped function rather than `create` delegating to
`this.insert`, exactly as the comment there records.

It reaches the prototype before the wiring runs:
`ensureAbstractAdapterMixinsApplied()` calls
`include(AbstractAdapter, DatabaseStatements)` at its top
(`abstract-adapter.ts:2797`) and `dirtiesQueryCache(...)` at its bottom, so
`typeof original === "function"` is true and the name is wrapped, not skipped.

Confirmed against the built `dist/` with a real instance — `create`, `insert`,
`update` and `delete` all resolve to the `dirtiesQueryCache` wrapper
("Clear unconditionally, …"), while `execInsert`/`execUpdate`/`execDelete`
resolve to their plain implementations, which is the intended post-convergence
shape. No change made.

## Review note — the `"default"` literal (converged; the causal claim did not hold)

The finding is right on the substance and wrong on the cause, so both halves are
recorded here.

**Substance — converged.** Rails' `DEFAULT_ENV = -> { RAILS_ENV.call || "default_env" }`
(`connection_handling.rb:7`) falls back to `"default_env"`, and
`connection_handler_test.rb:27` asserts exactly that string. trails spelled it
`"default"`. That literal is pre-existing — `database-configurations.ts:89` on
`origin/main` reads `return this._defaultEnv || "default"`, with the test
asserting `"default"` — but it sits on a line this PR rewrites, and an existing
deviation next to the work is a reason to converge it rather than match it. Both
the literal and the test assertion now read `"default_env"`, which also moves the
test's assertion value onto Rails'. Verified nothing else consumes the string:
every other `"default"` in the AR packages is a shard name or a column value.

**Cause — not this literal.** The red was
`AssertionError: expected 'test' to be 'default'`: the test *wanted* `"default"`
and received `"test"`. Nothing was comparing against `"default_env"` and getting
`"default"` back; the getter was falling through to `NODE_ENV` (`"test"` under
vitest) because the `||` chain lost Rails' `.presence` semantics, where a blank
value is nil and short-circuits to the literal instead of advancing to the next
lookup. That was fixed in `750fa112c`, which CI had not yet run when the review
was written. Swapping the literal alone would have left that fall-through in
place and turned the assertion into `expected 'test' to be 'default_env'`.

`parity:test:assertions` is green after the change (activerecord
assertion-value-mismatch unchanged at its mark), and all 141 affected test files
pass locally.

## Size

718 LOC against a 700 ceiling — 2.5% over for five stories; the overage is the
new gate's script + test, which is a whole new file pair.

Closes-story: gate-closing-story-citations-at-pr-time
Closes-story: converge-cache-dump-filename-onto-three-term-rails
Closes-story: converge-configs-for-name-returns-single-config
Closes-story: converge-databaseconfigurations-build-entry-points-onto-new
Closes-story: converge-dirties-query-cache-onto-rails-public-methods


