### PR TITLE
refactor(activerecord): retire model._associations for the reflection registry (RFC 0112)

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, afterEach, beforeAll, beforeEach, vi } from "vite
 import { Base, association, reflectOnAssociation, registerModel, NameError, pp } from "./index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { captureSql } from "./testing/sql-capture.js";
+import { clearReflectionsCache } from "./reflection.js";
 import { fixtures } from "./test-fixtures.js";
 import { Author, type Author as AuthorT } from "./test-helpers/models/author.js";
 import { CpkOrder, CpkBook } from "./test-helpers/models/cpk.js";
@@ -2288,7 +2289,7 @@ describe("AssociationsTest", () => {
     // than silently exempting composite-PK owners.
     const originalList = (ShardedBlogPost as any)._queryConstraintsList;
     const originalPk = (ShardedBlogPost as any)._primaryKey;
-    const originalAssociations = [...((ShardedBlogPost as any)._associations ?? [])];
+    const originalReflections = { ...((ShardedBlogPost as any)._reflections ?? {}) };
     try {
       (ShardedBlogPost as any)._primaryKey = ["blog_id", "id"];
       (ShardedBlogPost as any)._queryConstraintsList = ["blog_id", "id"];
@@ -2309,7 +2310,8 @@ describe("AssociationsTest", () => {
     } finally {
       (ShardedBlogPost as any)._queryConstraintsList = originalList;
       (ShardedBlogPost as any)._primaryKey = originalPk;
-      (ShardedBlogPost as any)._associations = originalAssociations;
+      (ShardedBlogPost as any)._reflections = originalReflections;
+      clearReflectionsCache(ShardedBlogPost as any);
     }
   });
 

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -494,9 +494,9 @@ export function validateInverseOf(
   assocName: string,
   inverseOf: string,
 ): void {
-  const targetAssocs: AssociationDefinition[] = targetModel._associations ?? [];
-  if (targetAssocs.length === 0) return;
-  if (targetAssocs.some((a) => a.name === inverseOf)) return;
+  const targetReflections = Reflection.reflections(targetModel);
+  if (Object.keys(targetReflections).length === 0) return;
+  if (targetModel._reflectOnAssociation(inverseOf) != null) return;
 
   throw new InverseOfAssociationNotFoundError(owner._reflectOnAssociation(assocName), targetModel);
 }
@@ -656,8 +656,7 @@ export function _hmtNotFound(
   assocName: string,
   through: string,
 ): HasManyThroughAssociationNotFoundError {
-  const assocs: AssociationDefinition[] = ctor._associations ?? [];
-  const dictionary = assocs.map((a) => a.name).filter((n) => n !== assocName);
+  const dictionary = Object.keys(Reflection.reflections(ctor)).filter((n) => n !== assocName);
   const corrections = _correctNames(dictionary, through);
   return new HasManyThroughAssociationNotFoundError(ctor.name, through, assocName, corrections);
 }
@@ -670,8 +669,7 @@ export function _hmtNotFound(
  * the failing name against `record.class.reflections.keys`.
  */
 export function _associationNotFound(record: Base, name: string): AssociationNotFoundError {
-  const assocs: AssociationDefinition[] = (record.constructor as typeof Base)._associations ?? [];
-  const dictionary = assocs.map((a) => a.name);
+  const dictionary = Object.keys(Reflection.reflections(record.constructor as typeof Base));
   const corrections = _correctNames(dictionary, name);
   return new AssociationNotFoundError(record, name, corrections);
 }
@@ -1410,11 +1408,7 @@ export function association<T extends Base = Base>(
   }
 
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = ctor._associations ?? [];
-  const assocDef = associations
-    .slice()
-    .reverse()
-    .find((a) => a.name === assocName);
+  const assocDef = ctor._reflectOnAssociation(assocName) as unknown as AssociationDefinition | null;
   if (!assocDef) {
     throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
   }

--- a/packages/activerecord/src/associations/builder/association.ts
+++ b/packages/activerecord/src/associations/builder/association.ts
@@ -134,22 +134,7 @@ export class Association {
     scope = this.buildScope(scope);
 
     const macro = this.macro();
-    const reflection = Reflection.create(macro as any, name, scope, options, model);
-
-    model._associations = [
-      ...model._associations,
-      {
-        type: macro,
-        name,
-        scope,
-        options: { ...options },
-        get foreignType(): string | null {
-          return (reflection as { foreignType?: string | null }).foreignType ?? null;
-        },
-      },
-    ];
-
-    return reflection;
+    return Reflection.create(macro as any, name, scope, options, model);
   }
 
   static buildScope(scope: ((...args: any[]) => any) | null): ((...args: any[]) => any) | null {

--- a/packages/activerecord/src/associations/builder/collection-association.ts
+++ b/packages/activerecord/src/associations/builder/collection-association.ts
@@ -100,10 +100,9 @@ export class CollectionAssociation extends Association {
     const prior = Array.isArray(existing) ? existing : [];
     model[fullCallbackName] = [...prior, ...normalized];
 
-    const assocs: any[] = model._associations ?? [];
-    const assocDef = assocs.find((a: any) => a.name === name);
-    if (assocDef) {
-      assocDef.options[callbackName] = model[fullCallbackName];
+    const reflection = model._reflectOnAssociation?.(name);
+    if (reflection) {
+      reflection.options[callbackName] = model[fullCallbackName];
     }
   }
 

--- a/packages/activerecord/src/associations/collection-proxy-count.trails.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-count.trails.test.ts
@@ -63,9 +63,9 @@ describe("CollectionProxy#count — non-through fast path", () => {
     registerModel("CpcAuthor", CpcAuthor);
     registerModel("CpcPost", CpcPost);
     registerModel("CpcComment", CpcComment);
-    (CpcAuthor as any)._associations = [];
-    (CpcPost as any)._associations = [];
-    (CpcComment as any)._associations = [];
+    (CpcAuthor as any)._reflections = {};
+    (CpcPost as any)._reflections = {};
+    (CpcComment as any)._reflections = {};
     Associations.hasMany.call(CpcAuthor, "cpcPosts", {
       className: "CpcPost",
       foreignKey: "author_id",

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -261,9 +261,9 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Mirrors Rails' `Association#reflection` (association.rb:16), which is the
    * rich `AssociationReflection` the constructor was handed off the owner's
    * class (`associations.rb:290-296`). Every macro declaration registers one
-   * (`associations.ts:704,723,742,813`, beside the `_associations` push the
-   * proxy is built from), so there is no reflection-less association to fall
-   * back for.
+   * (`associations.ts`'s `belongsTo`/`hasOne`/`hasMany`/HABTM macros each end
+   * in `Reflection.addReflection`), so there is no reflection-less association
+   * to fall back for.
    * @internal
    */
   get reflection(): AssociationDefinition {

--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.trails.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.trails.test.ts
@@ -67,11 +67,11 @@ describe("CollectionProxy#count — disable_joins through", () => {
     registerModel("CdAuthor", CdAuthor);
     registerModel("CdPost", CdPost);
     registerModel("CdComment", CdComment);
-    (CdAuthor as any)._associations = [];
     (CdAuthor as any)._reflections = {};
-    (CdPost as any)._associations = [];
+    (CdAuthor as any)._reflections = {};
     (CdPost as any)._reflections = {};
-    (CdComment as any)._associations = [];
+    (CdPost as any)._reflections = {};
+    (CdComment as any)._reflections = {};
     (CdComment as any)._reflections = {};
 
     Associations.hasMany.call(CdAuthor, "cdPosts", {
@@ -133,7 +133,7 @@ describe("CollectionProxy#count — disable_joins through", () => {
       }
     }
     registerModel("CdRating", CdRating);
-    (CdRating as any)._associations = [];
+    (CdRating as any)._reflections = {};
     (CdRating as any)._reflections = {};
 
     Associations.hasMany.call(CdComment, "cdRatings", {

--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.trails.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.trails.test.ts
@@ -68,10 +68,7 @@ describe("CollectionProxy#count — disable_joins through", () => {
     registerModel("CdPost", CdPost);
     registerModel("CdComment", CdComment);
     (CdAuthor as any)._reflections = {};
-    (CdAuthor as any)._reflections = {};
     (CdPost as any)._reflections = {};
-    (CdPost as any)._reflections = {};
-    (CdComment as any)._reflections = {};
     (CdComment as any)._reflections = {};
 
     Associations.hasMany.call(CdAuthor, "cdPosts", {
@@ -133,7 +130,6 @@ describe("CollectionProxy#count — disable_joins through", () => {
       }
     }
     registerModel("CdRating", CdRating);
-    (CdRating as any)._reflections = {};
     (CdRating as any)._reflections = {};
 
     Associations.hasMany.call(CdComment, "cdRatings", {

--- a/packages/activerecord/src/associations/disable-joins-association-scope.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.trails.test.ts
@@ -46,9 +46,9 @@ describe("DisableJoinsAssociationScope", () => {
     registerModel("DjsAuthor", DjsAuthor);
     registerModel("DjsPost", DjsPost);
     registerModel("DjsComment", DjsComment);
-    (DjsAuthor as any)._associations = [];
-    (DjsPost as any)._associations = [];
-    (DjsComment as any)._associations = [];
+    (DjsAuthor as any)._reflections = {};
+    (DjsPost as any)._reflections = {};
+    (DjsComment as any)._reflections = {};
     Associations.hasMany.call(DjsAuthor, "djsPosts", {
       className: "DjsPost",
       foreignKey: "djs_author_id",

--- a/packages/activerecord/src/associations/disable-joins-composite-key.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.trails.test.ts
@@ -70,9 +70,9 @@ describe("DJAS — composite key support", () => {
     registerModel("CkShop", CkShop);
     registerModel("CkOrder", CkOrder);
     registerModel("CkLineItem", CkLineItem);
-    (CkShop as any)._associations = [];
-    (CkOrder as any)._associations = [];
-    (CkLineItem as any)._associations = [];
+    (CkShop as any)._reflections = {};
+    (CkOrder as any)._reflections = {};
+    (CkLineItem as any)._reflections = {};
     Associations.hasMany.call(CkShop, "ckOrders", {
       className: "CkOrder",
       foreignKey: "shop_id",

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.trails.test.ts
@@ -95,10 +95,7 @@ describe("DJAS composite-key + nested-through", () => {
     registerModel("CknLineItem", CknLineItem);
     registerModel("CknTag", CknTag);
     (CknShop as any)._reflections = {};
-    (CknShop as any)._reflections = {};
     (CknOrder as any)._reflections = {};
-    (CknOrder as any)._reflections = {};
-    (CknLineItem as any)._reflections = {};
     (CknLineItem as any)._reflections = {};
 
     Associations.hasMany.call(CknShop, "cknOrders", {

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.trails.test.ts
@@ -94,11 +94,11 @@ describe("DJAS composite-key + nested-through", () => {
     registerModel("CknOrder", CknOrder);
     registerModel("CknLineItem", CknLineItem);
     registerModel("CknTag", CknTag);
-    (CknShop as any)._associations = [];
     (CknShop as any)._reflections = {};
-    (CknOrder as any)._associations = [];
+    (CknShop as any)._reflections = {};
     (CknOrder as any)._reflections = {};
-    (CknLineItem as any)._associations = [];
+    (CknOrder as any)._reflections = {};
+    (CknLineItem as any)._reflections = {};
     (CknLineItem as any)._reflections = {};
 
     Associations.hasMany.call(CknShop, "cknOrders", {

--- a/packages/activerecord/src/associations/disable-joins-nested-through.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-nested-through.trails.test.ts
@@ -76,9 +76,9 @@ describe("DJAS routing widening — nested-through", () => {
     registerModel("NtPost", NtPost);
     registerModel("NtComment", NtComment);
     registerModel("NtRating", NtRating);
-    (NtAuthor as any)._associations = [];
-    (NtPost as any)._associations = [];
-    (NtComment as any)._associations = [];
+    (NtAuthor as any)._reflections = {};
+    (NtPost as any)._reflections = {};
+    (NtComment as any)._reflections = {};
 
     Associations.hasMany.call(NtAuthor, "ntPosts", {
       className: "NtPost",

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.trails.test.ts
@@ -93,9 +93,9 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
     registerModel("DpGallery", DpGallery);
     registerModel("DpNonIdPhoto", DpNonIdPhoto);
     registerModel("DpNonIdArticle", DpNonIdArticle);
-    (DpAuthor as any)._associations = [];
     (DpAuthor as any)._reflections = {};
-    (DpGallery as any)._associations = [];
+    (DpAuthor as any)._reflections = {};
+    (DpGallery as any)._reflections = {};
     (DpGallery as any)._reflections = {};
 
     Associations.hasMany.call(DpAuthor, "dpGalleries", {

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.trails.test.ts
@@ -94,8 +94,6 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
     registerModel("DpNonIdPhoto", DpNonIdPhoto);
     registerModel("DpNonIdArticle", DpNonIdArticle);
     (DpAuthor as any)._reflections = {};
-    (DpAuthor as any)._reflections = {};
-    (DpGallery as any)._reflections = {};
     (DpGallery as any)._reflections = {};
 
     Associations.hasMany.call(DpAuthor, "dpGalleries", {

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.trails.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.trails.test.ts
@@ -74,8 +74,8 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     registerModel("RwComment", RwComment);
     registerModel("RwMember", RwMember);
     registerModel("RwOtherOrigin", RwOtherOrigin);
-    (RwAuthor as any)._associations = [];
-    (RwComment as any)._associations = [];
+    (RwAuthor as any)._reflections = {};
+    (RwComment as any)._reflections = {};
 
     Associations.hasMany.call(RwAuthor, "rwComments", {
       className: "RwComment",

--- a/packages/activerecord/src/associations/errors.trails.test.ts
+++ b/packages/activerecord/src/associations/errors.trails.test.ts
@@ -33,7 +33,9 @@ describe("AssociationErrors", () => {
     // Mirrors Rails AssociationNotFoundError#corrections, which feeds
     // `record.class.reflections.keys` into DidYouMean::SpellChecker.
     const record = {
-      constructor: { _associations: [{ name: "tagging" }, { name: "comments" }] },
+      constructor: {
+        _reflections: { tagging: { name: "tagging" }, comments: { name: "comments" } },
+      },
     } as any;
     const err = _associationNotFound(record, "taggingz");
     expect(err).toBeInstanceOf(AssociationNotFoundError);

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1503,7 +1503,7 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     Associations.hasMany.call(Author, "posts", { className: "Post", foreignKey: "author_id" });
-    const assoc = (Author as any)._associations.find((a: any) => a.name === "posts");
+    const assoc = (Author as any)._reflectOnAssociation("posts");
     expect(assoc).toBeDefined();
   });
 
@@ -1914,7 +1914,11 @@ describe("HasManyAssociationsTest", () => {
     registerModel(DepFirm);
 
     const firm = new DepFirm({ name: "Test" });
-    const proxy = new CollectionProxy(firm, "stiCompanies", (DepFirm as any)._associations[0]);
+    const proxy = new CollectionProxy(
+      firm,
+      "stiCompanies",
+      (DepFirm as any)._reflectOnAssociation("stiCompanies"),
+    );
     const company = proxy.build();
     expect(company).toBeInstanceOf(StiCompany);
   });
@@ -1952,7 +1956,11 @@ describe("HasManyAssociationsTest", () => {
     registerModel(DepFirm2);
 
     const firm = new DepFirm2({ name: "Test" });
-    const proxy = new CollectionProxy(firm, "stiCompany2s", (DepFirm2 as any)._associations[0]);
+    const proxy = new CollectionProxy(
+      firm,
+      "stiCompany2s",
+      (DepFirm2 as any)._reflectOnAssociation("stiCompany2s"),
+    );
     const company = proxy.build({ type: "StiCompany2" });
     expect(company).toBeInstanceOf(StiCompany2);
   });
@@ -1990,7 +1998,11 @@ describe("HasManyAssociationsTest", () => {
     registerModel(DepFirm3);
 
     const firm = new DepFirm3({ name: "Test" });
-    const proxy = new CollectionProxy(firm, "stiCompany3s", (DepFirm3 as any)._associations[0]);
+    const proxy = new CollectionProxy(
+      firm,
+      "stiCompany3s",
+      (DepFirm3 as any)._reflectOnAssociation("stiCompany3s"),
+    );
     const company = proxy.build({ type: "StiClient3" });
     expect(company).toBeInstanceOf(StiClient3);
   });
@@ -2025,7 +2037,11 @@ describe("HasManyAssociationsTest", () => {
     registerModel(DepFirm4);
 
     const firm = new DepFirm4({ name: "Test" });
-    const proxy = new CollectionProxy(firm, "stiCompany4s", (DepFirm4 as any)._associations[0]);
+    const proxy = new CollectionProxy(
+      firm,
+      "stiCompany4s",
+      (DepFirm4 as any)._reflectOnAssociation("stiCompany4s"),
+    );
     expect(() => proxy.build({ type: "Invalid" })).toThrow(SubclassNotFound);
   });
 
@@ -2067,7 +2083,11 @@ describe("HasManyAssociationsTest", () => {
     registerModel(DepFirm5);
 
     const firm = new DepFirm5({ name: "Test" });
-    const proxy = new CollectionProxy(firm, "stiCompany5s", (DepFirm5 as any)._associations[0]);
+    const proxy = new CollectionProxy(
+      firm,
+      "stiCompany5s",
+      (DepFirm5 as any)._reflectOnAssociation("stiCompany5s"),
+    );
     expect(() => proxy.build({ type: "UnrelatedModel" })).toThrow(SubclassNotFound);
   });
   it("build the association with an array", async () => {
@@ -6900,7 +6920,7 @@ describe("HasManyAssociationsTest", () => {
 
   it("has many without counter cache option", async () => {
     const ship = (await HmShip.create({ name: "Countless", treasures_count: 10 })) as any;
-    const assoc = (HmShip as any)._associations.find((a: any) => a.name === "treasures");
+    const assoc = (HmShip as any)._reflectOnAssociation("treasures");
     expect(assoc).toBeDefined();
     expect(assoc.options.counterCache).toBeUndefined();
     // Count comes from SQL, not the cached attribute

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -99,9 +99,9 @@ export class HasManyThroughAssociation extends HasManyAssociation {
    * (has_many_through_association.rb:121).
    */
   protected targetReflectionHasAssociatedRecord(): boolean {
-    const associations: AssociationDefinition[] =
-      (this.owner.constructor as typeof Base)._associations ?? [];
-    const throughAssoc = associations.find((a) => a.name === this.reflection.options.through);
+    const throughAssoc = (this.owner.constructor as typeof Base)._reflectOnAssociation(
+      this.reflection.options.through!,
+    ) as unknown as AssociationDefinition | null;
     // A missing through reflection is Rails' `check_validity!` failure, not
     // this predicate's: leave it to the loader below, which raises
     // HasManyThroughAssociationNotFoundError with the Rails message.
@@ -864,7 +864,7 @@ function targetReflectionHasAssociatedRecord(
   record: Base,
   throughAssoc: AssociationDefinition,
 ): boolean {
-  if (throughAssoc.type !== "belongsTo") return true;
+  if (throughAssoc.macro !== "belongsTo") return true;
   const fk = throughAssoc.options.foreignKey ?? `${underscore(throughAssoc.name)}_id`;
   const columns = Array.isArray(fk) ? fk : [fk];
   return !columns.every((column) => isBlank(record._readAttribute(String(column))));
@@ -902,8 +902,9 @@ async function loadHasManyThrough(
 ): Promise<Base[]> {
   const options = assocDef.options;
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = ctor._associations ?? [];
-  const throughAssoc = associations.find((a) => a.name === options.through);
+  const throughAssoc = ctor._reflectOnAssociation(
+    options.through!,
+  ) as unknown as AssociationDefinition | null;
   if (!throughAssoc) {
     throw _hmtNotFound(ctor, assocName, options.through!);
   }
@@ -917,14 +918,13 @@ async function loadHasManyThrough(
   const throughClassName =
     throughAssoc.options.className ?? camelize(singularize(throughAssoc.name));
   const throughModel = resolveAssocClass(record, throughAssoc.name, throughClassName);
-  const throughModelAssocs: AssociationDefinition[] = throughModel._associations ?? [];
   const sourceAssoc =
-    throughModelAssocs.find((a) => a.name === sourceName) ??
-    throughModelAssocs.find((a) => a.name === pluralize(sourceName));
-  const sourceAssocKind = sourceAssoc?.type ?? "belongsTo";
+    throughModel._reflectOnAssociation(sourceName) ??
+    throughModel._reflectOnAssociation(pluralize(sourceName));
+  const sourceAssocKind = sourceAssoc?.macro ?? "belongsTo";
 
   let throughRecords: Base[];
-  if (throughAssoc.type === "hasMany") {
+  if (throughAssoc.macro === "hasMany") {
     if (
       options.sourceType &&
       sourceAssoc?.options?.polymorphic &&
@@ -949,10 +949,10 @@ async function loadHasManyThrough(
     } else {
       throughRecords = await findHasManyTarget(record, throughAssoc.name, throughAssoc);
     }
-  } else if (throughAssoc.type === "hasOne") {
+  } else if (throughAssoc.macro === "hasOne") {
     const one = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
     throughRecords = one ? [one] : [];
-  } else if (throughAssoc.type === "belongsTo") {
+  } else if (throughAssoc.macro === "belongsTo") {
     const one = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
     throughRecords = one ? [one] : [];
   } else {
@@ -989,7 +989,7 @@ async function loadHasManyThrough(
     );
     return rel.toArray();
   } else {
-    const sourceAsName = sourceAssoc?.options?.as;
+    const sourceAsName = sourceAssoc?.options?.as as string | undefined;
     const sourceFk = sourceAsName
       ? (sourceAssoc?.options?.foreignKey ?? `${underscore(sourceAsName)}_id`)
       : (sourceAssoc?.options?.foreignKey ?? `${underscore(throughClassName)}_id`);

--- a/packages/activerecord/src/associations/has-one-through-association.ts
+++ b/packages/activerecord/src/associations/has-one-through-association.ts
@@ -542,18 +542,19 @@ async function loadHasOneThrough(
   options: AssociationOptions,
 ): Promise<Base | null> {
   const ctor = record.constructor as typeof Base;
-  const associations: AssociationDefinition[] = ctor._associations ?? [];
-  const throughAssoc = associations.find((a) => a.name === options.through);
+  const throughAssoc = ctor._reflectOnAssociation(
+    options.through!,
+  ) as unknown as AssociationDefinition | null;
   if (!throughAssoc) {
     throw _hmtNotFound(ctor, assocName, options.through!);
   }
 
   let throughRecord: Base | null;
-  if (throughAssoc.type === "hasOne") {
+  if (throughAssoc.macro === "hasOne") {
     throughRecord = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
-  } else if (throughAssoc.type === "belongsTo") {
+  } else if (throughAssoc.macro === "belongsTo") {
     throughRecord = (await association.call(record, throughAssoc.name).loadTarget()) as Base | null;
-  } else if (throughAssoc.type === "hasMany") {
+  } else if (throughAssoc.macro === "hasMany") {
     const throughHolder = _buildAssociationInstance.call(record, {
       name: throughAssoc.name,
       type: "hasMany",
@@ -569,13 +570,12 @@ async function loadHasOneThrough(
 
   const sourceName = options.source ?? assocName;
   const throughCtor = throughRecord.constructor as typeof Base;
-  const throughAssociations: AssociationDefinition[] = throughCtor._associations ?? [];
-  const sourceAssoc = throughAssociations.find((a) => a.name === sourceName);
+  const sourceAssoc = throughCtor._reflectOnAssociation(sourceName);
 
   if (sourceAssoc) {
-    if (sourceAssoc.type === "belongsTo") {
+    if (sourceAssoc.macro === "belongsTo") {
       return (await association.call(throughRecord, sourceName).loadTarget()) as Base | null;
-    } else if (sourceAssoc.type === "hasOne") {
+    } else if (sourceAssoc.macro === "hasOne") {
       return (await association.call(throughRecord, sourceName).loadTarget()) as Base | null;
     }
   }

--- a/packages/activerecord/src/associations/instance-methods.ts
+++ b/packages/activerecord/src/associations/instance-methods.ts
@@ -76,23 +76,20 @@ function assertSingularAssociation(
   expected: "belongsTo" | "hasOne",
 ): AssocDef {
   const ctor = this.constructor as typeof Base;
-  const assocDef = ctor._associations
-    ?.slice()
-    .reverse()
-    .find((a) => a.name === name);
+  const assocDef = ctor._reflectOnAssociation?.(name) as unknown as AssocDef | null;
   if (!assocDef) {
     throw _associationNotFound(this, name);
   }
-  if (assocDef.type !== expected) {
-    if (assocDef.type === "hasMany" || assocDef.type === "hasAndBelongsToMany") {
+  if (assocDef.macro !== expected) {
+    if (assocDef.macro === "hasMany" || assocDef.macro === "hasAndBelongsToMany") {
       throw new Error(
         `load${expected === "belongsTo" ? "BelongsTo" : "HasOne"} is for singular associations. ` +
-          `\`${ctor.name}.${name}\` is a ${assocDef.type} — await the reader: \`await record.${name}\`.`,
+          `\`${ctor.name}.${name}\` is a ${assocDef.macro} — await the reader: \`await record.${name}\`.`,
       );
     }
-    const right = assocDef.type === "belongsTo" ? "loadBelongsTo" : "loadHasOne";
+    const right = assocDef.macro === "belongsTo" ? "loadBelongsTo" : "loadHasOne";
     throw new Error(
-      `\`${ctor.name}.${name}\` is a ${assocDef.type}, not ${expected}. Use \`record.${right}("${name}")\` instead.`,
+      `\`${ctor.name}.${name}\` is a ${assocDef.macro}, not ${expected}. Use \`record.${right}("${name}")\` instead.`,
     );
   }
   return assocDef;
@@ -122,22 +119,14 @@ export function association(this: Base, name: string): AssociationInstance {
   }
 
   const ctor = this.constructor as typeof Base;
-  const assocDef = ctor._associations
-    ?.slice()
-    .reverse()
-    .find((a) => a.name === name);
+  // Rails constructs from the reflection (`associations.rb:290-296`:
+  // `reflection.association_class.new(self, reflection)`).
+  const assocDef = ctor._reflectOnAssociation?.(name) as unknown as AssocDef | undefined;
   if (!assocDef) {
     throw _associationNotFound(this, name);
   }
 
-  // Rails constructs from the reflection (`associations.rb:290-296`:
-  // `reflection.association_class.new(self, reflection)`); the `_associations`
-  // scan above stays only because it carries the subclass-override ordering
-  // and the macro `_buildAssociationInstance` dispatches on.
-  const instance = _buildAssociationInstance.call(
-    this,
-    (ctor._reflectOnAssociation?.(name) as unknown as AssocDef | undefined) ?? assocDef,
-  );
+  const instance = _buildAssociationInstance.call(this, assocDef);
   this._associationInstances.set(name, instance);
   syncAssociationInstance.call(this, name, instance);
   return instance;

--- a/packages/activerecord/src/associations/join-dependency-alias-tracker.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-alias-tracker.trails.test.ts
@@ -35,7 +35,7 @@ describe("JoinDependency AliasTracker wiring", () => {
 
   beforeEach(() => {
     for (const m of [Post, Comment, Tag]) {
-      (m as any)._associations = [];
+      (m as any)._reflections = {};
       registerModel(m);
     }
     Associations.hasMany.call(Post, "comments", { className: "Comment", foreignKey: "postId" });

--- a/packages/activerecord/src/associations/join-dependency-belongs-to-dedup.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-belongs-to-dedup.trails.test.ts
@@ -29,7 +29,7 @@ describe("JoinDependency cross-parent belongsTo dedup", () => {
 
   beforeEach(() => {
     for (const m of [Author, Post]) {
-      m._associations = [];
+      m._reflections = {};
       registerModel(m);
     }
 

--- a/packages/activerecord/src/associations/join-dependency-duplicate-objects.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-duplicate-objects.trails.test.ts
@@ -45,7 +45,7 @@ describe("JoinDependency dedupes duplicate join rows", () => {
 
   beforeEach(() => {
     for (const m of [Comment, Post, Reader]) {
-      m._associations = [];
+      m._reflections = {};
       registerModel(m);
     }
     Associations.hasMany.call(Post, "comments", { className: "Comment" });

--- a/packages/activerecord/src/associations/join-dependency-extra-columns.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-extra-columns.trails.test.ts
@@ -30,7 +30,7 @@ describe("JoinDependency extra columns in instantiate", () => {
 
   beforeEach(() => {
     for (const m of [Post, Comment]) {
-      m._associations = [];
+      m._reflections = {};
       registerModel(m);
     }
     Associations.hasMany.call(Post, "comments", { className: "Comment" });

--- a/packages/activerecord/src/associations/join-dependency-nested-hydration.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-nested-hydration.trails.test.ts
@@ -30,7 +30,7 @@ describe("JoinDependency nested hydration", () => {
 
   beforeEach(() => {
     for (const m of [Author, Comment, Post]) {
-      m._associations = [];
+      m._reflections = {};
       registerModel(m);
     }
     Associations.hasMany.call(Post, "comments", { className: "Comment" });

--- a/packages/activerecord/src/associations/join-dependency-polish.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-polish.trails.test.ts
@@ -23,7 +23,7 @@ describe("JoinBase.table", () => {
   }
 
   beforeEach(() => {
-    (Post as any)._associations = [];
+    (Post as any)._reflections = {};
     registerModel(Post);
   });
 
@@ -58,7 +58,7 @@ describe("joinType propagation in joinConstraints", () => {
 
   beforeEach(() => {
     for (const m of [Post, Comment]) {
-      (m as any)._associations = [];
+      (m as any)._reflections = {};
       registerModel(m);
     }
     Associations.hasMany.call(Post, "comments", { className: "Comment" });

--- a/packages/activerecord/src/associations/join-dependency-quoting.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-quoting.trails.test.ts
@@ -57,8 +57,8 @@ describe("JoinDependency Arel node construction", () => {
   }
 
   beforeEach(() => {
-    (Owner as any)._associations = [];
-    (Asset as any)._associations = [];
+    (Owner as any)._reflections = {};
+    (Asset as any)._reflections = {};
     registerModel(Owner);
     registerModel(Asset);
   });
@@ -105,8 +105,8 @@ describe("JoinDependency Arel node construction", () => {
     class StiSubOwner extends StiOwner {}
     StiOwner.inheritanceColumn = "type";
     registerSubclass(StiSubOwner);
-    (StiOwner as any)._associations = [];
-    (StiSubOwner as any)._associations = [];
+    (StiOwner as any)._reflections = {};
+    (StiSubOwner as any)._reflections = {};
     registerModel(StiOwner);
     registerModel(StiSubOwner);
 
@@ -143,9 +143,9 @@ describe("JoinDependency Arel node construction", () => {
     Vehicle.inheritanceColumn = "type";
     registerSubclass(Car);
     registerSubclass(ElectricCar);
-    (Vehicle as any)._associations = [];
-    (Car as any)._associations = [];
-    (ElectricCar as any)._associations = [];
+    (Vehicle as any)._reflections = {};
+    (Car as any)._reflections = {};
+    (ElectricCar as any)._reflections = {};
     registerModel(Vehicle);
     registerModel(Car);
     registerModel(ElectricCar);
@@ -249,7 +249,7 @@ describe("JoinDependency Arel node construction", () => {
         this.attribute("body", "string");
       }
     }
-    (Comment as any)._associations = [];
+    (Comment as any)._reflections = {};
     registerModel(Comment);
 
     Associations.hasMany.call(Owner, "assets", { className: "Asset", foreignKey: "owner_id" });

--- a/packages/activerecord/src/associations/join-dependency-spec.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-spec.trails.test.ts
@@ -49,7 +49,7 @@ describe("JoinDependency#build", () => {
 
   beforeEach(() => {
     for (const m of [Post, Comment, Author, Tag]) {
-      (m as any)._associations = [];
+      (m as any)._reflections = {};
       (m as any)._reflections = {};
       clearReflectionsCache(m);
       registerModel(m);

--- a/packages/activerecord/src/associations/join-dependency-spec.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-spec.trails.test.ts
@@ -50,7 +50,6 @@ describe("JoinDependency#build", () => {
   beforeEach(() => {
     for (const m of [Post, Comment, Author, Tag]) {
       (m as any)._reflections = {};
-      (m as any)._reflections = {};
       clearReflectionsCache(m);
       registerModel(m);
     }

--- a/packages/activerecord/src/associations/join-dependency-walk.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-walk.trails.test.ts
@@ -47,7 +47,6 @@ describe("JoinDependency walk() deduplication", () => {
   beforeEach(() => {
     for (const m of [Post, Comment, Author, Like]) {
       (m as any)._reflections = {};
-      (m as any)._reflections = {};
       clearReflectionsCache(m);
       registerModel(m);
     }
@@ -101,7 +100,6 @@ describe("JoinDependency walk() deduplication", () => {
         this.attribute("post_id", "integer");
       }
     }
-    (Tag as any)._reflections = {};
     (Tag as any)._reflections = {};
     clearReflectionsCache(Tag);
     registerModel(Tag);

--- a/packages/activerecord/src/associations/join-dependency-walk.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-walk.trails.test.ts
@@ -46,7 +46,7 @@ describe("JoinDependency walk() deduplication", () => {
 
   beforeEach(() => {
     for (const m of [Post, Comment, Author, Like]) {
-      (m as any)._associations = [];
+      (m as any)._reflections = {};
       (m as any)._reflections = {};
       clearReflectionsCache(m);
       registerModel(m);
@@ -101,7 +101,7 @@ describe("JoinDependency walk() deduplication", () => {
         this.attribute("post_id", "integer");
       }
     }
-    (Tag as any)._associations = [];
+    (Tag as any)._reflections = {};
     (Tag as any)._reflections = {};
     clearReflectionsCache(Tag);
     registerModel(Tag);

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -620,9 +620,9 @@ export class JoinDependency {
     );
 
     const inverseMap = new Map<string, string | undefined>();
-    const modelAssocs: any[] = (this._baseModel as any)._associations ?? [];
-    for (const assoc of modelAssocs) {
-      inverseMap.set(assoc.name, assoc.options?.inverseOf);
+    const modelReflections: Record<string, any> = (this._baseModel as any)._reflections ?? {};
+    for (const [assocName, reflection] of Object.entries(modelReflections)) {
+      inverseMap.set(assocName, reflection.options?.inverseOf);
     }
 
     for (const parent of parents) {

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -388,7 +388,7 @@ export class ThroughAssociation extends Association {
     if (refl) return refl;
 
     const model = (this.reflection as any).activeRecord;
-    const assocDef = model?._associations?.find((a: any) => a.name === this.reflection.name);
+    const assocDef = model?._reflectOnAssociation?.(this.reflection.name);
     if (assocDef?.options?.through) {
       return model._reflectOnAssociation(
         assocDef.options.through,
@@ -404,7 +404,7 @@ export class ThroughAssociation extends Association {
     const throughRefl = this.throughReflection;
     if (!throughRefl) return null;
     const model = (this.reflection as any).activeRecord;
-    const assocDef = model?._associations?.find((a: any) => a.name === this.reflection.name);
+    const assocDef = model?._reflectOnAssociation?.(this.reflection.name);
     // `source_reflection_names` (reflection.rb:1108-1110) is the candidate list
     // Rails scans. Unlike `source_reflection_name` it never touches
     // `through_reflection.klass`, so it cannot raise NameError while the model

--- a/packages/activerecord/src/associations/source-type-validation.trails.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.trails.test.ts
@@ -71,10 +71,7 @@ registerModel("StvMember", StvMember);
 
 function freshAssociations() {
   (StvAuthor as any)._reflections = {};
-  (StvAuthor as any)._reflections = {};
   (StvComment as any)._reflections = {};
-  (StvComment as any)._reflections = {};
-  (StvPost as any)._reflections = {};
   (StvPost as any)._reflections = {};
 }
 

--- a/packages/activerecord/src/associations/source-type-validation.trails.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.trails.test.ts
@@ -70,11 +70,11 @@ registerModel("StvPost", StvPost);
 registerModel("StvMember", StvMember);
 
 function freshAssociations() {
-  (StvAuthor as any)._associations = [];
   (StvAuthor as any)._reflections = {};
-  (StvComment as any)._associations = [];
+  (StvAuthor as any)._reflections = {};
   (StvComment as any)._reflections = {};
-  (StvPost as any)._associations = [];
+  (StvComment as any)._reflections = {};
+  (StvPost as any)._reflections = {};
   (StvPost as any)._reflections = {};
 }
 

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -4418,13 +4418,7 @@ describe("ChangedForAutosaveTest", () => {
     class Parent extends Base {
       static {
         this.attribute("id", "integer");
-        (this as any)._associations = [
-          {
-            name: "children",
-            type: "hasMany",
-            options: { autosave: true, className: "ChangedChild" },
-          },
-        ];
+        this.hasMany("children", { autosave: true, className: "ChangedChild" });
       }
     }
     registerModel("ChangedParent", Parent);
@@ -4451,13 +4445,7 @@ describe("ChangedForAutosaveTest", () => {
     class Parent2 extends Base {
       static {
         this.attribute("id", "integer");
-        (this as any)._associations = [
-          {
-            name: "child",
-            type: "hasOne",
-            options: { autosave: true, className: "ChangedChild2" },
-          },
-        ];
+        this.hasOne("child", { autosave: true, className: "ChangedChild2" });
       }
     }
     registerModel("ChangedParent2", Parent2);
@@ -4478,17 +4466,13 @@ describe("ChangedForAutosaveTest", () => {
     class A extends Base {
       static {
         this.attribute("id", "integer");
-        (this as any)._associations = [
-          { name: "b", type: "hasOne", options: { autosave: true, className: "CycleB" } },
-        ];
+        this.hasOne("b", { autosave: true, className: "CycleB" });
       }
     }
     class B extends Base {
       static {
         this.attribute("id", "integer");
-        (this as any)._associations = [
-          { name: "a", type: "belongsTo", options: { autosave: true, className: "CycleA" } },
-        ];
+        this.belongsTo("a", { autosave: true, className: "CycleA" });
       }
     }
     registerModel("CycleA", A);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -345,7 +345,6 @@ import {
   registerModelConstant,
   initInternals as _associationsInitInternals,
   initializeDup as _associationsInitializeDup,
-  type AssociationDefinition,
 } from "./associations.js";
 import * as _AttributeAssignment from "./attribute-assignment.js";
 import * as _NestedAttributes from "./nested-attributes.js";
@@ -678,7 +677,7 @@ function _applyScopeAttributes(
 /** @internal An association definition as `_extractAssociationAttrs` reads it. */
 interface _AssociationDefLike {
   name: string;
-  type: string;
+  macro: string;
 }
 
 /**
@@ -708,7 +707,7 @@ function _collectionIdsKeyOwner(
   if (!key.endsWith("Ids")) return undefined;
   return defs.find(
     (a) =>
-      (a.type === "hasMany" || a.type === "hasAndBelongsToMany") &&
+      (a.macro === "hasMany" || a.macro === "hasAndBelongsToMany") &&
       `${_singularize(a.name)}Ids` === key,
   );
 }
@@ -731,8 +730,11 @@ function _extractAssociationAttrs(
   rest: Record<string, unknown>;
   assocs: _PendingAssociationAttr[];
 } | null {
-  const defs = (ctor as { _associations?: _AssociationDefLike[] } | undefined)?._associations;
-  if (!defs || defs.length === 0) return null;
+  const reflections = (ctor as { _reflections?: Record<string, _AssociationDefLike> } | undefined)
+    ?._reflections;
+  if (!reflections) return null;
+  const defs = Object.values(reflections);
+  if (defs.length === 0) return null;
   // Common case: models that declare associations but receive only regular
   // attrs at construction (`new Post({title})`). First pass detects whether
   // any key matches an association; only then do we allocate `rest` and
@@ -784,14 +786,14 @@ function _dispatchAssociationAttrs(record: Base, assocs: _PendingAssociationAttr
     if (!proxy) continue;
     if (idsKey) {
       proxy.syncIdsWrite?.(value as unknown[]);
-    } else if (assoc.type === "hasMany" || assoc.type === "hasAndBelongsToMany") {
+    } else if (assoc.macro === "hasMany" || assoc.macro === "hasAndBelongsToMany") {
       // Rails fidelity: pass the value through unchanged. `replace` calls
       // `.each` on the argument and raises on nil / scalars, so an `Array.wrap`
       // here would silently accept inputs the writer rejects.
       proxy.syncWrite?.(value as unknown[]);
-    } else if (assoc.type === "hasOne") {
+    } else if (assoc.macro === "hasOne") {
       proxy.syncWrite?.(value);
-    } else if (assoc.type === "belongsTo") {
+    } else if (assoc.macro === "belongsTo") {
       proxy.writer?.(value);
     }
   }
@@ -848,8 +850,6 @@ export class Base extends Model {
   declare static _primaryKey?: string | string[];
   static readonly _isActiveRecordBase = true;
 
-  /** @internal */
-  declare static _associations: AssociationDefinition[];
   /** @internal */
   declare static _registryKeys: string[];
   /**
@@ -4581,14 +4581,9 @@ extend(Base, _Reflection.ClassMethods);
 // Mirrors `class_attribute :_reflections, instance_writer: false, default: {}`
 // (reflection.rb:11): reads walk the constructor chain, writes are local to the
 // class, so `add_reflection`'s reassignment is the whole copy-on-write
-// mechanism. `_associations` has no `class_attribute` of its own upstream —
-// reflection.rb:11-14 declares only `_reflections`, `aggregate_reflections`,
-// `automatic_scope_inversing` and `automatically_invert_plural_associations` —
-// it is trails-only registry bookkeeping carried on the same mechanism as the
-// `_reflections` it shadows, so the two cannot drift apart.
+// mechanism.
 classAttribute.call(Base, "_reflections", { instanceWriter: false, default: {} });
 classAttribute.call(Base, "aggregateReflections", { instanceWriter: false, default: {} });
-classAttribute.call(Base, "_associations", { instanceWriter: false, default: [] });
 classAttribute.call(Base, "_counterCacheColumns", { instanceAccessor: false, default: [] });
 classAttribute.call(Base, "_attrReadonly", { instanceAccessor: false, default: [] });
 classAttribute.call(Base, "defaultScopes", {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.trails.test.ts
@@ -166,6 +166,29 @@ describe("ReferenceDefinition#add", () => {
     expect(calls[2][3]).toMatchObject({ name: "index_taggings_on_taggable" });
   });
 
+  // `polymorphic_options` forwards `options.slice(:null, :first, :after)`
+  // (schema_definitions.rb:259), so MySQL positioning applies to BOTH halves of
+  // the pair rather than splitting them.
+  it("forwards first/after positioning onto the polymorphic type column", async () => {
+    const { calls, connection } = recorder();
+    await new ReferenceDefinition("taggable", { polymorphic: true, after: "id" }).add(
+      "taggings",
+      connection,
+    );
+
+    expect(calls[0][4]).toMatchObject({ after: "id" });
+    expect(calls[1][4]).toMatchObject({ after: "id" });
+
+    const first = recorder();
+    await new ReferenceDefinition("taggable", { polymorphic: true, first: true }).add(
+      "taggings",
+      first.connection,
+    );
+
+    expect(first.calls[0][4]).toMatchObject({ first: true });
+    expect(first.calls[1][4]).toMatchObject({ first: true });
+  });
+
   it("merges an index options hash", async () => {
     const { calls, connection } = recorder();
     await new ReferenceDefinition("user", { index: { unique: true, name: "my_index" } }).add(

--- a/packages/activerecord/src/delegate.ts
+++ b/packages/activerecord/src/delegate.ts
@@ -1,5 +1,4 @@
 import type { Base } from "./base.js";
-import type { AssociationDefinition } from "./associations.js";
 import { upcaseFirst } from "@blazetrails/activesupport";
 import { association } from "./associations/instance-methods.js";
 
@@ -30,14 +29,13 @@ export function delegate(
     Object.defineProperty(modelClass.prototype, delegatedName, {
       value: async function (this: Base) {
         const ctor = this.constructor as typeof Base;
-        const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
-        const assocDef = associations.find((a) => a.name === assocName);
+        const assocDef = (ctor as any)._reflectOnAssociation?.(assocName);
         if (!assocDef) {
           throw new Error(`Association "${assocName}" not found on ${ctor.name}`);
         }
 
         let target: Base | null = null;
-        if (assocDef.type === "belongsTo" || assocDef.type === "hasOne") {
+        if (assocDef.macro === "belongsTo" || assocDef.macro === "hasOne") {
           target = (await association.call(this, assocName).loadTarget()) as Base | null;
         }
 

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -85,21 +85,20 @@ export function acceptsNestedAttributesFor(
   }
 
   // Validate that the association exists
-  const associations: any[] = (modelClass as any)._associations ?? [];
-  const assocExists = associations.find((a: any) => a.name === associationName);
-  if (!assocExists) {
+  const reflection = (modelClass as any)._reflectOnAssociation?.(associationName);
+  if (!reflection) {
     throw new Error(`No association found for name '${associationName}'. Has it been defined yet?`);
   }
 
   // Rails sets `reflection.autosave = true` for every nested-attributes
   // association (nested_attributes.rb:359), so the parent's save cascades into
-  // the in-memory target. trails checks `options.autosave` dynamically at save
-  // time, so flipping the flag on the association definition is sufficient — and
-  // is what makes the synchronous in-memory target population in
+  // the in-memory target. The setter writes `options[:autosave]`
+  // (reflection.rb:399-405), which is what the save path reads — and is what
+  // makes the synchronous in-memory target population in
   // `assignNestedAttributesForCollectionAssociation` reachable for plain
   // `acceptsNestedAttributesFor(Model, "assoc")` callers, not only those who
   // also pass `{ autosave: true }` to `hasMany`.
-  assocExists.options = { ...assocExists.options, autosave: true };
+  reflection.autosave = true;
 
   // Rails accepts_nested_attributes_for calls `define_autosave_validation_callbacks`
   // after flipping autosave (nested_attributes.rb:368-370). The association's
@@ -107,14 +106,7 @@ export function acceptsNestedAttributesFor(
   // callback is gated on `reflection.validate?` — false at declaration time for a
   // plain belongs_to/has_one (autosave not yet set). Re-running it here wires the
   // nested-record validator so a singular nested association is validated.
-  const reflection = (modelClass as any)._reflectOnAssociation?.(associationName);
-  if (reflection) {
-    // Rails `reflection.autosave = true` — flip it on the rich reflection too
-    // (not just the `_associations` entry the save path reads) so
-    // `reflection.validate?` sees it and the validation callback is wired.
-    reflection.autosave = true;
-    defineAutosaveValidationCallbacks.call(modelClass, reflection);
-  }
+  defineAutosaveValidationCallbacks.call(modelClass, reflection);
 
   // Rails does NOT reject polymorphic belongs_to at declaration time — the
   // check is deferred to build time (the writer raises when it tries to build
@@ -127,10 +119,9 @@ export function acceptsNestedAttributesFor(
   nestedAttributesOptions[associationName] = options;
   modelClass.nestedAttributesOptions = nestedAttributesOptions;
 
-  const type =
-    assocExists.type === "hasMany" || assocExists.type === "hasAndBelongsToMany"
-      ? "collection"
-      : "one_to_one";
+  // `type = (reflection.collection? ? :collection : :one_to_one)`
+  // (nested_attributes.rb:361).
+  const type = reflection.isCollection() ? "collection" : "one_to_one";
   modelClass.generateAssociationWriter(associationName, type);
 
   // Wrap save to flush pending nested attributes after the parent is persisted
@@ -213,12 +204,11 @@ async function processNestedAttributes(record: Base): Promise<void> {
     const config = ctor.nestedAttributesOptions[assocName];
     if (!config) continue;
 
-    const associations: any[] = (ctor as any)._associations ?? [];
-    const assocDef = associations.find((a: any) => a.name === assocName);
+    const assocDef = (ctor as any)._reflectOnAssociation?.(assocName);
     if (!assocDef) continue;
 
     // Resolve target model
-    const className = collectionAssociationClassName(assocDef, assocName);
+    const className = assocDef.className;
 
     const targetModel = modelRegistry.get(className);
     if (!targetModel) continue;
@@ -470,8 +460,7 @@ export function raiseNestedAttributesRecordNotFoundBang(
   recordId: unknown,
 ): never {
   const ctor = record.constructor as typeof Base;
-  const associations: any[] = (ctor as any)._associations ?? [];
-  const assocDef = associations.find((a: any) => a.name === associationName);
+  const assocDef = (ctor as any)._reflectOnAssociation?.(associationName);
   const modelName = assocDef?.options?.className ?? camelize(singularize(associationName));
   throw new RecordNotFound(
     `Couldn't find ${modelName} with ID=${recordId} for ${ctor.name} with ID=${record.id}`,
@@ -560,9 +549,8 @@ export function generateAssociationWriter(
 
 /** @internal */
 export function isPolymorphicBelongsTo(record: Base, associationName: string): boolean {
-  const associations: any[] = (record.constructor as any)._associations ?? [];
-  const assocDef = associations.find((a: any) => a.name === associationName);
-  return assocDef?.type === "belongsTo" && Boolean(assocDef?.options?.polymorphic);
+  const assocDef = (record.constructor as any)._reflectOnAssociation?.(associationName);
+  return assocDef?.macro === "belongsTo" && Boolean(assocDef?.options?.polymorphic);
 }
 
 /**
@@ -932,8 +920,7 @@ export function assignNestedAttributesForCollectionAssociation(
   // For non-autosave associations there is no autosave cascade to persist the
   // change, so existing records stay in the pending map for the trails-specific
   // post-save flush (`processNestedAttributes`).
-  const associations: any[] = (ctor as any)._associations ?? [];
-  const assocDef = associations.find((a: any) => a.name === associationName);
+  const assocDef = (ctor as any)._reflectOnAssociation?.(associationName);
   const isAutosave = assocDef?.options?.autosave === true;
 
   // Rails collects the assignment's result records into `nested_attributes_target`
@@ -943,9 +930,9 @@ export function assignNestedAttributesForCollectionAssociation(
   // The `else` (non-autosave existing-record) branch does NOT append to
   // `nestedTarget`, which would break that 1:1 ordering — but it is unreachable
   // for any `accepts_nested_attributes_for` collection: `acceptsNestedAttributesFor`
-  // unconditionally sets `assocExists.options.autosave = true` (above), and
-  // `assocDef` is re-read from the live `_associations` array on every call, so
-  // `isAutosave` is always true here. The branch remains only as a guard for a
+  // unconditionally sets `reflection.autosave = true` (above), and `assocDef` is
+  // re-read from the live reflection registry on every call, so `isAutosave` is
+  // always true here. The branch remains only as a guard for a
   // hypothetical direct caller on a non-autosave collection (which never sets a
   // nestedAttributesTarget and defers everything to the post-save flush).
   const collectionTargetModel = resolveCollectionTargetModel(record, associationName);
@@ -1029,8 +1016,7 @@ function populateInMemoryExistingRecord(
   attrs: Record<string, unknown>,
 ): Base | null {
   const ctor = record.constructor as typeof Base;
-  const associations: any[] = (ctor as any)._associations ?? [];
-  const assocDef = associations.find((a: any) => a.name === associationName);
+  const assocDef = (ctor as any)._reflectOnAssociation?.(associationName);
   const targetModel = resolveCollectionTargetModel(record, associationName);
   if (!targetModel || !assocDef) return null;
 
@@ -1110,23 +1096,8 @@ function loadedCollectionTarget(record: Base, associationName: string): Base[] {
 }
 
 /**
- * Class name backing a collection association: explicit `className` option, else
- * the camelized singular of the association name. Single source of truth for
- * `processNestedAttributes` and `resolveCollectionTargetModel`.
- * @internal
- */
-function collectionAssociationClassName(assocDef: any, associationName: string): string {
-  return (
-    assocDef.options.className ??
-    (assocDef.type === "hasMany" || assocDef.type === "hasAndBelongsToMany"
-      ? camelize(singularize(associationName))
-      : camelize(associationName))
-  );
-}
-
-/**
- * Resolve the model class backing a collection association via the registry,
- * mirroring the className resolution in `processNestedAttributes`.
+ * Resolve the model class backing a collection association via the registry —
+ * the trails stand-in for Rails' `reflection.klass` constant lookup.
  * @internal
  */
 function resolveCollectionTargetModel(
@@ -1134,10 +1105,9 @@ function resolveCollectionTargetModel(
   associationName: string,
 ): typeof Base | undefined {
   const ctor = record.constructor as typeof Base;
-  const associations: any[] = (ctor as any)._associations ?? [];
-  const assocDef = associations.find((a: any) => a.name === associationName);
+  const assocDef = (ctor as any)._reflectOnAssociation?.(associationName);
   if (!assocDef) return undefined;
-  return modelRegistry.get(collectionAssociationClassName(assocDef, associationName));
+  return modelRegistry.get(assocDef.className);
 }
 
 export const InstanceMethods = {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -360,17 +360,20 @@ export class AbstractReflection {
         if (this._counterCacheColumnKlass === resolvedKlass) {
           return this._counterCacheColumn as string | null;
         }
-        const targetAssocs: Array<{ type: string; name: string; options: any }> =
-          (resolvedKlass as any)._associations ?? [];
+        const targetAssocs = reflectOnAllAssociations(resolvedKlass, "hasMany");
         // Match on both class name AND FK so that when a target declares multiple
         // hasManyS to the same class with different FKs (e.g. DogLover has
         // hasMany("trainedDogs") and hasMany("dogs")), we pick the one whose FK
         // matches the belongsTo's FK rather than the first class-name match.
         const hmDefaultFk = `${underscore((resolvedKlass as any).name)}_id`;
         const inverseHm = targetAssocs.find((a) => {
-          if (a.type !== "hasMany") return false;
           if ((a.options.className ?? camelize(singularize(a.name))) !== ownerName) return false;
-          const hmFkNorm = normFk(a.options.foreignKey ?? hmDefaultFk);
+          // Same `queryConstraints` fallback as `btFk` above: a composite
+          // `foreignKey:` is normalized off `options` and onto
+          // `options.queryConstraints` when the reflection is built.
+          const hmFkNorm = normFk(
+            a.options.foreignKey ?? a.options.queryConstraints ?? hmDefaultFk,
+          );
           return hmFkNorm.length === btFkNorm.length && hmFkNorm.every((k, i) => k === btFkNorm[i]);
         });
         // Only use the inverse hasMany's name when its singular camelCase form is

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -367,7 +367,7 @@ export class AbstractReflection {
         // matches the belongsTo's FK rather than the first class-name match.
         const hmDefaultFk = `${underscore((resolvedKlass as any).name)}_id`;
         const inverseHm = targetAssocs.find((a) => {
-          if ((a.options.className ?? camelize(singularize(a.name))) !== ownerName) return false;
+          if (a.className !== ownerName) return false;
           // Same `queryConstraints` fallback as `btFk` above: a composite
           // `foreignKey:` is normalized off `options` and onto
           // `options.queryConstraints` when the reflection is built.

--- a/packages/activerecord/src/relation/unscope-coverage.trails.test.ts
+++ b/packages/activerecord/src/relation/unscope-coverage.trails.test.ts
@@ -26,8 +26,8 @@ describe("Relation#unscope — full Rails key coverage", () => {
   beforeEach(() => {
     registerModel("UscAuthor", UscAuthor);
     registerModel("UscPost", UscPost);
-    (UscAuthor as any)._associations = [];
-    (UscPost as any)._associations = [];
+    (UscAuthor as any)._reflections = {};
+    (UscPost as any)._reflections = {};
     Associations.hasMany.call(UscAuthor, "uscPosts", {
       className: "UscPost",
       foreignKey: "usc_author_id",


### PR DESCRIPTION
Two RFC 0112 stories.

## 1. `ReferenceDefinition#polymorphicOptions` — first/after positioning

The forwarding itself landed in #6718; what was missing was the coverage the
story asks for. `polymorphic_options` is
`as_options(polymorphic).merge(conditional_options).merge(options.slice(:null, :first, :after))`
(`schema_definitions.rb:259`), so `t.references :taggable, polymorphic: true,
after: :id` must position **both** halves of the `*_type`/`*_id` pair rather
than splitting them. The new test asserts that for `after:` and `first:`, and
fails on a tree with the two spread lines removed.

## 2. Retire `model._associations` for the reflection registry

`Builder::Association.createReflection` pushed a lightweight
`{ type, name, scope, options }` entry onto a per-model `_associations` array
*beside* `Reflection.addReflection`. Rails has only the second:
`create_reflection` ends at `Reflection.create(macro, name, scope, options,
model)` (`associations/builder/association.rb:48-49`) and `add_reflection`
(`reflection.rb:18-22`) is the single registry.

The array is gone. Every read site now resolves through the registry —
`_reflectOnAssociation` for a per-name lookup, `reflections` /
`reflectOnAllAssociations` for a list (which is what Rails' own
`AssociationNotFoundError#corrections` reads) — and bodies read `macro` where
they read the array's `type`.

Fallout worth calling out:

- **`acceptsNestedAttributesFor`** flipped autosave twice: once by replacing
  `options` on the array entry, once via `reflection.autosave = true`. Only the
  second survives; its setter writes `options[:autosave]`
  (`reflection.rb:399-405`), which is what the save path reads. `type` is now
  `reflection.collection?` (`nested_attributes.rb:361`), and the trails-only
  `collectionAssociationClassName` helper is replaced by `reflection.className`
  — Rails' `AssociationReflection#class_name`.
- **`counterCacheColumn`**'s inverse-`has_many` scan needed the same
  `options.queryConstraints` fallback the `belongs_to` side already had: a
  composite `foreignKey:` is normalized off `options` when the reflection is
  built, so reading `options.foreignKey` alone missed every CPK inverse.
- **`association(name)`** no longer scans for a definition before preferring
  the reflection — it just takes the reflection, as Rails does
  (`associations.rb:290-296`).

### Carved out

The story's third criterion — no reader duplicated between
`AssociationDefinition` and the reflection classes — is not met here, and the
story itself anticipated more than one PR. It is blocked on the two paths that
still build ad-hoc holders with no registered reflection (`findCollectionTarget`
and `loadHasManyThrough`'s synthesised `sourceType` scope), which is what
`_richReflectionFor`'s `@noRailsEquivalent CONVERGEABLE` receipt exists for.
Filed as `retire-ad-hoc-association-definition-holders` under the same RFC.

### Verification

`pnpm typecheck`, `pnpm lint` clean. 115 association test files (2048 tests),
`relation/`, `associations.test.ts`, `autosave-association.test.ts`,
`nested-attributes.test.ts`, `inheritance.test.ts`, `base`/`reflection`/
`counter-cache` all green. `parity:api:calls`, `parity:api:calls:args` and
`parity:api:extra:gate` OK; `parity:test --gates --check` exits 0.
`parity:api:extra` for activerecord *drops* (novel 376→374, total 1324→1320).

Closes-story: reference-definition-polymorphic-options-forwards-first-and-after
Closes-story: retire-associations-array-for-reflection-registry
