### PR TITLE
fix(arel,activerecord): converge six surfaced deviations across arel and migration

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -308,7 +308,7 @@ export class SchemaCreation {
     parts.push("INDEX");
     if (o.algorithm) parts.push(o.algorithm);
     if (o.ifNotExists) parts.push("IF NOT EXISTS");
-    if (index.type) parts.push(index.type.toUpperCase());
+    if (index.type) parts.push(index.type);
     parts.push(
       `${this.conn.quoteColumnName(index.name)} ON ${this.conn.quoteTableName(index.table)}`,
     );

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -53,11 +53,8 @@ class InvertibleChangeTableMigration extends SilentMigration {
 
 class InvertibleTransactionMigration extends InvertibleMigration {
   async change(): Promise<void> {
-    // The Ruby writes a bare `transaction do super end`
-    // (invertible_migration_test.rb:36-42), which reaches the connection —
-    // the CommandRecorder while reverting — through `Migration#method_missing`
-    // (migration.rb:1044-1057). `Migration` has no `#transaction` of its own in
-    // Rails, so the forwarding itself is the mirror.
+    // Rails has no `Migration#transaction`: the Ruby's bare `transaction do`
+    // reaches the connection through `method_missing` (migration.rb:1044-1057).
     await this.methodMissing("transaction", async () => {
       await super.change();
     });

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -53,7 +53,12 @@ class InvertibleChangeTableMigration extends SilentMigration {
 
 class InvertibleTransactionMigration extends InvertibleMigration {
   async change(): Promise<void> {
-    await this.connection.transaction(async () => {
+    // The Ruby writes a bare `transaction do super end`
+    // (invertible_migration_test.rb:36-42), which reaches the connection —
+    // the CommandRecorder while reverting — through `Migration#method_missing`
+    // (migration.rb:1044-1057). `Migration` has no `#transaction` of its own in
+    // Rails, so the forwarding itself is the mirror.
+    await this.methodMissing("transaction", async () => {
       await super.change();
     });
   }

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -48,8 +48,8 @@ export class CommandRecorder {
     this._reverting = value;
   }
 
-  // Mirrors `attr_accessor :commands` (command_recorder.rb:65) — the live
-  // array, which `change_table`'s bulk path and `revert` both mutate in place.
+  /** Mirrors `attr_accessor :commands` (command_recorder.rb:65) — the live
+   *  array, which `change_table`'s bulk path and `revert` mutate in place. */
   get commands(): MigrationCommand[] {
     return this._commands;
   }

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -48,8 +48,14 @@ export class CommandRecorder {
     this._reverting = value;
   }
 
+  // Mirrors `attr_accessor :commands` (command_recorder.rb:65) — the live
+  // array, which `change_table`'s bulk path and `revert` both mutate in place.
   get commands(): MigrationCommand[] {
-    return [...this._commands];
+    return this._commands;
+  }
+
+  set commands(value: MigrationCommand[]) {
+    this._commands = value;
   }
 
   /**

--- a/packages/arel/src/nodes/bind-param.test.ts
+++ b/packages/arel/src/nodes/bind-param.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Nodes } from "../index.js";
 
-// `Arel::Nodes::Node` is instantiable in Ruby (node.rb:8); trails declares the
-// class `abstract` even though it has no abstract members.
-const NodeCtor = Nodes.Node as unknown as new () => Nodes.Node;
-
 describe("BindParam", () => {
   it("is equal to other bind params with the same value", () => {
     expect(new Nodes.BindParam(1)).toEqual(new Nodes.BindParam(1));
@@ -12,7 +8,7 @@ describe("BindParam", () => {
   });
 
   it("is not equal to other nodes", () => {
-    expect(new Nodes.BindParam(null)).not.toEqual(new NodeCtor());
+    expect(new Nodes.BindParam(null)).not.toEqual(new Nodes.Node());
   });
 
   it("is not equal to bind params with different values", () => {

--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -9,15 +9,10 @@ function ancestors(klass: unknown): unknown[] {
   return chain;
 }
 
-// `Arel::Nodes::Node` is instantiable in Ruby (node.rb:8); trails declares the
-// class `abstract` even though it has no abstract members, so the Rails bodies
-// below construct one through this cast.
-const NodeCtor = Nodes.Node as unknown as new () => Nodes.Node;
-
 describe("TestNode", () => {
   const users = new Table("users");
   it("includes factory methods", () => {
-    expect(typeof new NodeCtor().createJoin === "function").toBeTruthy();
+    expect(typeof new Nodes.Node().createJoin === "function").toBeTruthy();
   });
 
   it("all nodes are nodes", () => {

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -23,7 +23,7 @@ export const _engine: { current: ArelEngine | null } = { current: null };
  * (factory-methods.ts imports concrete node subclasses).
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export abstract class Node {
+export class Node {
   not(): Node {
     return new (assertRegistered(_Not, "Not"))(this);
   }

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -54,7 +54,7 @@ describe("SelectManagerTest", () => {
     describe("as", () => {
       it("makes an AS node by grouping the AST", () => {
         const mgr = new SelectManager();
-        const as = mgr.as("foo");
+        const as = mgr.as(sql("foo"));
         expect(as.left).toBeInstanceOf(Nodes.Grouping);
         expect((as.left as Nodes.Grouping).expr).toBe(mgr.ast);
         expect(String(as.right)).toBe("foo");
@@ -70,7 +70,7 @@ describe("SelectManagerTest", () => {
         const mgr = new SelectManager();
         mgr.project(star());
         mgr.from(sql("zomg"));
-        const as = mgr.as("foo");
+        const as = mgr.as(sql("foo"));
         const outer = new SelectManager();
         outer.project(sql("name"));
         outer.from(as);
@@ -1188,30 +1188,6 @@ describe("SelectManagerTest", () => {
     );
   });
 
-  describe("joins", () => {
-    it("returns inner join sql", () => {
-      expect(
-        users
-          .project(users.get("name"), posts.get("title"))
-          .join(posts)
-          .on(users.get("id").eq(posts.get("user_id")))
-          .toSql(),
-      ).toBe(
-        'SELECT "users"."name", "posts"."title" FROM "users" INNER JOIN "posts" ON "users"."id" = "posts"."user_id"',
-      );
-    });
-
-    it("returns outer join sql", () => {
-      expect(
-        users
-          .project(star())
-          .outerJoin(posts)
-          .on(users.get("id").eq(posts.get("user_id")))
-          .toSql(),
-      ).toBe('SELECT * FROM "users" LEFT OUTER JOIN "posts" ON "users"."id" = "posts"."user_id"');
-    });
-  });
-
   it("group by and having", () => {
     expect(
       users
@@ -1270,12 +1246,6 @@ describe("SelectManagerTest", () => {
   it("comment ctor stores the values array", () => {
     const c = new Nodes.Comment(["hello", "world"]);
     expect(c.values).toEqual(["hello", "world"]);
-  });
-
-  describe("lock", () => {
-    it("adds a lock node", () => {
-      expect(users.project(star()).lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
-    });
   });
 
   it("chaining returns the manager", () => {
@@ -1342,18 +1312,6 @@ describe("SelectManagerTest", () => {
     const froms = manager.froms;
     expect(froms.length).toBe(1);
     expect(froms[0]).toBe(users);
-  });
-
-  describe("window definition", () => {
-    it("takes a range frame, current row", () => {
-      const mgr = new SelectManager(users);
-      mgr.project(users.get("id"));
-      const win = mgr.window("w");
-      win.frame(new Nodes.Range(new Nodes.CurrentRow()));
-      const sql = mgr.toSql();
-      expect(sql).toContain("RANGE");
-      expect(sql).toContain("CURRENT ROW");
-    });
   });
 
   it("should take an order", () => {
@@ -1470,17 +1428,6 @@ describe("SelectManagerTest", () => {
       expect(mgr.toSql()).toBe(
         'SELECT FROM "users" WINDOW "a_window" AS (RANGE UNBOUNDED FOLLOWING)',
       );
-    });
-  });
-
-  describe("delete", () => {
-    it("copies where", () => {
-      const mgr = new SelectManager(users);
-      mgr.project(star()).where(users.get("id").eq(1)).where(users.get("name").eq("Alice"));
-      const whereSql = mgr.whereSql()?.value;
-      expect(whereSql).toContain("WHERE");
-      expect(whereSql).toContain("AND");
-      expect(mgr.constraints.length).toBe(2);
     });
   });
 

--- a/packages/arel/src/select-manager.trails.test.ts
+++ b/packages/arel/src/select-manager.trails.test.ts
@@ -68,4 +68,35 @@ describe("SelectManagerTest (trails)", () => {
       expect(mgr.lock().toSql()).toBe('SELECT * FROM "users" FOR UPDATE');
     });
   });
+
+  // `join`/`outerJoin` + `on` builder chain. Rails' select_manager_test.rb
+  // "joins" describe exercises the join SQL by handing `from` a pre-built
+  // Nodes::InnerJoin/OuterJoin instead, so the fluent path has no Rails
+  // counterpart test and is pinned here rather than under a Rails test name.
+  describe("join builder chain", () => {
+    const posts = new Table("posts");
+    const star = new Nodes.SqlLiteral("*");
+
+    it("builds INNER JOIN sql through join().on()", () => {
+      expect(
+        users
+          .project(users.get("name"), posts.get("title"))
+          .join(posts)
+          .on(users.get("id").eq(posts.get("user_id")))
+          .toSql(),
+      ).toBe(
+        'SELECT "users"."name", "posts"."title" FROM "users" INNER JOIN "posts" ON "users"."id" = "posts"."user_id"',
+      );
+    });
+
+    it("builds LEFT OUTER JOIN sql through outerJoin().on()", () => {
+      expect(
+        users
+          .project(star)
+          .outerJoin(posts)
+          .on(users.get("id").eq(posts.get("user_id")))
+          .toSql(),
+      ).toBe('SELECT * FROM "users" LEFT OUTER JOIN "posts" ON "users"."id" = "posts"."user_id"');
+    });
+  });
 });

--- a/packages/arel/src/select-manager.trails.test.ts
+++ b/packages/arel/src/select-manager.trails.test.ts
@@ -69,10 +69,8 @@ describe("SelectManagerTest (trails)", () => {
     });
   });
 
-  // `join`/`outerJoin` + `on` builder chain. Rails' select_manager_test.rb
-  // "joins" describe exercises the join SQL by handing `from` a pre-built
-  // Nodes::InnerJoin/OuterJoin instead, so the fluent path has no Rails
-  // counterpart test and is pinned here rather than under a Rails test name.
+  // Rails' "joins" describe exercises join SQL by handing `from` a pre-built
+  // Nodes::InnerJoin/OuterJoin, so the fluent chain has no Rails counterpart.
   describe("join builder chain", () => {
     const posts = new Table("posts");
     const star = new Nodes.SqlLiteral("*");

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -116,7 +116,7 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#as
    */
-  as(other: string): TableAlias {
+  as(other: string | SqlLiteral): TableAlias {
     return this.createTableAlias(
       this.grouping(this.ast),
       new SqlLiteral(other, { retryable: true }),


### PR DESCRIPTION
Six surfaced deviations, converged.

**`Nodes::Node` was `abstract`** — `node.rb:8` is an ordinary instantiable class and the Rails suite constructs one. Dropped the modifier; `node.test.ts` and `bind-param.test.ts` lost their `NodeCtor` casts and write `new Nodes.Node()`.

**`SelectManager#as` typed `other: string`** — `select_manager.rb:48-50` passes whatever `SqlLiteral.new` accepts, and `select_manager_test.rb:47,66` calls `manager.as(Arel.sql("foo"))`. The parameter widens to `string | SqlLiteral` (the constructor already unwraps a literal rather than nesting one), and both Rails bodies now pass `sql("foo")`.

**Duplicate Rails test names in `select-manager.test.ts`** — five names remained doubled (`adds a lock node`, `copies where`, `returns inner join sql`, `returns outer join sql`, `takes a range frame, current row`); the rest of the story's list had already been converged. The Rails-mirroring occurrence stays in each case. `lock`, `copies where` and the window frame were strictly covered by the mirrored bodies (and by the existing `lock` block in `select-manager.trails.test.ts`), so the leftovers are deleted; the `join().on()` / `outerJoin().on()` builder chain is genuine trails-only rigour — Rails exercises join SQL by handing `from` a pre-built `Nodes::InnerJoin` — so it moved to `select-manager.trails.test.ts` under non-Rails names.

**`CommandRecorder#commands` returned a defensive copy** — `command_recorder.rb:65` is `attr_accessor :commands`. The getter hands back the live array and the writer half exists. `revert` / `record` / `changeTable` keep touching `_commands` directly, which is the ivar Ruby uses at those same sites.

**`visit_CreateIndexDefinition` upcased `index.type`** — `schema_creation.rb:114` emits it verbatim, and trails stores it verbatim from the caller's `type:` option (`schema-statements.ts:1683`), so the `.toUpperCase()` was pure invention. The MySQL override keeps its upcase, which is Rails' own (`mysql/schema_creation.rb:43`), and is the path `fulltext` / `spatial` actually take — no SQL-text assertion moved.

**`invert_transaction`** — PR #7038 landed the sub-recorder; both items the story left open resolve as documented rather than as code, and one of them was a fix:

- The block still runs in the `transaction` forwarder rather than inside `invertTransaction`, because `inverse_of` is sync in both languages while a TS block returns a promise. Converging it means making `record`/`inverseOf` async — a *further* deviation from Rails' sync signature, and it reds every synchronous `expect(recorder.inverseOf(...)).toEqual(...)`. Left split, documented at both call sites.
- `Migration#transaction` is **not** added: Rails' `Migration` has no such method either — `transaction do super end` reaches the connection through `method_missing` (`migration.rb:1044-1057`). `InvertibleTransactionMigration` now mirrors that forwarding via `this.methodMissing("transaction", …)` instead of `this.connection.transaction(…)`, which is the Ruby's actual dispatch and adds no surface.

Gates: `parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate`, `parity:test:assertions` all OK; arel `parity:test` stays 707/707 with the file's extras down. `pnpm typecheck` clean.

Closes-story: arel-nodes-node-is-abstract-but-rails-instantiates-it
Closes-story: select-manager-as-accepts-sql-literal
Closes-story: select-manager-duplicate-rails-test-names
Closes-story: command-recorder-commands-getter-returns-a-copy
Closes-story: create-index-type-emitted-uppercase-not-verbatim
Closes-story: invert-transaction-sub-recorder
