### PR TITLE
test(activerecord): port json_shared_test_cases.rb as a shared module (RFC 0112)

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -9,7 +9,6 @@ import { fixtures } from "../../test-fixtures.js";
 import { jsonSharedTestCases, JsonDataType as klass } from "../../cases/json-shared-test-cases.js";
 import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
-// Rails: private def column_type; :json; end
 const columnType = "json";
 
 describeIfSqlite("SQLite3JSONTest", () => {
@@ -17,9 +16,8 @@ describeIfSqlite("SQLite3JSONTest", () => {
 
   let connection: SQLite3Adapter;
 
-  // Rails: def setup; super; @connection.create_table("json_data_type") { ... }; end
-  // Registered before the shared module's own setup so the table exists by the
-  // time that hook reflects the columns (Ruby reflects lazily, per test).
+  // Registered before the shared module's setup so the table exists by the time
+  // that hook reflects its columns; Ruby reflects lazily, per test.
   beforeEach(async () => {
     connection = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
     // Teardown lives in the shared module's afterEach (Rails: JSONSharedTestCases#teardown).
@@ -30,7 +28,6 @@ describeIfSqlite("SQLite3JSONTest", () => {
     });
   });
 
-  // Rails: include JSONSharedTestCases
   jsonSharedTestCases({ columnType });
 
   it("test_default", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -1,54 +1,47 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/sqlite3/json_test.rb
- * (plus the JSONSharedTestCases it includes).
  */
-import { it, expect, beforeEach, afterEach } from "vitest";
+import { it, expect, beforeEach } from "vitest";
 import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
+import { jsonSharedTestCases, JsonDataType as klass } from "../../cases/json-shared-test-cases.js";
 import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
-let adapter: SQLite3Adapter;
-
-class JsonDataType extends Base {
-  static {
-    this.tableName = "json_data_type";
-  }
-}
+// Rails: private def column_type; :json; end
+const columnType = "json";
 
 describeIfSqlite("SQLite3JSONTest", () => {
   fixtures([]);
 
+  let connection: SQLite3Adapter;
+
+  // Rails: def setup; super; @connection.create_table("json_data_type") { ... }; end
+  // Registered before the shared module's own setup so the table exists by the
+  // time that hook reflects the columns (Ruby reflects lazily, per test).
   beforeEach(async () => {
-    adapter = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
-    // Mirrors Rails JSONSharedTestCases#setup creating the table ad-hoc:
-    //   t.json "payload", default: {}
-    //   t.json "settings"
-    await adapter.createTable("json_data_type", {}, (t: any) => {
+    connection = (await Base.leaseConnection()) as unknown as SQLite3Adapter;
+    // Teardown lives in the shared module's afterEach (Rails: JSONSharedTestCases#teardown).
+    // eslint-disable-next-line blazetrails/require-table-teardown
+    await connection.createTable("json_data_type", {}, (t: any) => {
       t.json("payload", { default: {} });
       t.json("settings");
     });
   });
 
-  afterEach(async () => {
-    // Mirrors Rails JSONSharedTestCases#teardown: drop_table :json_data_type.
-    await adapter.dropTable("json_data_type", { ifExists: true });
-    void JsonDataType.resetColumnInformation();
-  });
-
-  it("test_assigning_string_literal", async () => {
-    await JsonDataType.loadSchema();
-    const json = await JsonDataType.create({ payload: "foo" });
-    expect((json as any).payload).toBe("foo");
-  });
+  // Rails: include JSONSharedTestCases
+  jsonSharedTestCases({ columnType });
 
   it("test_default", async () => {
     const defaultVal = { users: "read", posts: ["read", "write"] };
-    await adapter.addColumn("json_data_type", "permissions", "json", { default: defaultVal });
-    await JsonDataType.loadSchema();
+    await connection.addColumn("json_data_type", "permissions", columnType, {
+      default: defaultVal,
+    });
+    await klass.resetColumnInformation();
+    await klass.loadSchema();
 
-    expect(JsonDataType.columnDefaults["permissions"]).toEqual(defaultVal);
-    expect((new JsonDataType() as any).permissions).toEqual(defaultVal);
+    expect(klass.columnDefaults["permissions"]).toEqual(defaultVal);
+    expect((new klass() as any).permissions).toEqual(defaultVal);
   });
 });

--- a/packages/activerecord/src/cases/json-shared-test-cases.ts
+++ b/packages/activerecord/src/cases/json-shared-test-cases.ts
@@ -27,9 +27,6 @@ export interface JSONSharedTestCasesHost {
   insertStatementPerDatabase?: (values: string) => string;
 }
 
-// Rails: class JsonDataType < ActiveRecord::Base
-//   self.table_name = "json_data_type"
-//   store_accessor :settings, :resolution
 export class JsonDataType extends Base {
   static {
     this.tableName = "json_data_type";
@@ -37,7 +34,6 @@ export class JsonDataType extends Base {
   }
 }
 
-// Rails: class MySettings
 class MySettings {
   constructor(private readonly hash: Record<string, unknown>) {}
   toHash(): Record<string, unknown> {
@@ -51,10 +47,6 @@ class MySettings {
   }
 }
 
-// Rails: class JsonDataTypeWithFilter < ActiveRecord::Base
-//   self.table_name = "json_data_type"
-//   attribute :payload, :json
-//   def self.filter_attributes; super + [:password]; end
 class JsonDataTypeWithFilter extends Base {
   static {
     this.tableName = "json_data_type";
@@ -70,7 +62,6 @@ class JsonDataTypeWithFilter extends Base {
  */
 type JsonRecord = InstanceType<typeof JsonDataType> & Record<string, unknown>;
 
-// Rails: private def klass; JsonDataType; end
 function klass(): typeof JsonDataType {
   return JsonDataType;
 }
@@ -78,14 +69,12 @@ function klass(): typeof JsonDataType {
 export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
   const columnType = host.columnType;
 
-  // Rails: private def insert_statement_per_database(values)
   const insertStatementPerDatabase =
     host.insertStatementPerDatabase ??
     ((values: string) => `insert into json_data_type (payload) VALUES ('${values}')`);
 
   let connection: AbstractAdapter;
 
-  // Rails: private def assert_type_match(type, sql_type)
   async function assertTypeMatch(type: string, sqlType: string | undefined): Promise<void> {
     const nativeType = (
       (await Base.leaseConnection()).nativeDatabaseTypes()[type] as { name: string }
@@ -93,7 +82,6 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
     expect(sqlType ?? "").toMatch(new RegExp(`^${nativeType}\\b`));
   }
 
-  // Rails: def setup; @connection = ActiveRecord::Base.lease_connection; end
   beforeEach(async () => {
     connection = await Base.leaseConnection();
     // trails: Rails reflects the ad-hoc table's columns lazily on first
@@ -101,10 +89,6 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
     await klass().loadSchema();
   });
 
-  // Rails: def teardown
-  //   @connection.drop_table :json_data_type, if_exists: true
-  //   klass.reset_column_information
-  // end
   afterEach(async () => {
     await connection.dropTable("json_data_type", { ifExists: true });
     void klass().resetColumnInformation();
@@ -283,8 +267,8 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
   // order-insensitive `Hash#==`; trails' port compares with `!==`
   // (activemodel/src/type/value.ts:77), so two structurally equal hashes are
   // "changed". Converging that base predicate is a change to every value type,
-  // tracked as its own story — not something to paper over with a `Json`-only
-  // `changed?` override Rails does not have.
+  // tracked as converge-value-type-changed-to-ruby-equality — not something to
+  // paper over with a `Json`-only `changed?` override Rails does not have.
   it.skip("test_changes_in_place_ignores_key_order", async () => {
     const json = klass().new() as JsonRecord;
     expect(json.isChanged).toBe(false);

--- a/packages/activerecord/src/cases/json-shared-test-cases.ts
+++ b/packages/activerecord/src/cases/json-shared-test-cases.ts
@@ -34,27 +34,6 @@ export class JsonDataType extends Base {
   }
 }
 
-class MySettings {
-  constructor(private readonly hash: Record<string, unknown>) {}
-  toHash(): Record<string, unknown> {
-    return this.hash;
-  }
-  static load(hash: unknown): MySettings {
-    return new MySettings(hash as Record<string, unknown>);
-  }
-  static dump(object: unknown): unknown {
-    return (object as MySettings).toHash();
-  }
-}
-
-class JsonDataTypeWithFilter extends Base {
-  static {
-    this.tableName = "json_data_type";
-    this.attribute("payload", "json");
-    this.filterAttributes = [...(Base.filterAttributes ?? []), "password"];
-  }
-}
-
 /**
  * A `JsonDataType` seen through its generated attribute readers (`payload`,
  * `resolution`), which are declared by the schema at runtime rather than by
@@ -62,25 +41,10 @@ class JsonDataTypeWithFilter extends Base {
  */
 type JsonRecord = InstanceType<typeof JsonDataType> & Record<string, unknown>;
 
-function klass(): typeof JsonDataType {
-  return JsonDataType;
-}
-
 export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
   const columnType = host.columnType;
 
-  const insertStatementPerDatabase =
-    host.insertStatementPerDatabase ??
-    ((values: string) => `insert into json_data_type (payload) VALUES ('${values}')`);
-
   let connection: AbstractAdapter;
-
-  async function assertTypeMatch(type: string, sqlType: string | undefined): Promise<void> {
-    const nativeType = (
-      (await Base.leaseConnection()).nativeDatabaseTypes()[type] as { name: string }
-    ).name;
-    expect(sqlType ?? "").toMatch(new RegExp(`^${nativeType}\\b`));
-  }
 
   beforeEach(async () => {
     connection = await Base.leaseConnection();
@@ -92,7 +56,6 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
   afterEach(async () => {
     await connection.dropTable("json_data_type", { ifExists: true });
     void klass().resetColumnInformation();
-    void JsonDataTypeWithFilter.resetColumnInformation();
   });
 
   it("test_column", async () => {
@@ -121,14 +84,15 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
   });
 
   it("test_cast_value_on_write", async () => {
-    // Ruby's `:symbol => :bar` Symbol key/value survives `payload_before_type_cast`
-    // and is stringified by the cast; JS object keys and string values are already
-    // strings, so both halves read the same here.
-    const x = klass().new({ payload: { string: "foo", symbol: "bar" } }) as JsonRecord;
-    expect((x.attributeBeforeTypeCast as (attrName: string) => unknown)("payload")).toEqual({
-      string: "foo",
-      symbol: "bar",
-    });
+    // Ruby's `{ "string" => "foo", :symbol => :bar }` keeps its Symbol key and
+    // value in `payload_before_type_cast` and is stringified only by the cast.
+    // JS has no Symbol-vs-String distinction to normalize, so the live half of
+    // the same assertion is identity: before-type-cast is the assigned object
+    // itself, while the reader returns the serialize/deserialize round trip.
+    const payload = { string: "foo", symbol: "bar" };
+    const x = klass().new({ payload }) as JsonRecord;
+    expect((x.attributeBeforeTypeCast as (attrName: string) => unknown)("payload")).toBe(payload);
+    expect(x.payload).not.toBe(payload);
     expect(x.payload).toEqual({ string: "foo", symbol: "bar" });
     await x.saveBang();
     expect((await x.reload()).payload).toEqual({ string: "foo", symbol: "bar" });
@@ -328,6 +292,19 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
     expect(() => new NewKlass()).toThrow(ColumnNotSerializableError);
   });
 
+  class MySettings {
+    constructor(private readonly hash: Record<string, unknown>) {}
+    toHash(): Record<string, unknown> {
+      return this.hash;
+    }
+    static load(hash: unknown): MySettings {
+      return new MySettings(hash as Record<string, unknown>);
+    }
+    static dump(object: unknown): unknown {
+      return (object as MySettings).toHash();
+    }
+  }
+
   it("test_json_with_serialized_attributes", async () => {
     // Rails: Class.new(klass) { serialize :settings, coder: MySettings }
     class NewKlass extends klass() {}
@@ -346,6 +323,14 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
     expect(((await record.reload()).settings as MySettings).toHash()).toEqual({ three: "four" });
   });
 
+  class JsonDataTypeWithFilter extends Base {
+    static {
+      this.tableName = "json_data_type";
+      this.attribute("payload", "json");
+      this.filterAttributes = [...(Base.filterAttributes ?? []), "password"];
+    }
+  }
+
   it("test_pretty_print", async () => {
     await JsonDataTypeWithFilter.loadSchema();
     const x = (await JsonDataTypeWithFilter.createBang({ payload: {} })) as JsonRecord;
@@ -354,4 +339,19 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
     await pp(x, { write: (s: string) => (string += s) });
     expect(string).toBeTruthy();
   });
+
+  function klass(): typeof JsonDataType {
+    return JsonDataType;
+  }
+
+  const insertStatementPerDatabase =
+    host.insertStatementPerDatabase ??
+    ((values: string) => `insert into json_data_type (payload) VALUES ('${values}')`);
+
+  async function assertTypeMatch(type: string, sqlType: string | undefined): Promise<void> {
+    const nativeType = (
+      (await Base.leaseConnection()).nativeDatabaseTypes()[type] as { name: string }
+    ).name;
+    expect(sqlType ?? "").toMatch(new RegExp(`^${nativeType}\\b`));
+  }
 }

--- a/packages/activerecord/src/cases/json-shared-test-cases.ts
+++ b/packages/activerecord/src/cases/json-shared-test-cases.ts
@@ -327,7 +327,14 @@ export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
     static {
       this.tableName = "json_data_type";
       this.attribute("payload", "json");
-      this.filterAttributes = [...(Base.filterAttributes ?? []), "password"];
+    }
+
+    static override get filterAttributes(): (
+      | string
+      | RegExp
+      | ((key: string, value: unknown) => unknown)
+    )[] {
+      return [...super.filterAttributes, "password"];
     }
   }
 

--- a/packages/activerecord/src/cases/json-shared-test-cases.ts
+++ b/packages/activerecord/src/cases/json-shared-test-cases.ts
@@ -1,0 +1,373 @@
+/**
+ * Mirrors Rails activerecord/test/cases/json_shared_test_cases.rb — the module
+ * the sqlite3, PostgreSQL and MySQL JSON suites all `include`.
+ *
+ * Ruby `include JSONSharedTestCases` mixes the cases into the including
+ * TestCase, which supplies `column_type` (and, in the PG/MySQL suites,
+ * `insert_statement_per_database`). TypeScript has no such mixin for vitest
+ * suites, so the module is a function called from inside the including
+ * `describe`, taking the same overridable members as its host argument.
+ */
+import { it, expect, beforeEach, afterEach } from "vitest";
+import { Temporal } from "@blazetrails/date";
+import { stringify as yamlStringify, parse as yamlParse } from "@blazetrails/activesupport/yaml";
+import { Base } from "../base.js";
+import { serialize } from "../serialize.js";
+import { ColumnNotSerializableError } from "../attribute-methods/serialization.js";
+import { SchemaDumper } from "../schema-dumper.js";
+import { pp } from "../pretty-print.js";
+import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+import type { Table } from "../connection-adapters/abstract/schema-definitions.js";
+
+/** The members an including suite supplies — Rails' overridable private methods. */
+export interface JSONSharedTestCasesHost {
+  /** Rails: `def column_type` — `:json` everywhere but PG's jsonb suite. */
+  columnType: string;
+  /** Rails: `def insert_statement_per_database(values)`. */
+  insertStatementPerDatabase?: (values: string) => string;
+}
+
+// Rails: class JsonDataType < ActiveRecord::Base
+//   self.table_name = "json_data_type"
+//   store_accessor :settings, :resolution
+export class JsonDataType extends Base {
+  static {
+    this.tableName = "json_data_type";
+    this.storeAccessor("settings", { accessors: ["resolution"] });
+  }
+}
+
+// Rails: class MySettings
+class MySettings {
+  constructor(private readonly hash: Record<string, unknown>) {}
+  toHash(): Record<string, unknown> {
+    return this.hash;
+  }
+  static load(hash: unknown): MySettings {
+    return new MySettings(hash as Record<string, unknown>);
+  }
+  static dump(object: unknown): unknown {
+    return (object as MySettings).toHash();
+  }
+}
+
+// Rails: class JsonDataTypeWithFilter < ActiveRecord::Base
+//   self.table_name = "json_data_type"
+//   attribute :payload, :json
+//   def self.filter_attributes; super + [:password]; end
+class JsonDataTypeWithFilter extends Base {
+  static {
+    this.tableName = "json_data_type";
+    this.attribute("payload", "json");
+    this.filterAttributes = [...(Base.filterAttributes ?? []), "password"];
+  }
+}
+
+/**
+ * A `JsonDataType` seen through its generated attribute readers (`payload`,
+ * `resolution`), which are declared by the schema at runtime rather than by
+ * the class body.
+ */
+type JsonRecord = InstanceType<typeof JsonDataType> & Record<string, unknown>;
+
+// Rails: private def klass; JsonDataType; end
+function klass(): typeof JsonDataType {
+  return JsonDataType;
+}
+
+export function jsonSharedTestCases(host: JSONSharedTestCasesHost): void {
+  const columnType = host.columnType;
+
+  // Rails: private def insert_statement_per_database(values)
+  const insertStatementPerDatabase =
+    host.insertStatementPerDatabase ??
+    ((values: string) => `insert into json_data_type (payload) VALUES ('${values}')`);
+
+  let connection: AbstractAdapter;
+
+  // Rails: private def assert_type_match(type, sql_type)
+  async function assertTypeMatch(type: string, sqlType: string | undefined): Promise<void> {
+    const nativeType = (
+      (await Base.leaseConnection()).nativeDatabaseTypes()[type] as { name: string }
+    ).name;
+    expect(sqlType ?? "").toMatch(new RegExp(`^${nativeType}\\b`));
+  }
+
+  // Rails: def setup; @connection = ActiveRecord::Base.lease_connection; end
+  beforeEach(async () => {
+    connection = await Base.leaseConnection();
+    // trails: Rails reflects the ad-hoc table's columns lazily on first
+    // attribute access; `loadSchema()` is async here, so it is awaited up front.
+    await klass().loadSchema();
+  });
+
+  // Rails: def teardown
+  //   @connection.drop_table :json_data_type, if_exists: true
+  //   klass.reset_column_information
+  // end
+  afterEach(async () => {
+    await connection.dropTable("json_data_type", { ifExists: true });
+    void klass().resetColumnInformation();
+    void JsonDataTypeWithFilter.resetColumnInformation();
+  });
+
+  it("test_column", async () => {
+    const column = klass().columnsHash()["payload"];
+    expect(column.type).toBe(columnType);
+    await assertTypeMatch(columnType, column.sqlType);
+
+    const type = klass().typeForAttribute("payload");
+    expect(type.isBinary()).toBe(false);
+  });
+
+  it("test_change_table_supports_json", async () => {
+    await connection.changeTable("json_data_type", async (t: Table) => {
+      await (t as unknown as Record<string, (name: string) => Promise<void>>)[columnType]("users");
+    });
+    await klass().resetColumnInformation();
+    await klass().loadSchema();
+    const column = klass().columnsHash()["users"];
+    expect(column.type).toBe(columnType);
+    await assertTypeMatch(columnType, column.sqlType);
+  });
+
+  it("test_schema_dumping", async () => {
+    const output = await SchemaDumper.dumpTableSchema(connection, "json_data_type");
+    expect(output).toMatch(new RegExp(`t\\.${columnType}\\(\\s*"settings"`));
+  });
+
+  it("test_cast_value_on_write", async () => {
+    // Ruby's `:symbol => :bar` Symbol key/value survives `payload_before_type_cast`
+    // and is stringified by the cast; JS object keys and string values are already
+    // strings, so both halves read the same here.
+    const x = klass().new({ payload: { string: "foo", symbol: "bar" } }) as JsonRecord;
+    expect((x.attributeBeforeTypeCast as (attrName: string) => unknown)("payload")).toEqual({
+      string: "foo",
+      symbol: "bar",
+    });
+    expect(x.payload).toEqual({ string: "foo", symbol: "bar" });
+    await x.saveBang();
+    expect((await x.reload()).payload).toEqual({ string: "foo", symbol: "bar" });
+  });
+
+  it("test_type_cast_json", () => {
+    const type = klass().typeForAttribute("payload");
+
+    const data = '{"a_key":"a_value"}';
+    const hash = type.deserialize(data);
+    expect(hash).toEqual({ a_key: "a_value" });
+    expect(type.deserialize(data)).toEqual({ a_key: "a_value" });
+
+    expect(type.deserialize("{}")).toEqual({});
+    expect(type.deserialize('{"key": null}')).toEqual({ key: null });
+    expect(type.deserialize('{"c":"}", "\\"a\\"":"b \\"a b"}')).toEqual({
+      c: "}",
+      '"a"': 'b "a b',
+    });
+  });
+
+  it("test_rewrite", async () => {
+    await connection.execute(insertStatementPerDatabase('{"k":"v"}'));
+    const x = (await klass().first()) as JsonRecord;
+    x.payload = { "\"a'": "b" };
+    expect(await x.saveBang()).toBeTruthy();
+  });
+
+  it("test_select", async () => {
+    await connection.execute(insertStatementPerDatabase('{"k":"v"}'));
+    const x = (await klass().first()) as JsonRecord;
+    expect(x.payload).toEqual({ k: "v" });
+  });
+
+  it("test_select_multikey", async () => {
+    await connection.execute(insertStatementPerDatabase('{"k1":"v1", "k2":"v2", "k3":[1,2,3]}'));
+    const x = (await klass().first()) as JsonRecord;
+    expect(x.payload).toEqual({ k1: "v1", k2: "v2", k3: [1, 2, 3] });
+  });
+
+  it("test_null_json", async () => {
+    await connection.execute(insertStatementPerDatabase("null"));
+    const x = (await klass().first()) as JsonRecord;
+    expect(x.payload).toBeNull();
+  });
+
+  it("test_select_nil_json_after_create", async () => {
+    const json = (await klass().createBang({ payload: null })) as JsonRecord;
+    const x = await klass().where({ payload: null }).first();
+    expect(json.equals(x)).toBe(true);
+  });
+
+  it("test_select_nil_json_after_update", async () => {
+    const json = (await klass().createBang({ payload: "foo" })) as JsonRecord;
+    let x = await klass().where({ payload: null }).first();
+    expect(x).toBeNull();
+
+    await json.update({ payload: null });
+    x = await klass().where({ payload: null }).first();
+    expect((await json.reload()).equals(x)).toBe(true);
+  });
+
+  it("test_select_array_json_value", async () => {
+    await connection.execute(insertStatementPerDatabase('["v0",{"k1":"v1"}]'));
+    const x = (await klass().first()) as JsonRecord;
+    expect(x.payload).toEqual(["v0", { k1: "v1" }]);
+  });
+
+  it("test_rewrite_array_json_value", async () => {
+    await connection.execute(insertStatementPerDatabase('["v0",{"k1":"v1"}]'));
+    const x = (await klass().first()) as JsonRecord;
+    x.payload = ["v1", { k2: "v2" }, "v3"];
+    expect(await x.saveBang()).toBeTruthy();
+  });
+
+  it("test_with_store_accessors", async () => {
+    let x = klass().new({ resolution: "320×480" }) as JsonRecord;
+    expect(x.resolution).toBe("320×480");
+
+    await x.saveBang();
+    x = (await klass().first()) as JsonRecord;
+    expect(x.resolution).toBe("320×480");
+
+    x.resolution = "640×1136";
+    await x.saveBang();
+
+    x = (await klass().first()) as JsonRecord;
+    expect(x.resolution).toBe("640×1136");
+  });
+
+  it("test_duplication_with_store_accessors", () => {
+    const x = klass().new({ resolution: "320×480" }) as JsonRecord;
+    expect(x.resolution).toBe("320×480");
+
+    const y = x.dup();
+    expect(y.resolution).toBe("320×480");
+  });
+
+  it("test_yaml_round_trip_with_store_accessors", () => {
+    const x = klass().new({ resolution: "320×480" }) as JsonRecord;
+    expect(x.resolution).toBe("320×480");
+
+    // Rails: YAML.dump(x) / YAML.unsafe_load(payload) round-trips the record
+    // through AR's encode_with / init_with hooks. trails has no object-graph
+    // YAML for a record, so the round trip runs one level down, over the
+    // attribute hash the store accessor state lives in.
+    const payload = yamlStringify(x.serializableHash());
+    const y = klass().new(yamlParse(payload) as Record<string, unknown>) as JsonRecord;
+    expect(y.resolution).toBe("320×480");
+  });
+
+  it("test_changes_in_place", async () => {
+    const json = klass().new() as JsonRecord;
+    expect(json.isChanged).toBe(false);
+
+    json.payload = { one: "two" };
+    expect(json.isChanged).toBe(true);
+    expect((json.payloadChanged as () => boolean)()).toBe(true);
+
+    await json.saveBang();
+    expect(json.isChanged).toBe(false);
+
+    (json.payload as Record<string, string>)["three"] = "four";
+    expect((json.payloadChanged as () => boolean)()).toBe(true);
+
+    await json.saveBang();
+    await json.reload();
+
+    expect(json.payload).toEqual({ one: "two", three: "four" });
+    expect(json.isChanged).toBe(false);
+  });
+
+  // SKIP: reassigning an equal-but-reordered hash reads as changed. Rails'
+  // `Type::Value#changed?` is `old_value != new_value` (activemodel/lib/
+  // active_model/type/value.rb:114-116), which for a Hash is Ruby's
+  // order-insensitive `Hash#==`; trails' port compares with `!==`
+  // (activemodel/src/type/value.ts:77), so two structurally equal hashes are
+  // "changed". Converging that base predicate is a change to every value type,
+  // tracked as its own story — not something to paper over with a `Json`-only
+  // `changed?` override Rails does not have.
+  it.skip("test_changes_in_place_ignores_key_order", async () => {
+    const json = klass().new() as JsonRecord;
+    expect(json.isChanged).toBe(false);
+
+    json.payload = { three: "four", one: "two" };
+    await json.saveBang();
+    await json.reload();
+
+    json.payload = { three: "four", one: "two" };
+    expect(json.isChanged).toBe(false);
+
+    json.payload = [
+      { three: "four", one: "two" },
+      { seven: "eight", five: "six" },
+    ];
+    await json.saveBang();
+    await json.reload();
+
+    json.payload = [
+      { three: "four", one: "two" },
+      { seven: "eight", five: "six" },
+    ];
+    expect(json.isChanged).toBe(false);
+  });
+
+  it("test_changes_in_place_with_ruby_object", async () => {
+    const time = Temporal.Now.instant();
+    const json = (await klass().createBang({ payload: time })) as JsonRecord;
+
+    await json.reload();
+    expect(json.isChanged).toBe(false);
+
+    json.payload = time;
+    expect(json.isChanged).toBe(false);
+  });
+
+  it("test_assigning_string_literal", async () => {
+    const json = (await klass().createBang({ payload: "foo" })) as JsonRecord;
+    expect(json.payload).toBe("foo");
+  });
+
+  it("test_assigning_number", async () => {
+    const json = (await klass().createBang({ payload: 1.234 })) as JsonRecord;
+    expect(json.payload).toBe(1.234);
+  });
+
+  it("test_assigning_boolean", async () => {
+    const json = (await klass().createBang({ payload: true })) as JsonRecord;
+    expect(json.payload).toBe(true);
+  });
+
+  it("test_not_compatible_with_serialize_json", async () => {
+    // Rails: Class.new(klass) { serialize :payload, coder: JSON }
+    class NewKlass extends klass() {}
+    // Rails: `coder: JSON` — trails names the same built-in coder `"json"`.
+    serialize(NewKlass, "payload", { coder: "json" });
+    expect(() => new NewKlass()).toThrow(ColumnNotSerializableError);
+  });
+
+  it("test_json_with_serialized_attributes", async () => {
+    // Rails: Class.new(klass) { serialize :settings, coder: MySettings }
+    class NewKlass extends klass() {}
+    serialize(NewKlass, "settings", { coder: MySettings });
+    await NewKlass.loadSchema();
+
+    await NewKlass.createBang({ settings: new MySettings({ one: "two" }) });
+    const record = (await NewKlass.first()) as JsonRecord;
+
+    expect(record.settings).toBeInstanceOf(MySettings);
+    expect((record.settings as MySettings).toHash()).toEqual({ one: "two" });
+
+    record.settings = new MySettings({ three: "four" });
+    await record.saveBang();
+
+    expect(((await record.reload()).settings as MySettings).toHash()).toEqual({ three: "four" });
+  });
+
+  it("test_pretty_print", async () => {
+    await JsonDataTypeWithFilter.loadSchema();
+    const x = (await JsonDataTypeWithFilter.createBang({ payload: {} })) as JsonRecord;
+    (x.payload as Record<number, string>)[11] = "foo";
+    let string = "";
+    await pp(x, { write: (s: string) => (string += s) });
+    expect(string).toBeTruthy();
+  });
+}

--- a/packages/activerecord/src/type/json.ts
+++ b/packages/activerecord/src/type/json.ts
@@ -5,6 +5,31 @@ import { ValueType } from "@blazetrails/activemodel";
 import { ActiveSupportJSON } from "@blazetrails/activesupport";
 import { StringKeyedHashAccessor } from "../store.js";
 
+/**
+ * Ruby `Hash#==` / `Array#==` over decoded JSON, which JS has no operator for:
+ * two hashes with the same pairs are equal whatever order the keys were
+ * written in. Re-encoding both sides and comparing strings is NOT the same
+ * test — it reports a key reordering as a change.
+ */
+function jsonEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (globalThis.Array.isArray(a) || globalThis.Array.isArray(b)) {
+    if (!globalThis.Array.isArray(a) || !globalThis.Array.isArray(b)) return false;
+    return a.length === b.length && a.every((el, i) => jsonEqual(el, b[i]));
+  }
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  return (
+    aKeys.length === bKeys.length &&
+    aKeys.every(
+      (k) =>
+        Object.prototype.hasOwnProperty.call(b, k) &&
+        jsonEqual((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k]),
+    )
+  );
+}
+
 export class Json extends ValueType<unknown> {
   // Widened to string (not literal) so Jsonb can override to "jsonb".
   readonly name: string = "json";
@@ -51,6 +76,6 @@ export class Json extends ValueType<unknown> {
   }
 
   override isChangedInPlace(rawOldValue: unknown, newValue: unknown): boolean {
-    return this.serialize(this.deserialize(rawOldValue)) !== this.serialize(newValue);
+    return !jsonEqual(this.deserialize(rawOldValue), newValue);
   }
 }


### PR DESCRIPTION
Ports `vendor/rails/activerecord/test/cases/json_shared_test_cases.rb` — the
25-case module Rails' sqlite3, PostgreSQL and MySQL JSON suites all
`include` — as `packages/activerecord/src/cases/json-shared-test-cases.ts`,
and rewires `adapters/sqlite3/json.test.ts` (which had hand-copied 2 of the
25) to draw from it, mirroring `adapters/sqlite3/json_test.rb`.

Ruby's `include JSONSharedTestCases` has no vitest equivalent, so the module
is a function called from inside the including `describe`, taking the same
members the including TestCase overrides (`column_type`, and PG/MySQL's
`insert_statement_per_database`) as its host argument. The module's Ruby
`setup`/`teardown`, its `JsonDataType` / `MySettings` /
`JsonDataTypeWithFilter` classes and its private `klass` /
`assert_type_match` / `insert_statement_per_database` are ported one to one.
`json_data_type` stays the ad-hoc table Rails' `setup` creates.

**24 of 25 cases pass.** `test_changes_in_place_ignores_key_order` is ported
and `it.skip`ped with the reason at the call site: reassigning an
equal-but-reordered hash reads as changed because trails' `Type::Value#changed?`
compares with `!==` (`packages/activemodel/src/type/value.ts:77`) where Rails
is `old_value != new_value` (`activemodel/lib/active_model/type/value.rb:114`)
— Ruby's order-insensitive `Hash#==`. Converging that base predicate touches
every value type, so it is filed as
`converge-value-type-changed-to-ruby-equality` (RFC 0023) rather than papered
over with a `Json`-only `changed?` override Rails does not have.

Also converges the sibling half, `ActiveRecord::Type::Json#changed_in_place?`,
onto its Rails body (`activerecord/lib/active_record/type/json.rb`:
`deserialize(raw_old_value) != new_value`); the port re-encoded both sides and
compared strings, which reports a key reordering as a change.

PG/MySQL adoption is out of scope here (the PG suite is currently a bespoke
non-Rails file, and there is no MySQL JSON suite) and is filed as
`adopt-json-shared-test-cases-pg-mysql` under the same RFC.

Gates: `parity:api:calls` OK, `parity:api:calls:args` OK,
`parity:api:extra --package activerecord` shows no rows for the new file,
`parity:test` unchanged, typecheck + lint clean.

Closes-story: port-json-shared-test-cases
