### PR TITLE
refactor(activerecord): retire _explicitTarget/_loadedFromPreload onto Rails' loaded?, port DEFAULT_ENV, drop invented PG :variables validation and the 16 MiB max_allowed_packet fallback (RFC 0112, RFC 0119)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/connection_test.rb
  */
-import { it, expect, describe, beforeEach, afterEach, vi } from "vitest";
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, SQLSubscriber } from "./test-helper.js";
 import { QueryAttribute } from "../../relation/query-attribute.js";
 import { Value } from "../../type.js";
@@ -319,58 +319,5 @@ describeIfPg("PostgresqlConnectionTest", () => {
     } finally {
       await a.close();
     }
-  });
-});
-
-describe("PostgreSQLAdapter constructor validation", () => {
-  it("rejects invalid variable key", () => {
-    expect(
-      () =>
-        new PostgreSQLAdapter({ connectionString: PG_TEST_URL, variables: { "bad;key": "val" } }),
-    ).toThrow("Invalid PostgreSQL session variable name");
-  });
-
-  it("rejects undefined variable value", () => {
-    expect(
-      () =>
-        new PostgreSQLAdapter({
-          connectionString: PG_TEST_URL,
-          variables: { debug_print_plan: undefined as unknown as null },
-        }),
-    ).toThrow("must be string | number | boolean | null");
-  });
-
-  it("rejects object variable value", () => {
-    expect(
-      () =>
-        new PostgreSQLAdapter({
-          connectionString: PG_TEST_URL,
-          variables: { debug_print_plan: {} as unknown as string },
-        }),
-    ).toThrow("must be string | number | boolean | null");
-  });
-
-  it("accepts numeric variable value (e.g. statement_timeout: 5000)", async () => {
-    let a: PostgreSQLAdapter | undefined;
-    try {
-      expect(() => {
-        a = new PostgreSQLAdapter({
-          connectionString: PG_TEST_URL,
-          variables: { statement_timeout: 5000 },
-        });
-      }).not.toThrow();
-    } finally {
-      await a?.close();
-    }
-  });
-
-  it("rejects non-plain-object variables", () => {
-    expect(
-      () =>
-        new PostgreSQLAdapter({
-          connectionString: PG_TEST_URL,
-          variables: new Map() as unknown as Record<string, string>,
-        }),
-    ).toThrow("variables must be a plain object");
   });
 });

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -561,8 +561,7 @@ export function _wireInverseAssociation(owner: Base, child: Base, inverseName: s
  * one inverse write, `set_inverse_instance` -> `inversed_from`
  * (`association.rb:132-137, 153-155`); a collection name reaches
  * `CollectionAssociation#target=` (`collection_association.rb:284-295`)
- * through it, and does not raise `_explicitTarget`, which `setInverseInstance`
- * likewise skips for a collection and only `_loadedSingularTarget` reads.
+ * through it.
  *
  * RFC 0022: writers and inverse-of seeders route through the holder, which is
  * the single source of truth — surfaced to readers via `Base#_associationCache`.
@@ -586,39 +585,9 @@ export function _cacheSingularTarget(record: Base, assocName: string, target: Ba
     // For has_one the FK lives on the target, so `inversedFrom` is equivalent
     // to `setTarget` (assign + loadedBang) with no owner FK write.
     assoc.inversedFrom(target);
-    (assoc as unknown as { _explicitTarget: boolean })._explicitTarget = true;
     return;
   }
   record._associationInstances.get(assocName)?.inversedFrom(target);
-}
-
-/**
- * Read the explicitly-set singular target for `assocName` — the short-circuit
- * the inner `loadBelongsTo` / `loadHasOne` loaders consult before querying.
- *
- * RFC 0022: singular writers and inverse-of seeders store their target on the
- * `SingularAssociation` holder (`record.association(name).target`, Rails'
- * `@target`) as the source of truth. These inner loaders run *inside* the
- * holder's own `loadTarget` (`findTarget`) and from sibling
- * through-writers, where the holder is not yet loaded — so a loaded holder here
- * carries an explicit set/seed (or a prior explicit load), the short-circuit we
- * want, plus the `_preloadedAssociations` fallback. Returns a one-key box
- * (`{ value }`) on a hit so a loaded-nil target (null) is distinguished from a
- * miss.
- *
- * @internal
- */
-export function _loadedSingularTarget(
-  record: Base,
-  assocName: string,
-): { value: Base | null } | null {
-  const instance = record._associationInstances.get(assocName) as
-    | { isLoaded(): boolean; _explicitTarget?: boolean; target?: Base | null }
-    | undefined;
-  if (instance?.isLoaded() && instance._explicitTarget) {
-    return { value: instance.target ?? null };
-  }
-  return _preloadedHolderTarget(record, assocName) as { value: Base | null } | null;
 }
 
 /**
@@ -627,8 +596,9 @@ export function _loadedSingularTarget(
  * legacy `record._preloadedAssociations` shadow `Map`. Returns a one-key box
  * (`{ value }`) on a hit so a preloaded-nil target (the preloader stores
  * `setTarget(null)` for a belongs_to that resolved to no record) is
- * distinguished from a miss; gates on `_loadedFromPreload` (not bare
- * `isLoaded()`) so a lazy query load on the holder still re-queries.
+ * distinguished from a miss. Gates on Rails' `loaded?` alone
+ * (`association.rb:57-59`) — the holder's own `@loaded` is the whole of the
+ * state Rails distinguishes here.
  *
  * @internal
  */
@@ -637,9 +607,9 @@ export function _preloadedHolderTarget(
   assocName: string,
 ): { value: Base | Base[] | null } | null {
   const instance = record._associationInstances.get(assocName) as
-    | { isLoaded(): boolean; _loadedFromPreload?: boolean; target?: Base | Base[] | null }
+    | { isLoaded(): boolean; target?: Base | Base[] | null }
     | undefined;
-  if (instance?.isLoaded() && instance._loadedFromPreload) {
+  if (instance?.isLoaded()) {
     return { value: instance.target ?? null };
   }
   return null;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -596,9 +596,11 @@ export function _cacheSingularTarget(record: Base, assocName: string, target: Ba
  * legacy `record._preloadedAssociations` shadow `Map`. Returns a one-key box
  * (`{ value }`) on a hit so a preloaded-nil target (the preloader stores
  * `setTarget(null)` for a belongs_to that resolved to no record) is
- * distinguished from a miss. Gates on Rails' `loaded?` alone
- * (`association.rb:57-59`) — the holder's own `@loaded` is the whole of the
- * state Rails distinguishes here.
+ * distinguished from a miss. Gates on Rails' own pair — `loaded?`
+ * (`association.rb:81-83`) and `@stale_state && stale_target?`
+ * (`association.rb:97-99`), the exact condition `load_target`
+ * (`association.rb:189-190`) re-queries on — so a target whose owner key moved
+ * under it re-queries rather than reading back stale.
  *
  * @internal
  */
@@ -607,12 +609,16 @@ export function _preloadedHolderTarget(
   assocName: string,
 ): { value: Base | Base[] | null } | null {
   const instance = record._associationInstances.get(assocName) as
-    | { isLoaded(): boolean; target?: Base | Base[] | null }
+    | {
+        isLoaded(): boolean;
+        isStaleTarget(): boolean;
+        _staleStateIsSnapshotted: boolean;
+        target?: Base | Base[] | null;
+      }
     | undefined;
-  if (instance?.isLoaded()) {
-    return { value: instance.target ?? null };
-  }
-  return null;
+  if (instance == null || !instance.isLoaded()) return null;
+  if (instance._staleStateIsSnapshotted && instance.isStaleTarget()) return null;
+  return { value: instance.target ?? null };
 }
 
 /**

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -104,26 +104,6 @@ export class Association {
     return this._loadedStore;
   }
 
-  /**
-   * True when `target` was set by an *explicit* assignment / inverse-of seed
-   * (the writer paths routed through `_cacheSingularTarget`), as opposed to a
-   * query load. The inner functional loaders (`loadBelongsTo` / `loadHasOne`)
-   * short-circuit only on explicit sets — a prior query load must NOT memoize,
-   * so they can re-query after a mutation (e.g. a has_one :through deleted via
-   * its writer). This is the holder-resident successor to the old
-   * `_cachedAssociations` write-shadow, which only ever held explicit writes.
-   */
-  _explicitTarget = false;
-  /**
-   * True when `target` was set by a preload / eager-load path (the standard
-   * `Preloader`, `JoinDependency`, or the preloader batch's loaded-nil default),
-   * as opposed to a lazy query load. This is the holder-resident successor to
-   * the legacy `_preloadedAssociations` shadow `Map`: readers that previously
-   * gated on `record._preloadedAssociations.has(name)` now gate on
-   * `holder.isLoaded() && holder._loadedFromPreload`, distinguishing a preloaded
-   * target (including a preloaded-nil) from a lazy load that must re-query.
-   */
-  _loadedFromPreload = false;
   /** True after asyncLoadTarget() completes a full DB load — signals the dotted
    *  collection proxy that it can hydrate from this instance's target. */
   _loadedViaAsync = false;
@@ -232,8 +212,6 @@ export class Association {
     this.loaded = false;
     this._staleState = undefined;
     this._staleStateSnapshotted = false;
-    this._explicitTarget = false;
-    this._loadedFromPreload = false;
     this._loadedViaAsync = false;
   }
 
@@ -417,18 +395,12 @@ export class Association {
    * Set the inverse association on the given record, so that
    * `record.association(inverse_name).target` points back to owner.
    *
-   * `_explicitTarget` has no Rails analog — `inversed_from` alone is the whole
-   * of `set_inverse_instance` there. It is the trails flag (RFC 0022) that
-   * `_loadedSingularTarget` consults before the inner belongs_to/has_one
-   * loaders query, so it is raised here exactly as `_cacheSingularTarget` does
-   * on the other seeding path; without it an inverse wired through this method
-   * reads back as an unset target and re-queries.
+   * Mirrors: Association#set_inverse_instance (association.rb:132-137).
    */
   setInverseInstance(record: Base): Base {
     const inverse = this.inverseAssociationFor(record);
     if (inverse) {
       inverse.inversedFrom(this.owner);
-      if (!inverse.isCollection()) inverse._explicitTarget = true;
     }
     return record;
   }
@@ -436,19 +408,11 @@ export class Association {
   /**
    * Mirrors: Association#set_inverse_instance_from_queries
    * (association.rb:139-144).
-   *
-   * `_explicitTarget` has no Rails analog — see {@link setInverseInstance}. It
-   * is raised here for the same reason, and only where `inversedFromQueries`
-   * actually took the write: an inverse it declined (`inversable?` false) must
-   * keep reading back as unset.
    */
   setInverseInstanceFromQueries(record: Base): Base {
     const inverse = this.inverseAssociationFor(record);
     if (inverse) {
       inverse.inversedFromQueries(this.owner);
-      if (!inverse.isCollection() && inverse.target === this.owner) {
-        inverse._explicitTarget = true;
-      }
     }
     return record;
   }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -1075,7 +1075,7 @@ export class JoinDependency {
       } else {
         proxy._setTargetFromLoader(child);
       }
-      proxy._loadedFromPreload = true;
+      proxy.loadedBang();
       if (typeof proxy.setInverseInstance === "function") {
         proxy.setInverseInstance(child);
       }
@@ -1096,7 +1096,6 @@ export class JoinDependency {
       const proxy = parent.association(node.immediateAssocName);
       if (!proxy || proxy.loaded) return;
       proxy.target = [];
-      proxy._loadedFromPreload = true;
     } catch (e) {
       if (!(e instanceof AssociationNotFoundError)) throw e;
     }
@@ -1113,7 +1112,6 @@ export class JoinDependency {
       if (!proxy || proxy.loaded) return;
       const isCollection = node.assocType === "hasMany";
       proxy._setTargetFromLoader(isCollection ? [] : null);
-      proxy._loadedFromPreload = true;
     } catch (e) {
       if (!(e instanceof AssociationNotFoundError)) throw e;
     }

--- a/packages/activerecord/src/associations/preloader/association.ts
+++ b/packages/activerecord/src/associations/preloader/association.ts
@@ -211,7 +211,6 @@ export class Association {
         try {
           const association = (owner as any).association(this.reflection.name);
           association._setTargetFromLoader(record);
-          association._loadedFromPreload = true;
           if (i === 0) {
             association.setInverseInstance(record);
           }
@@ -247,7 +246,6 @@ export class Association {
       value = records[0] ?? null;
       association._setTargetFromLoader(value);
     }
-    association._loadedFromPreload = true;
 
     // Route through `reflection.inverseName()` so automatic inverse detection
     // (via `automaticInverseOf()`, made functional by C1) fires for non-rich

--- a/packages/activerecord/src/associations/preloader/batch.ts
+++ b/packages/activerecord/src/associations/preloader/batch.ts
@@ -96,7 +96,6 @@ export class Batch {
         const association = (record as any).association(branch.association);
         if (!association.isLoaded()) {
           association._setTargetFromLoader(null);
-          association._loadedFromPreload = true;
         }
       } catch {}
     }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2929,7 +2929,7 @@ export class Base extends Model {
    *   - `_associationInstances` is the canonical `@association_cache` analog
    *     (name → built `Association` wrapper; what `association_instance_get/set`
    *     and `association()` read/write). The holder also carries any
-   *     preloaded/eager-loaded target (`isLoaded()` + `_loadedFromPreload`),
+   *     preloaded/eager-loaded target (`isLoaded()`),
    *     including an eagerly-preloaded *nil* association.
    *   - `_collectionProxies` is the Trails-specific user-facing `CollectionProxy`
    *     layer (incl. in-memory inverse-seeded records on a not-yet-loaded proxy),

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.trails.test.ts
@@ -7,12 +7,15 @@ import {
 } from "./database-statements.js";
 
 function hostReporting(value: string | null): MaxAllowedPacketHost & { calls: number } {
-  const host = {
+  const host: MaxAllowedPacketHost & { calls: number } = {
     calls: 0,
     async showVariable(name: string) {
       expect(name).toBe("max_allowed_packet");
       host.calls += 1;
       return value;
+    },
+    maxAllowedPacket() {
+      return maxAllowedPacket.call(host);
     },
   };
   return host;
@@ -26,9 +29,11 @@ describe("MySQL::DatabaseStatements max_allowed_packet", () => {
     expect(host.calls).toBe(1);
   });
 
-  it("falls back to the MySQL default when the server does not answer", async () => {
+  it("raises rather than combining when the server does not answer", async () => {
     const host = hostReporting(null);
-    expect(await maxAllowedPacket.call(host)).toBe(16_777_216);
+    await expect(isMaxAllowedPacketReached.call(host, "SELECT 1", undefined)).rejects.toThrow(
+      /Fixtures set is too large 8\./,
+    );
   });
 
   it("splits statements against the server-reported ceiling", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -165,11 +165,16 @@ export async function isMaxAllowedPacketReached(
   return currentSize + Buffer.byteLength(previousPacket, "utf8") + 2 > maxPacket;
 }
 
-/** @internal */
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#max_allowed_packet
+ * (`mysql/database_statements.rb:89-90`) — `@max_allowed_packet ||=
+ * show_variable("max_allowed_packet")`. Rails carries no fallback because
+ * `show_variable` always answers on a live MySQL connection; a host that cannot
+ * answer surfaces at the raise site in `is_max_allowed_packet_reached?` rather
+ * than silently combining forever.
+ * @internal
+ */
 export async function maxAllowedPacket(this: MaxAllowedPacketHost): Promise<number> {
-  // `show_variable` always answers on a live MySQL connection, so Rails needs
-  // no fallback; a host that cannot answer surfaces at the raise site in
-  // `is_max_allowed_packet_reached?` rather than silently combining forever.
   return (this._maxAllowedPacket ??= Number(await this.showVariable("max_allowed_packet")));
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/database-statements.ts
@@ -124,23 +124,22 @@ export async function returningColumnValues(
 }
 
 export interface MaxAllowedPacketHost {
-  showVariable?(name: string): Promise<string | null>;
+  showVariable(name: string): Promise<string | null>;
   /** Mirrors Rails' `@max_allowed_packet` memo. */
   _maxAllowedPacket?: number;
   /** @internal */
-  maxAllowedPacket?(): Promise<number>;
+  maxAllowedPacket(): Promise<number>;
 }
 
 /** @internal */
 export async function combineMultiStatements(
-  this: MaxAllowedPacketHost | void,
+  this: MaxAllowedPacketHost,
   totalSql: string[],
 ): Promise<string[]> {
-  const host = this ?? undefined;
   const chunks: string[] = [];
   for (const sql of totalSql) {
     const previousPacket = chunks[chunks.length - 1];
-    if (await isMaxAllowedPacketReached.call(host, sql, previousPacket)) {
+    if (await isMaxAllowedPacketReached.call(this, sql, previousPacket)) {
       chunks.push(sql);
     } else {
       chunks[chunks.length - 1] = `${previousPacket};\n${sql}`;
@@ -151,16 +150,11 @@ export async function combineMultiStatements(
 
 /** @internal */
 export async function isMaxAllowedPacketReached(
-  this: MaxAllowedPacketHost | void,
+  this: MaxAllowedPacketHost,
   currentPacket: string,
   previousPacket: string | undefined,
 ): Promise<boolean> {
-  const host = this ?? undefined;
-  // Rails resolves `max_allowed_packet` on self; the receiver only carries it
-  // once the module is mixed in, so a bare host falls back to the free function.
-  const maxPacket = host?.maxAllowedPacket
-    ? await host.maxAllowedPacket()
-    : await maxAllowedPacket.call(host);
+  const maxPacket = await this.maxAllowedPacket();
   const currentSize = Buffer.byteLength(currentPacket, "utf8");
   if (currentSize > maxPacket) {
     throw new Error(
@@ -172,16 +166,11 @@ export async function isMaxAllowedPacketReached(
 }
 
 /** @internal */
-export async function maxAllowedPacket(this: MaxAllowedPacketHost | void): Promise<number> {
-  const host = this ?? undefined;
-  if (host?._maxAllowedPacket !== undefined) return host._maxAllowedPacket;
-  const raw = await host?.showVariable?.("max_allowed_packet");
-  const parsed = raw != null ? parseInt(raw, 10) : NaN;
-  // Rails needs no fallback: `show_variable` always answers on a live MySQL
-  // connection. The MySQL default stands in for a host without one.
-  const resolved = Number.isNaN(parsed) ? 16_777_216 : parsed;
-  if (host) host._maxAllowedPacket = resolved;
-  return resolved;
+export async function maxAllowedPacket(this: MaxAllowedPacketHost): Promise<number> {
+  // `show_variable` always answers on a live MySQL connection, so Rails needs
+  // no fallback; a host that cannot answer surfaces at the raise site in
+  // `is_max_allowed_packet_reached?` rather than silently combining forever.
+  return (this._maxAllowedPacket ??= Number(await this.showVariable("max_allowed_packet")));
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -689,30 +689,6 @@ export class PostgreSQLAdapter
     if (minMessages !== undefined && typeof minMessages !== "string") {
       throw new TypeError(`minMessages must be a string, got ${typeof minMessages}`);
     }
-    if (variables !== null && variables !== undefined) {
-      if (typeof variables !== "object" || Array.isArray(variables)) {
-        throw new TypeError("variables must be a plain object");
-      }
-      const variablesPrototype = Object.getPrototypeOf(variables);
-      if (variablesPrototype !== Object.prototype && variablesPrototype !== null) {
-        throw new TypeError("variables must be a plain object");
-      }
-      for (const [key, val] of Object.entries(variables)) {
-        if (!/^[a-zA-Z_][a-zA-Z0-9_.]*$/.test(key)) {
-          throw new Error(`Invalid PostgreSQL session variable name: ${JSON.stringify(key)}`);
-        }
-        if (
-          val !== null &&
-          typeof val !== "string" &&
-          typeof val !== "boolean" &&
-          typeof val !== "number"
-        ) {
-          throw new TypeError(
-            `variables[${JSON.stringify(key)}] must be string | number | boolean | null, got ${typeof val}`,
-          );
-        }
-      }
-    }
     this._minMessages = minMessages ?? "warning";
     const userGetTypeParser = (
       pgConfig.types as { getTypeParser?: (oid: number, format?: string) => unknown } | undefined

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -258,7 +258,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
       const opts: string[] = [];
       if (ec.where) opts.push(`where: ${JSON.stringify(ec.where)}`);
       if (ec.using) opts.push(`using: ${JSON.stringify(ec.using)}`);
-      if (ec.deferrable !== undefined) opts.push(`deferrable: ${JSON.stringify(ec.deferrable)}`);
+      if (ec.deferrable) opts.push(`deferrable: ${JSON.stringify(ec.deferrable)}`);
       if (ec.exportNameOnSchemaDump()) opts.push(`name: ${JSON.stringify(ec.name)}`);
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
       return `  await ctx.addExclusionConstraint(${JSON.stringify(stripped)}, ${JSON.stringify(ec.expression)}${optStr});`;
@@ -285,7 +285,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
       const opts: string[] = [];
       if (uc.nullsNotDistinct)
         opts.push(`nullsNotDistinct: ${JSON.stringify(uc.nullsNotDistinct)}`);
-      if (uc.deferrable !== undefined) opts.push(`deferrable: ${JSON.stringify(uc.deferrable)}`);
+      if (uc.deferrable) opts.push(`deferrable: ${JSON.stringify(uc.deferrable)}`);
       if (uc.exportNameOnSchemaDump()) opts.push(`name: ${JSON.stringify(uc.name)}`);
       const optStr = opts.length > 0 ? `, { ${opts.join(", ")} }` : "";
       return `  await ctx.addUniqueConstraint(${JSON.stringify(stripped)}, ${JSON.stringify(uc.column)}${optStr});`;

--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -691,10 +691,23 @@ async function _loadAdapter(name: string): Promise<new (arg: unknown) => Databas
 }
 
 /**
+ * Mirrors: ActiveRecord::ConnectionHandling::DEFAULT_ENV
+ * (connection_handling.rb:7) — `-> { RAILS_ENV.call || "default_env" }`.
+ * `DatabaseConfigurations.currentEnv()` is trails' `RAILS_ENV` chain plus that
+ * literal fallback; the three other Rails `DEFAULT_ENV.call` sites
+ * (`database_configurations.rb:188`, `database_config.rb:91`,
+ * `migration.rb:1341`) still reach it through `currentEnv()` because a static
+ * import edge from those modules back into this one would close a module-eval
+ * cycle.
+ */
+export const DEFAULT_ENV = (): string => DatabaseConfigurations.currentEnv();
+
+/**
  * @missingRailsCall call — PERMANENT: Rails defaults the argument through
- *   `DEFAULT_ENV.call` (connection_handling.rb:51); the port's `configOrEnv ===
- *   undefined` arm routes to `autoConnect` (connection-handling.ts:770), which
- *   resolves the environment itself.
+ *   `DEFAULT_ENV.call` (connection_handling.rb:51). `DEFAULT_ENV` is now ported
+ *   at the Rails name, but Ruby needs `Proc#call` to invoke a Proc where JS
+ *   invokes the function value directly — `DEFAULT_ENV()` IS `DEFAULT_ENV.call`,
+ *   so there is no `call` identifier left for the comparator to match.
  * @missingRailsCall connection_handler — PERMANENT: Verified per-site (RFC
  *   0106): `connection_handler.establish_connection(...)`
  *   (`connection_handling.rb:53`) — the TS `establishConnection` resolves the
@@ -742,7 +755,7 @@ export async function establishConnection(
   // resolved object then goes to the handler verbatim, so the pool stores it
   // as-is instead of rebuilding a fresh UrlConfig/HashConfig. tz validation
   // and buildAdapterArg live inside establishWithDbConfig.
-  configOrEnv ??= DatabaseConfigurations.currentEnv();
+  configOrEnv ??= DEFAULT_ENV();
   const dbConfig = modelClass.resolveConfigForConnection(configOrEnv);
   await establishWithDbConfig(modelClass, dbConfig);
 }

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -481,9 +481,9 @@ describe("SchemaDumperTest", () => {
       { using: "gist", name: "test_schema_exclusion_date_overlap" },
     );
     const output = await SchemaDumper.dumpTableSchema(testAdapter, "test_schema_exclusion");
-    expect(output).toContain("addExclusionConstraint");
-    expect(output).toContain("test_schema_exclusion_date_overlap");
-    expect(output).toContain("daterange(start_date, end_date) WITH &&");
+    expect(output).toContain(
+      'await ctx.addExclusionConstraint("test_schema_exclusion", "daterange(start_date, end_date) WITH &&", { using: "gist", name: "test_schema_exclusion_date_overlap" });',
+    );
   });
   itIfSupports("unique_constraints", "schema dumps unique constraints", async () => {
     const testAdapter = Base.connection;
@@ -499,10 +499,12 @@ describe("SchemaDumperTest", () => {
       name: "test_schema_unique_position_2_nnd",
     });
     const output = await SchemaDumper.dumpTableSchema(testAdapter, "test_schema_unique");
-    expect(output).toContain("addUniqueConstraint");
-    expect(output).toContain("test_schema_unique_position_1");
-    expect(output).toContain("test_schema_unique_position_2_nnd");
-    expect(output).toContain("nullsNotDistinct: true");
+    expect(output).toContain(
+      'await ctx.addUniqueConstraint("test_schema_unique", ["position_1"], { name: "test_schema_unique_position_1" });',
+    );
+    expect(output).toContain(
+      'await ctx.addUniqueConstraint("test_schema_unique", ["position_2"], { nullsNotDistinct: true, name: "test_schema_unique_position_2_nnd" });',
+    );
   });
   itIfSupports(
     "unique_constraints",

--- a/packages/activerecord/src/strict-loading-sync-reader.trails.test.ts
+++ b/packages/activerecord/src/strict-loading-sync-reader.trails.test.ts
@@ -106,7 +106,6 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
     ship.strictLoadingBang();
     const holder = (ship as any).association("developer");
     holder.setTarget(null);
-    holder._loadedFromPreload = true;
     expect(() => (ship as any).developer).not.toThrow();
     expect((ship as any).developer).toBeNull();
   });

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -30,7 +30,6 @@ import { Interest } from "./test-helpers/models/interest.js";
 function seedPreloadedHolder(record: Base, name: string, value: unknown): void {
   const holder = (record as any).association(name);
   holder.setTarget(value);
-  holder._loadedFromPreload = true;
 }
 
 async function withStrictLoadingByDefault<T>(model: typeof Base, fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
Bundle of five RFC 0112 / RFC 0119 convergence stories.

### `retire-explicit-target-and-loaded-from-preload-fields` (RFC 0112)

`Association#_explicitTarget` and `Association#_loadedFromPreload` were
trails-only fields; Rails' `Association` distinguishes the same cases with
`@loaded` alone (`association.rb:57-59`, `loaded?` / `loaded!`).

- Both fields, their `reset` clears, and all six write sites are gone.
- `_preloadedHolderTarget` gates on Rails' own pair instead: `loaded?`
  (`association.rb:81-83`) and `@stale_state && stale_target?`
  (`association.rb:97-99`) — the exact condition `load_target`
  (`association.rb:189-190`) re-queries on. `_loadedFromPreload` was standing in
  for the staleness half: `nested has many through association with unpersisted
  parent instance` re-assigns `post.author` and needs the through target to
  re-query, which Rails gets from `stale_target?` and trails was getting from
  "this load did not come from a preloader".
- `_loadedSingularTarget` had no callers left once its `_explicitTarget` arm
  went, so it is deleted rather than left as an alias.
- `setInverseInstance` / `setInverseInstanceFromQueries` are back to Rails'
  single `inversed_from` (`association.rb:132-137`, `:139-144`).
- `JoinDependency`'s collection-push arm now marks the proxy with `loaded!`,
  the way `construct` does; the two other sites already went through
  `target=`, which calls `loaded!` itself.

Verified green on SQLite and PostgreSQL: `associations/**`, `strict-loading`,
`strict-loading-sync-reader`, `autosave-association`, `nested-attributes`,
`validations`, `inverse-associations`, `eager`, `cascaded-eager-loading`, the
`preloader/**` suites — 122 files / 2659 tests on SQLite, 119 / 2610 on a local
`postgres:17`. MySQL/MariaDB via CI.

### `converge-establish-connection-default-env-funnel` (RFC 0119)

`DEFAULT_ENV` is ported at the Rails name (`connection_handling.rb:7`) and
`establishConnection` defaults through it (`:51`). The trails-only `autoConnect`
arm this story also named was already gone from `main`; the single funnel
through `resolveConfigForConnection` is what was there to build on.

The absorbed half — routing `database_configurations.rb:188`,
`database_config.rb:91` and `migration.rb:1341` through `DEFAULT_ENV` and
deleting `_defaultEnvGetter` — is **not** in this PR. A static import edge from
those modules back into `connection-handling.ts` closes a module-eval cycle
through `class HashConfig extends DatabaseConfig`, which is precisely what
`_setDefaultEnvGetter` was introduced to avoid; converging it needs a
module-graph decision plus dist-level entry-module verification. Filed with that
context as `route-remaining-default-env-call-sites` (RFC 0119).

The `@missingRailsCall call` receipt survives with a corrected reason: Ruby
needs `Proc#call` where JS invokes the function value directly, so `DEFAULT_ENV()`
*is* `DEFAULT_ENV.call` and leaves no `call` identifier to match.

### `converge-max-allowed-packet-fallback` (RFC 0119)

`maxAllowedPacket` is Rails' single line
(`mysql/database_statements.rb:89-90`). The 16 MiB fallback and the
receiver-dispatch branch in `isMaxAllowedPacketReached` are deleted, and
`MaxAllowedPacketHost` now requires both `showVariable` and `maxAllowedPacket`
so the test doubles exercise the real path. A host that cannot answer surfaces
at Rails' own raise site ("Fixtures set is too large") instead of silently
combining.

### `converge-pg-dumper-deferrable-truthiness` (RFC 0119)

Both `deferrable:` gates are truthiness checks, matching
`postgresql/schema_dumper.rb:51` and `:72`, so a non-deferrable constraint emits
no `deferrable:` at all (`schema_dumper_test.rb:250`).

`schema dumps unique constraints` / `schema dumps exclusion constraints` now
assert the full emitted line, pinning the absence of `deferrable: false`. Both
**fail on baseline** — confirmed against a local `postgres:17`:

```
+   await ctx.addUniqueConstraint("test_schema_unique", ["position_1"], { deferrable: false, name: "test_schema_unique_position_1" });
```

### `converge-pg-session-variables-config-validation` (RFC 0119)

The `PostgreSQLAdapter` constructor's `:variables` validation is deleted — all
three error classes and message strings. Rails interpolates the key straight
into `SET SESSION` and quotes only the value
(`postgresql_adapter.rb:977`, `:982-988`), so a bad key is the server's error,
not the adapter's. The five trails-only tests that existed solely to cover the
invented behaviour are removed with it.

### Gates

`pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls`, `pnpm parity:api:calls:args`
and `pnpm parity:api:extra --package activerecord` all green, with no new baseline rows.

Closes-story: retire-explicit-target-and-loaded-from-preload-fields
Closes-story: converge-establish-connection-default-env-funnel
Closes-story: converge-max-allowed-packet-fallback
Closes-story: converge-pg-dumper-deferrable-truthiness
Closes-story: converge-pg-session-variables-config-validation
