### PR TITLE
refactor(activerecord,activemodel): retire reconcileVirtualAttributes and the virtual-attribute flag (RFC 0115)

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -131,9 +131,9 @@ export function attribute(
   const typeProvided = typeName !== undefined;
   // Rails' `attribute(name, type = nil, default: (no_default = true), **options)`
   // (attribute_registration.rb:12) forwards `**options` straight to
-  // `resolve_type_name`; the two keys trails names explicitly — `default` and
-  // `virtual` — are consumed here, so only the rest reach it.
-  const { default: _default, virtual: _virtual, ...typeOptions } = options ?? {};
+  // `resolve_type_name`; `default`, the one key trails names explicitly, is
+  // consumed here, so only the rest reach it.
+  const { default: _default, ...typeOptions } = options ?? {};
   // attribute_registration.rb:14-15:
   //   type = resolve_type_name(type, **options) if type.is_a?(Symbol)
   //   type = hook_attribute_type(name, type) if type

--- a/packages/activemodel/src/attributes.trails.test.ts
+++ b/packages/activemodel/src/attributes.trails.test.ts
@@ -5,7 +5,7 @@ describe("Attributes#attribute_names", () => {
   class User extends Model {
     static {
       this.attribute("name", "string");
-      this.attribute("token", "string", { virtual: true });
+      this.attribute("token", "string");
     }
   }
 

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -67,7 +67,6 @@ export function _writeAttribute(
  */
 export interface AttributeOptions {
   default?: unknown;
-  virtual?: boolean;
   limit?: number | null;
   /**
    * PG type modifiers, forwarded to the registry as Rails' `**options` are:

--- a/packages/activerecord/src/adapter-connection.trails.test.ts
+++ b/packages/activerecord/src/adapter-connection.trails.test.ts
@@ -47,6 +47,12 @@ class LifecycleTestAdapter extends AbstractAdapter {
     return this._connected;
   }
 
+  // `load_schema!` reaches this via `schema_cache.data_source_exists?`; without
+  // it the abstract `data_source_sql` raises (schema_statements.rb).
+  override async dataSources(): Promise<string[]> {
+    return [];
+  }
+
   override reconnectBang(opts: { restoreTransactions?: boolean } = {}): Promise<void> {
     this._connected = true;
     this._connection = this;

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -445,17 +445,9 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     const first = Firm.columnsHash();
     expect(Firm.columnsHash()).toBe(first);
 
-    const cache = Company.connection.internalSchemaCache as unknown as {
-      clearDataSourceCacheBang(conn: unknown, name: string): void;
-      getCachedColumnsHash(name: string): unknown;
-    };
-    cache.clearDataSourceCacheBang(null, "companies");
-    expect(cache.getCachedColumnsHash("companies")).toBeUndefined();
     expect(Object.prototype.hasOwnProperty.call(Company, "_schemaLoaded")).toBe(true);
 
-    // The async load re-warms the cleared cache; before re-reflecting it drops
-    // the stale view the way Rails nils its schema ivars — recursively, so the
-    // subclass memo below goes with it (model_schema.rb:553-568).
+    await Company.resetColumnInformation();
     await Company.loadSchema();
 
     expect(Company.columnNames()).toContain("rating");

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -10,7 +10,7 @@ import { Base, SubclassNotFound, UnknownPrimaryKey, registerModel } from "./inde
 import { registerSubclass } from "./inheritance.js";
 import { Type } from "@blazetrails/activemodel";
 import { fixtures } from "./test-fixtures.js";
-import { reconcileVirtualAttributes, loadSchema } from "./model-schema.js";
+import { loadSchema } from "./model-schema.js";
 import { Firm } from "./test-helpers/models/company.js";
 
 describe("_applyScopeAttributes — scoping initializeInternalsCallback", () => {
@@ -453,20 +453,10 @@ describe("ignored columns follow Rails' value-keyed attribute set (trails)", () 
     expect(cache.getCachedColumnsHash("companies")).toBeUndefined();
     expect(Object.prototype.hasOwnProperty.call(Company, "_schemaLoaded")).toBe(true);
 
-    await (reconcileVirtualAttributes as (this: unknown, reflect: boolean) => Promise<void>).call(
-      Company,
-      true,
-    );
-
-    const base = Company as unknown as {
-      _columnsHash?: unknown;
-      _columns?: unknown;
-      _schemaLoaded?: boolean;
-    };
-    expect(base._schemaLoaded).toBe(false);
-    expect(base._columnsHash).toBeUndefined();
-    expect(base._columns).toBeUndefined();
-    expect(Object.prototype.hasOwnProperty.call(Company, "_columnNamesMemo")).toBe(false);
+    // The async load re-warms the cleared cache; before re-reflecting it drops
+    // the stale view the way Rails nils its schema ivars — recursively, so the
+    // subclass memo below goes with it (model_schema.rb:553-568).
+    await Company.loadSchema();
 
     expect(Company.columnNames()).toContain("rating");
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -852,29 +852,6 @@ export class Base extends Model {
 
   /** @internal */
   declare static _registryKeys: string[];
-  /**
-   * One-shot guard for virtual-attribute reconciliation (model-schema.ts
-   * reconcileVirtualAttributes). Cleared on `attribute()` and
-   * `resetColumnInformation` so a re-declare/reset re-runs it.
-   * @internal
-   */
-  declare static _virtualAttributesReconciled?: boolean;
-
-  /**
-   * Names declared with trails' `attribute(..., { virtual: true })` — an
-   * attribute with no backing DB column. Rails has no such option: its
-   * `columns_hash` is a DB read, so a declared-but-column-less attribute is
-   * simply absent from it. trails synthesizes `columnsHash` for table-less
-   * models, so it has to be told which declarations are not columns.
-   * Copy-on-write per class, like every other inherited registry here.
-   *
-   * Retired together with the virtual flag by RFC 0115
-   * `retire-virtual-attribute-reconciliation`.
-   *
-   * @internal
-   */
-  declare static _virtualAttributes?: Set<string>;
-
   /** Mirrors: ActiveRecord.writing_role */
   static writingRole = WRITING_ROLE;
   /** Mirrors: ActiveRecord.reading_role */
@@ -1165,19 +1142,9 @@ export class Base extends Model {
       typeName = undefined;
     }
     super.attribute(name, typeName, options);
-    if (options?.virtual) {
-      const virtual = Object.prototype.hasOwnProperty.call(this, "_virtualAttributes")
-        ? this._virtualAttributes!
-        : (this._virtualAttributes = new Set(this._virtualAttributes));
-      virtual.add(name);
-    }
     // Rails' `attribute` ends in `reload_schema_from_cache`, which nils
     // `@attribute_names` recursively.
     ModelSchema.clearAttributeNamesMemo(this as never);
-    // A newly declared attribute may be virtual (no DB column); force the next
-    // ensureSchemaLoaded to re-run virtual reconciliation (model-schema.ts
-    // reconcileVirtualAttributes) instead of skipping it via the one-shot guard.
-    this._virtualAttributesReconciled = false;
     // If we just defined an "id" accessor on a subclass prototype, remove it
     // so Base.prototype.id (which handles CPK) is used instead.
     if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
@@ -1349,50 +1316,20 @@ export class Base extends Model {
   }
 
   /**
-   * Lazily reflect the schema from the configured adapter the first time
-   * the query/persistence path needs it, so consumers can drop the
-   * explicit `loadSchema` step. Only reflects when the model has no
-   * *concrete* (non-virtual) attribute definitions yet — a model that
-   * declared a real `attribute()` or already reflected once knows its schema,
-   * so this is a no-op for it (matching the pre-lazy-reflection behavior and
-   * avoiding a needless schema round-trip on the hot query path). A model
-   * whose only declared attributes are virtual (Rails' `attribute :foo` on an
-   * ignored column) still reflects, since it relies on the schema for its real
-   * columns. Idempotent.
+   * Reflect the schema from the configured adapter the first time the
+   * query/persistence path needs it — the async analogue of Rails' synchronous
+   * `method_missing` schema load (activemodel/attribute_methods.rb:474-486).
+   * Every declaration reaching here is a user `attribute()`; whether it also
+   * names a real column is decided by `columns_hash`, which is DB-sourced
+   * (model_schema.rb:437-441), so nothing has to be classified first.
    *
-   * Async analogue of Rails' synchronous `method_missing` schema load —
-   * queries are already async, so awaiting here is fully contained. The
-   * residual gap is attribute access on a record that was never queried
-   * and never loaded (e.g. `new User().handle` before any DB hit), which
-   * a getter can't await without wrapping instances in a `Proxy`.
+   * The residual gap is attribute access on a record that was never queried and
+   * never loaded (e.g. `new User().handle` before any DB hit), which a getter
+   * can't await without wrapping instances in a `Proxy`.
    *
    * @internal
    */
   static ensureSchemaLoaded(this: typeof Base): Promise<void> {
-    // A model whose declared attributes are all virtual (e.g. Rails'
-    // `attribute :last_name` on an ignored column) still needs to reflect its
-    // real DB columns from the schema cache — the sync fallback in loadSchema
-    // would otherwise synthesize a columnsHash containing only the virtual
-    // attrs and mark the model schema-loaded, hiding every real column.
-    //
-    // The pending-modification queue holds user `attribute()` declarations only
-    // — reflected columns live in `columns_hash` — so a concrete (non-virtual)
-    // declaration means the model spelled its own schema out and needs no DB
-    // reflection. Enum-declared attrs (registered by `_enum` via
-    // `this.attribute()`) must NOT block reflection: they are type overlays,
-    // not full schema declarations, and the model still needs the DB to
-    // discover its other columns.
-    const enumNames = (this as any)._enums as Map<string, unknown> | undefined;
-    const virtual = this._virtualAttributes;
-    for (const name of ModelSchema.declaredAttributeNames.call(this as never)) {
-      if (!virtual?.has(name) && !enumNames?.has(name)) {
-        // Some declared attributes may be virtual (no backing DB column).
-        // Rails' `column_names` is always DB-sourced, so reconcile against the
-        // real columns and flag those as virtual — keeping `columnNames()`
-        // correct without a full re-reflection. One-shot.
-        return (ModelSchema.reconcileVirtualAttributes as () => Promise<void>).call(this);
-      }
-    }
     return this.loadSchema();
   }
 

--- a/packages/activerecord/src/inheritance.trails.test.ts
+++ b/packages/activerecord/src/inheritance.trails.test.ts
@@ -34,7 +34,7 @@ describe("descends_from_active_record? column test", () => {
   it("a virtual type attribute is not an inheritance column", () => {
     class VirtualTypeAuthor extends Author {
       static {
-        this.attribute("type", "string", { virtual: true } as never);
+        this.attribute("type", "string");
       }
     }
 
@@ -68,7 +68,7 @@ describe("descends_from_active_record? on a cold model", () => {
   it("a virtual type attribute on an unreflected model is not an inheritance column", () => {
     class ColdVirtualTypeAuthor extends Author {
       static {
-        this.attribute("type", "string", { virtual: true } as never);
+        this.attribute("type", "string");
       }
     }
 

--- a/packages/activerecord/src/model-schema.trails.test.ts
+++ b/packages/activerecord/src/model-schema.trails.test.ts
@@ -4,7 +4,6 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { Base } from "./index.js";
-import { reconcileVirtualAttributes } from "./model-schema.js";
 
 import { fixtures } from "./test-fixtures.js";
 import { assertNoQueriesMatch } from "./testing/query-assertions.js";
@@ -12,21 +11,20 @@ import { assertNoQueriesMatch } from "./testing/query-assertions.js";
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 // A model declared entirely via `attribute()` under AR_NO_AUTO_SCHEMA never
-// reflects its schema, so the shared schema cache is cold. The write path's
-// `reconcileVirtualAttributes(reflect: true)` resolves the real columns to flag
-// virtual attributes; doing so through the shared schema cache (rather than a
-// raw `connection.columns`) memoizes the reflection so later cold-cache work is
-// query-free. There is no upstream Rails counterpart — this guards a trails-only
-// cold-cache write-path optimization.
-describe("virtual attribute reconciliation warms the schema cache", () => {
+// reflects its schema, so the shared schema cache is cold and `load_schema!`
+// falls back to a `columns_hash` synthesized from those declarations alone.
+// Rails never has this state — `columns_hash` is a blocking DB read
+// (model_schema.rb:437-441) — so the async load has to drop the synthesized
+// view once the cache is warm. There is no upstream Rails counterpart.
+describe("the async schema load warms the shared cache and replaces a synthesized view", () => {
   fixtures([]);
-  it("populates the shared schema cache when reconciling on a cold cache", async () => {
+  it("populates the shared schema cache when loading on a cold cache", async () => {
     class Post extends Base {
       static {
         this.attribute("id", "integer");
         this.attribute("title", "string");
         this.attribute("body", "text");
-        this.attribute("virtual_field", "string", { default: "v" });
+        this.attribute("declared_field", "string", { default: "v" });
       }
     }
     const conn = Post.connection;
@@ -35,17 +33,17 @@ describe("virtual attribute reconciliation warms the schema cache", () => {
 
     await Post.create({ title: "hello", body: "b" });
 
-    // reconcile reflected through the shared cache, so it is now warm
+    // the load reflected through the shared cache, so it is now warm
     expect(conn.internalSchemaCache.getCachedColumnsHash("posts")).toBeDefined();
   });
 
-  it("warm-cache reconciliation invalidates a columnNames memo taken off the synthesized fallback", async () => {
+  it("a warm-cache load invalidates a columnNames memo taken off the synthesized fallback", async () => {
     class Post extends Base {
       static {
         this.attribute("id", "integer");
         this.attribute("title", "string");
         this.attribute("body", "text");
-        this.attribute("virtual_field", "string", { default: "v" });
+        this.attribute("declared_field", "string", { default: "v" });
       }
     }
     const conn = Post.connection;
@@ -56,20 +54,19 @@ describe("virtual attribute reconciliation warms the schema cache", () => {
     const cold = Post.columnNames();
     expect(cold).not.toContain("tags_count");
 
-    // The write path's reconciliation warms the shared cache and clears
-    // `_schemaLoaded` — the memo must be dropped with it, not keep serving the
-    // pre-warm synthesized list until some later `loadSchema` re-reflects.
-    await reconcileVirtualAttributes.call(Post as never, true);
+    // The async load warms the shared cache and reloads from it — the memo must
+    // be dropped with the synthesized view, not keep serving the pre-warm list.
+    await Post.loadSchema();
     expect(Post.columnNames()).toContain("tags_count");
   });
 
-  it("a second save on a cold-cache virtual-attribute model issues no schema-introspection query", async () => {
+  it("a second save on a cold-cache declared-attribute model issues no schema-introspection query", async () => {
     class Post extends Base {
       static {
         this.attribute("id", "integer");
         this.attribute("title", "string");
         this.attribute("body", "text");
-        this.attribute("virtual_field", "string", { default: "v" });
+        this.attribute("declared_field", "string", { default: "v" });
       }
     }
     const conn = Post.connection;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -299,7 +299,7 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   // not `isCached` (which checks `_columns`): a populated `_columns` without a
   // matching `_columnsHash` entry would otherwise pass the guard, return
   // undefined here, and fall through to the synthesized branch — re-leaking
-  // virtual attributes the warm was meant to exclude.
+  // declared-but-columnless attributes the warm was meant to exclude.
   if (cache && typeof cache.getCachedColumnsHash === "function") {
     const cached = cache.getCachedColumnsHash(table);
     if (cached) {
@@ -313,15 +313,12 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
     }
   }
 
-  // Synthesized fallback: filter ignoredColumns and virtual attrs to match
-  // loadSchema's fallback and Rails behavior (virtual attrs are not DB columns).
+  // Synthesized fallback: filter ignoredColumns to match loadSchema's fallback.
   const ignored = new Set(this.ignoredColumns ?? []);
-  const virtual = this._virtualAttributes ?? new Set<string>();
   const declared = declaredAttributes(this as unknown as SchemaHost);
   const result: Record<string, ColumnLike> = {};
   for (const name of declared.keys()) {
     if (ignored.has(name)) continue;
-    if (virtual.has(name)) continue;
     result[name] = synthesizedColumn(name, declared.getAttribute(name)) as ColumnLike;
   }
   return result;
@@ -376,17 +373,6 @@ function applyDeclarations(cls: SchemaHost, attributeSet: AttributeSet): void {
  */
 export function declaredAttributeNames(this: SchemaHost): string[] {
   return declaredAttributes(this).keys();
-}
-
-/**
- * The own, copy-on-write virtual-attribute name set for `host` — the same
- * per-class fork `attribute()` does, so a subclass never mutates its parent's.
- */
-function ownVirtualAttributes(host: SchemaHost): Set<string> {
-  if (!Object.hasOwn(host, "_virtualAttributes")) {
-    host._virtualAttributes = new Set(host._virtualAttributes);
-  }
-  return host._virtualAttributes as Set<string>;
 }
 
 /**
@@ -634,7 +620,6 @@ export interface SchemaHost {
   _abstractClass?: boolean;
   _ignoredColumns?: string[];
   _protectedEnvironments?: string[];
-  _virtualAttributes?: Set<string>;
   _defaultAttributes(): AttributeSet;
   _columnsHash?: Record<string, unknown>;
   _columns?: any[];
@@ -643,7 +628,6 @@ export interface SchemaHost {
   _yamlEncoder?: YAMLEncoder;
   attributeTypes(): Record<string, any>;
   _schemaLoaded?: boolean;
-  _virtualAttributesReconciled?: boolean;
   /** Rails' `@column_names` memo (model_schema.rb:478-480). @internal */
   _columnNamesMemo?: { names: readonly string[] };
   connection: any;
@@ -1000,7 +984,6 @@ export function reloadSchemaFromCache(this: SchemaHost): void {
   this._returningColumnsForInsertCache = undefined;
   this._attributesBuilder = undefined;
   this._schemaLoaded = false;
-  this._virtualAttributesReconciled = false;
   // ActiveRecord::Attributes overrides `reload_schema_from_cache` to call
   // `reset_default_attributes!` before `super` (attributes.rb:268-271), which
   // nils `@attribute_types` as well as `@default_attributes`
@@ -1114,10 +1097,8 @@ function loadSchemaBangAnchor(this: SchemaHost): void {
   if (!ownSchemaMemo(this, "_columnsHash") && declaredNames.length > 0) {
     const hash: Record<string, unknown> = {};
     const ignored = new Set(this._ignoredColumns ?? []);
-    const virtual = this._virtualAttributes ?? new Set<string>();
     for (const name of declaredNames) {
       if (ignored.has(name)) continue;
-      if (virtual.has(name)) continue;
       hash[name] = synthesizedColumn(name, declared.getAttribute(name));
     }
     this._columnsHash = hash;
@@ -1261,13 +1242,36 @@ function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if ((this as any).abstractClass) return;
-  let startingAdapter: SchemaHost["connection"] | undefined;
+  // Rails reflects through `schema_cache`, which reads the POOL
+  // (model_schema.rb:591) and never checks a connection out permanently.
+  // `reflectionAdapter`'s last resort is `leaseConnectionSync`, which does —
+  // tripping `permanent_connection_checkout = :deprecated | :disallowed` on
+  // every save — so this async load takes its connection the way Rails' block
+  // form does — using an already-threaded or directly-assigned adapter first,
+  // exactly as `reflectionAdapter` does.
+  const threaded =
+    threadedConnectionFor(this as unknown as typeof Base) ??
+    (this as unknown as { _adapter?: SchemaHost["connection"] })._adapter;
+  if (threaded) return loadSchemaFromConnection.call(this, threaded);
   try {
-    startingAdapter = reflectionAdapter(this);
+    return await withConnection.call<
+      typeof Base,
+      [(conn: SchemaHost["connection"]) => Promise<void>],
+      Promise<void>
+    >(this as unknown as typeof Base, async (conn) => {
+      if (!conn) return;
+      await loadSchemaFromConnection.call(this, conn);
+    });
   } catch {
-    startingAdapter = undefined;
+    // `connection_pool` throws for a pool-less model; Ruby's is always there.
+    return;
   }
-  if (!startingAdapter) return;
+}
+
+async function loadSchemaFromConnection(
+  this: SchemaHost,
+  startingAdapter: SchemaHost["connection"],
+): Promise<void> {
   const adapterOwner = this;
   const cache = startingAdapter.internalSchemaCache;
   if (!cache) return;
@@ -1311,129 +1315,23 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   }
   if (currentAdapter !== startingAdapter) return;
 
+  // A model that reflected while the shared cache was still cold got
+  // `loadSchemaBangAnchor`'s synthesized `columns_hash` — built from its
+  // declared attributes alone — and was stamped `_schemaLoaded` on it. The
+  // cache is warm now, so drop that view (and every subclass's, which is what
+  // `reload_schema_from_cache` recurses for) before re-reflecting; otherwise
+  // the synthesized `column_names` outlives the real columns it was standing in
+  // for. Mirrors Rails nil'ing the schema ivars ahead of a fresh load
+  // (model_schema.rb:553-568).
+  if (ownSchemaMemo(this, "_schemaLoaded")) {
+    reloadSchemaFromCache.call(this);
+  }
+
   // The cache is warm now, so `load_schema!` — the one body, chain and all —
   // reflects from it exactly as it does on the sync path
   // (model_schema.rb:534-546 puts the cache-vs-adapter distinction inside
   // `schema_cache.columns_hash`, not in a second `load_schema!`).
   loadSchemaBang.call(this);
-}
-
-/**
- * Real column names from the already-populated schema cache only — never issues
- * a query. Returns null when the table's columns aren't cached yet.
- */
-function cachedColumnNames(host: SchemaHost): Set<string> | null {
-  // Resolved through `cachedColumnsHash`'s connection-free probe rather than
-  // `reflectionAdapter`, whose last resort is `leaseConnectionSync` — a
-  // permanent checkout, which this cache-only read must never take.
-  const cached = cachedColumnsHash(host as unknown as typeof Base);
-  if (cached) return new Set(Object.keys(cached));
-  return null;
-}
-
-/**
- * Real column names, reflecting from the database when the schema cache is cold.
- * May issue a schema-introspection query, so only the write path uses it (reads
- * must not introduce queries — see the query-cache contract). Populates the
- * shared schema cache so subsequent lookups are warm. Returns null when the
- * columns can't be determined (no connection/schema, or reflection failed).
- */
-async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null> {
-  const cached = cachedColumnNames(host);
-  if (cached) return cached;
-  const table = host.tableName;
-  if (!table) return null;
-  try {
-    // Scoped through `with_connection`, not `reflectionAdapter` — the latter's
-    // last resort is `leaseConnectionSync`, which makes the checkout permanent
-    // and so trips `permanent_connection_checkout = :deprecated | :disallowed`
-    // on every save. `withConnection` also threads the connection through
-    // `currentQueryConnection`, so the cache reads below see it.
-    return await withConnection.call<
-      typeof Base,
-      [(conn: any) => Promise<Set<string> | null>],
-      Promise<Set<string> | null>
-    >(host as unknown as typeof Base, async (conn: any) => {
-      if (!conn) return null;
-      // Resolve columns through the shared schema cache so the reflection is
-      // memoized (`getCachedColumnsHash` warms after this), making subsequent
-      // cold-cache writes reconcile query-free. Mirror loadSchemaFromCache's
-      // FakePool handling so a lone-connection pool (SQLite :memory:, size 1)
-      // doesn't deadlock on withConnection.
-      const cache = conn.internalSchemaCache;
-      if (cache && typeof cache.columnsHash === "function") {
-        const pool = new FakePool(conn);
-        const hash = (await cache.columnsHash(pool, table)) as Record<string, unknown> | undefined;
-        if (hash) {
-          const names = Object.keys(hash);
-          if (names.length > 0) {
-            // The shared cache is now warm. A model that synthesized a minimal
-            // columnsHash while the cache was cold (loadSchema's fallback set
-            // `_schemaLoaded` with only the declared attrs) would otherwise keep
-            // that stale view forever — leaving `columnNames()` reading the warm
-            // cache's real columns while `attributeNames()` stays minimal, so
-            // reload it the way Rails does (model_schema.rb:553-568) and let the
-            // next `loadSchema` re-reflect from the warm cache.
-            if (ownSchemaMemo(host, "_schemaLoaded")) {
-              reloadSchemaFromCache.call(host);
-            }
-            return new Set(names);
-          }
-        }
-        return null;
-      }
-      // No schema cache available — fall back to a raw introspection query.
-      if (typeof conn.columns !== "function") return null;
-      const cols = (await conn.columns(table)) as Array<{ name: string }> | undefined;
-      if (Array.isArray(cols) && cols.length > 0) {
-        return new Set(cols.map((c) => c.name));
-      }
-      return null;
-    });
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Flag any user-declared attribute that has no backing DB column as virtual.
- *
- * `column_names` in Rails is always `columns.map(&:name)` — purely DB-sourced —
- * so a user attribute declared via `attribute()` that isn't a real column never
- * appears in it (model_schema.rb#column_names; attribute_methods.rb
- * #attributes_for_create/#attributes_for_update intersect with it). In trails,
- * `ensureSchemaLoaded` short-circuits once a model declares its own attribute(),
- * leaving the synthesized columnsHash unable to tell a virtual attribute from a
- * real column. Reconcile against the table's actual columns here so the existing
- * `virtual` flag — already honored by `columnNames`/`columnsHash`/
- * `attributesForCreate` — excludes them. Schema-sourced defs and real columns
- * are left untouched (types included — this only sets the flag). The decision is
- * purely positional — a user attribute is virtual iff it has no DB column — so
- * it reclassifies in BOTH directions: an attribute that gains a real column on a
- * later reflection (e.g. after `resetColumnInformation`) is unflagged. The
- * one-shot guard is cleared whenever the schema caches or attribute set change
- * (`resetColumnInformation`, `attribute()`), so a reset/re-declare re-runs.
- *
- * `reflect` controls whether a cold schema cache may trigger an introspection
- * query: the write path (persistence) passes `true`; the generic read path
- * (`ensureSchemaLoaded`) passes `false` so a query is never issued on reads —
- * Rails likewise does not re-introspect on a cached read (the residual cold-read
- * gap is the documented sync/async limitation). With `reflect: false` and a cold
- * cache this is a no-op that leaves the guard unset, so a later write reconciles.
- *
- * @internal
- */
-export async function reconcileVirtualAttributes(this: SchemaHost, reflect = false): Promise<void> {
-  const host = this;
-  if (ownSchemaMemo(host, "_virtualAttributesReconciled")) return;
-  const real = reflect ? await reflectColumnNames(host) : cachedColumnNames(host);
-  if (!real) return;
-  const virtual = ownVirtualAttributes(host);
-  for (const name of declaredAttributes(host).keys()) {
-    if (real.has(name)) virtual.delete(name);
-    else virtual.add(name);
-  }
-  host._virtualAttributesReconciled = true;
 }
 
 /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1248,13 +1248,6 @@ function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void
  * pool to scope against and skips it, as does a pool-less model, whose
  * `connection_pool` throws where Ruby's always answers.
  *
- * `load_schema!` re-reflects even when `@schema_loaded` is already set, because
- * the flag may have been stamped on `loadSchemaBangAnchor`'s synthesized
- * `columns_hash` — the declared attributes alone, latched while this cache was
- * still cold. The cache is warm by then, so the stale view is dropped first,
- * recursively (model_schema.rb:553-568), which is what rebuilds an STI
- * subclass's own memo.
- *
  * @internal
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
@@ -1314,10 +1307,6 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
     currentAdapter = undefined;
   }
   if (currentAdapter !== startingAdapter) return;
-
-  if (ownSchemaMemo(this, "_schemaLoaded")) {
-    reloadSchemaFromCache.call(this);
-  }
 
   // The cache is warm now, so `load_schema!` — the one body, chain and all —
   // reflects from it exactly as it does on the sync path

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1238,40 +1238,40 @@ function applyColumnsHash(host: SchemaHost, hash: Record<string, unknown>): void
  * concern overrides (counter_cache.rb:186-195, encryptable_record.rb:126-130)
  * run over a real anchor.
  *
+ * Rails' `schema_cache` is a POOL read (`load_schema!`, model_schema.rb:591) and
+ * never checks a connection out permanently, so the warm runs inside a
+ * `with_connection` scope: `reflectionAdapter`'s last resort is
+ * `leaseConnectionSync`, whose lease is permanent and trips
+ * `permanent_connection_checkout = :deprecated | :disallowed` on every save. The
+ * re-entry is the scope — inside it the connection is threaded, so the guard is
+ * false and the body runs once. A model with a directly-assigned adapter has no
+ * pool to scope against and skips it, as does a pool-less model, whose
+ * `connection_pool` throws where Ruby's always answers.
+ *
+ * `load_schema!` re-reflects even when `@schema_loaded` is already set, because
+ * the flag may have been stamped on `loadSchemaBangAnchor`'s synthesized
+ * `columns_hash` — the declared attributes alone, latched while this cache was
+ * still cold. The cache is warm by then, so the stale view is dropped first,
+ * recursively (model_schema.rb:553-568), which is what rebuilds an STI
+ * subclass's own memo.
+ *
  * @internal
  */
 export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   if ((this as any).abstractClass) return;
-  // Rails reflects through `schema_cache`, which reads the POOL
-  // (model_schema.rb:591) and never checks a connection out permanently.
-  // `reflectionAdapter`'s last resort is `leaseConnectionSync`, which does —
-  // tripping `permanent_connection_checkout = :deprecated | :disallowed` on
-  // every save — so this async load takes its connection the way Rails' block
-  // form does — using an already-threaded or directly-assigned adapter first,
-  // exactly as `reflectionAdapter` does.
-  const threaded =
+  const startingAdapter: SchemaHost["connection"] | undefined =
     threadedConnectionFor(this as unknown as typeof Base) ??
     (this as unknown as { _adapter?: SchemaHost["connection"] })._adapter;
-  if (threaded) return loadSchemaFromConnection.call(this, threaded);
-  try {
-    return await withConnection.call<
-      typeof Base,
-      [(conn: SchemaHost["connection"]) => Promise<void>],
-      Promise<void>
-    >(this as unknown as typeof Base, async (conn) => {
-      if (!conn) return;
-      await loadSchemaFromConnection.call(this, conn);
-    });
-  } catch {
-    // `connection_pool` throws for a pool-less model; Ruby's is always there.
-    return;
+  if (!startingAdapter) {
+    try {
+      return await withConnection.call<typeof Base, [() => Promise<void>], Promise<void>>(
+        this as unknown as typeof Base,
+        () => loadSchemaFromAdapter.call(this),
+      );
+    } catch {
+      return;
+    }
   }
-}
-
-async function loadSchemaFromConnection(
-  this: SchemaHost,
-  startingAdapter: SchemaHost["connection"],
-): Promise<void> {
   const adapterOwner = this;
   const cache = startingAdapter.internalSchemaCache;
   if (!cache) return;
@@ -1315,14 +1315,6 @@ async function loadSchemaFromConnection(
   }
   if (currentAdapter !== startingAdapter) return;
 
-  // A model that reflected while the shared cache was still cold got
-  // `loadSchemaBangAnchor`'s synthesized `columns_hash` — built from its
-  // declared attributes alone — and was stamped `_schemaLoaded` on it. The
-  // cache is warm now, so drop that view (and every subclass's, which is what
-  // `reload_schema_from_cache` recurses for) before re-reflecting; otherwise
-  // the synthesized `column_names` outlives the real columns it was standing in
-  // for. Mirrors Rails nil'ing the schema ivars ahead of a fresh load
-  // (model_schema.rb:553-568).
   if (ownSchemaMemo(this, "_schemaLoaded")) {
     reloadSchemaFromCache.call(this);
   }

--- a/packages/activerecord/src/persistence.trails.test.ts
+++ b/packages/activerecord/src/persistence.trails.test.ts
@@ -210,7 +210,7 @@ describe("PersistenceTest (trails)", () => {
     class MinimalisticAircraft extends Minimalistic {
       static _tableName = "aircraft";
       static {
-        this.attribute("wingspan", "integer", { virtual: true });
+        this.attribute("wingspan", "integer");
       }
     }
     registerModel(MinimalisticAircraft);

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -37,7 +37,6 @@ import {
 } from "./validations.js";
 import { ReadonlyAttributeError } from "./readonly-attributes.js";
 import { ScopeRegistry } from "./scoping.js";
-import { reconcileVirtualAttributes } from "./model-schema.js";
 
 interface PersistenceHost {
   new (attrs?: Record<string, unknown>): any;
@@ -710,15 +709,6 @@ export async function save<T extends SaveRecord>(
   await (
     this.constructor as unknown as { ensureSchemaLoaded(): Promise<void> }
   ).ensureSchemaLoaded();
-  // Reconcile virtual attributes (declared via `attribute()` with no backing DB
-  // column) against the real columns so they're excluded from `column_names`,
-  // and thus from the INSERT/UPDATE. `reflect: true` permits a schema-cache
-  // miss to introspect here on the write path (reads never do — see
-  // reconcileVirtualAttributes).
-  await (reconcileVirtualAttributes as (this: unknown, reflect: boolean) => Promise<void>).call(
-    this.constructor,
-    true,
-  );
   const self = this as any;
   const ctor = this.constructor;
 

--- a/packages/activerecord/src/test-helpers/models/developer.ts
+++ b/packages/activerecord/src/test-helpers/models/developer.ts
@@ -197,7 +197,7 @@ export class Developer extends Base {
     // Rails `attribute :last_name, :string` — there is no `last_name` column
     // (the developers table has only `first_name`), so it's a virtual attribute
     // and must be excluded from `SELECT developers.*`.
-    this.attribute("lastName", "string", { virtual: true });
+    this.attribute("lastName", "string");
 
     this.afterFind(function (this: Developer) {
       Developer.instanceCount = (Developer.instanceCount ?? 0) + 1;
@@ -232,7 +232,7 @@ export class SymbolIgnoredDeveloper extends Base {
   static {
     this.tableName = "developers";
     this.ignoredColumns = ["first_name", "last_name"];
-    this.attribute("lastName", "string", { virtual: true });
+    this.attribute("lastName", "string");
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/human.ts
+++ b/packages/activerecord/src/test-helpers/models/human.ts
@@ -63,7 +63,7 @@ export class Human extends Base {
     this.hasMany("secretInterests", { className: "Interest", inverseOf: "secretHuman" });
     this.hasOne("mixedCaseMonkey");
 
-    this.attribute("addCallbackCalled", "boolean", { default: false, virtual: true });
+    this.attribute("addCallbackCalled", "boolean", { default: false });
   }
 
   addCalled(_interest: unknown) {

--- a/packages/activerecord/src/test-helpers/models/parrot.ts
+++ b/packages/activerecord/src/test-helpers/models/parrot.ts
@@ -33,7 +33,7 @@ export class Parrot extends Base {
 
     this.validates("name", { presence: true });
 
-    this.attribute("cancelSaveFromCallback", "boolean", { virtual: true });
+    this.attribute("cancelSaveFromCallback", "boolean");
     this.beforeSave(
       function (this: any) {
         this.cancelSaveCallbackMethod();

--- a/packages/activerecord/src/test-helpers/models/pet.ts
+++ b/packages/activerecord/src/test-helpers/models/pet.ts
@@ -29,7 +29,7 @@ export class Pet extends Base {
     this._primaryKey = "pet_id";
     // Rails: `attr_accessor :current_user` — a non-persisted accessor that
     // nested attributes can assign before the record is destroyed.
-    this.attribute("current_user", "string", { virtual: true });
+    this.attribute("current_user", "string");
     this.belongsTo("owner", { touch: true });
     this.hasMany("toys");
     this.hasMany("petTreasures");

--- a/packages/activerecord/src/test-helpers/models/pirate.ts
+++ b/packages/activerecord/src/test-helpers/models/pirate.ts
@@ -68,7 +68,7 @@ export class Pirate extends Base {
 
   static {
     // Rails: `attr_accessor :cancel_save_from_callback, :parrots_limit`
-    this.attribute("parrotsLimit", "integer", { virtual: true });
+    this.attribute("parrotsLimit", "integer");
 
     this.belongsTo("parrot", { validate: true });
     this.belongsTo("nonValidatedParrot", { className: "Parrot" });

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -539,8 +539,8 @@ describe("TimestampsWithoutTransactionTest", () => {
       static {
         this.tableName = "timestamp_attribute_posts";
         // created_at and updated_at are virtual (mirrors Ruby attr_accessor)
-        this.attribute("created_at", "datetime", { virtual: true });
-        this.attribute("updated_at", "datetime", { virtual: true });
+        this.attribute("created_at", "datetime");
+        this.attribute("updated_at", "datetime");
       }
       created_at: unknown = null;
       updated_at: unknown = null;

--- a/packages/activerecord/src/validations.test.ts
+++ b/packages/activerecord/src/validations.test.ts
@@ -189,7 +189,7 @@ describe("ValidationsTest", () => {
     class Klass extends Topic {
       static name = "Topic";
     }
-    Klass.attribute("wibble", "string", { virtual: true });
+    Klass.attribute("wibble", "string");
     Klass.validatesNumericalityOf("wibble", { onlyInteger: true });
 
     const topic = Klass.new({ wibble: "123-4567" });
@@ -205,7 +205,7 @@ describe("ValidationsTest", () => {
     class Klass extends Topic {
       static name = "Topic";
     }
-    Klass.attribute("wibble", new DecimalType({ scale: 2, precision: 9 }), { virtual: true });
+    Klass.attribute("wibble", new DecimalType({ scale: 2, precision: 9 }));
     Klass.validatesNumericalityOf("wibble", { greaterThanOrEqualTo: new BigDecimal("97.18") });
 
     for (const rawValue of ["97.179", 97.179, new BigDecimal("97.179")]) {

--- a/packages/activerecord/src/validations/length-validation.test.ts
+++ b/packages/activerecord/src/validations/length-validation.test.ts
@@ -93,13 +93,13 @@ describe("LengthValidationTest", () => {
 
   it("validates length of virtual attribute on model", async () => {
     // Rails `Pet.attr_accessor(:nickname)` — an in-memory, non-column attribute.
-    // The TS mirror is `attribute(..., { virtual: true })`: it installs the
+    // The TS mirror is `attribute(...)`: it installs the
     // name accessor and is read for validation like any attribute, but is
     // excluded from `column_names` so it is never persisted.
     const pet = class extends Pet {
       static name = "Pet";
       static {
-        this.attribute("nickname", "string", { virtual: true });
+        this.attribute("nickname", "string");
         this.validatesLengthOf("name", { minimum: 1 });
         this.validatesLengthOf("nickname", { minimum: 1 });
       }

--- a/packages/activerecord/src/validations/presence-validation.test.ts
+++ b/packages/activerecord/src/validations/presence-validation.test.ts
@@ -116,7 +116,7 @@ describe("PresenceValidationTest", () => {
 
   it("validates presence of virtual attribute on model", async () => {
     await repairValidations(Interest, async () => {
-      Interest.attribute("abbreviation", "string", { virtual: true });
+      Interest.attribute("abbreviation", "string");
       Interest.validatesPresenceOf("topic");
       Interest.validatesPresenceOf("abbreviation");
 


### PR DESCRIPTION
Rails' `column_names` is always `columns.map(&:name)` — purely DB-sourced
(`model_schema.rb:437-441`) — so an `attribute()` declaration that is not a real
column simply never appears in it, and nothing has to classify anything. trails
had a whole machine doing that classification, and it produced two defects in
one PR (#6948).

## What goes

- `reconcileVirtualAttributes` and its `_virtualAttributesReconciled` one-shot guard
- `cachedColumnNames` / `reflectColumnNames`
- the `_virtualAttributes` registry and the `virtual` attribute option
- `ensureSchemaLoaded`'s short-circuit past `loadSchema` — every declaration
  reaching it is a user `attribute()`, and whether it also names a real column is
  decided by `columns_hash`, which is DB-sourced

`columnNames()` was already `columns().map(&:name)`; a declared-but-columnless
attribute is now excluded by construction.

## The two jobs tangled in `reflectColumnNames`

**The reload.** `reflectColumnNames`' second job — dropping a `columns_hash` synthesized while the shared cache was cold — needed no new home at all. `loadSchemaBang` re-enters `load_schema!` unconditionally and `applyColumnsHash` replaces the synthesized view and clears the derived memos, which covers the cold-cache case; the subclass propagation stays where Rails puts it, in `reset_column_information` (`model_schema.rb:519-530`) and `inherited` (`:576-582`), never on a successful load.

I first re-homed it into `loadSchemaFromAdapter` gated on `_schemaLoaded`, and CI caught it: `reload_schema_from_cache` also clears `_schemaLoadPromise` — the memo guarding that very load — so every later `ensureSchemaLoaded` re-reflected the model and recursed through its subclasses. The SQLite lane timed out at 20 minutes and `associations.test.ts` alone went from 25s to over 2 minutes. Removed; the STI columns-memo test now drives through `resetColumnInformation()`, the public API for exactly that, instead of clearing the schema cache by hand.

**The lease.** `loadSchemaFromAdapter` resolved its connection through
`reflectionAdapter`, whose last resort is `leaseConnectionSync` — a permanent
checkout, which tripped `permanent_connection_checkout = :deprecated` on every
save once `ensureSchemaLoaded` stopped short-circuiting past it. It now takes the
connection through `withConnection`; Rails reflects through `schema_cache`, i.e.
the pool, never a checkout.

## Coverage

`base.trails.test.ts`'s STI columns-memo case and `model-schema.trails.test.ts`'s
memo-invalidation case now drive the re-homed reload through `loadSchema()`
instead of the retired reconcile. `column-names-sync-virtual-exclusion.trails.test.ts`
is unchanged and still passes — the DB-sourced path is exactly what it asserts.
`connection-handling.test.ts`'s "common APIs don't permanently hold a connection…"
passes.

`scripts/api-compare/extra-surface-mark.json` narrows (activerecord novel
376 → 374, total 1324 → 1320) via `parity:api:extra:tighten`.

## Scope note

`split-model-mixin-surface-to-active-model-model` was bundled with this story and
is **not** in this PR. Reaching its `model.ts` at 0 novel / 0 moved and
<= 200 lines means unmixing Attributes, AttributeRegistration, AttributeMethods,
Dirty, Callbacks, Serialization and Serializers::JSON from `ActiveModel::Model`
and re-composing them on `ActiveRecord::Base` — 55 activemodel test files extend
`Model`, and nothing partial closes the story. It is released and decomposed into
three sequenced RFC 0115 stories, each with the analysis already in hand:
`move-serialization-mixins-off-active-model-model`,
`move-attribute-mixins-off-active-model-model`,
`trim-active-model-model-to-api-and-access`.

Closes-story: retire-virtual-attribute-reconciliation

