### PR TITLE
fix(arel,activerecord,trailties): converge six RFC 0051/0124 surfaced deviations

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -335,10 +335,8 @@ describeIfPg("PostgreSQLAdapter", () => {
               await schema.createTable(
                 "postgresql_enums_in_test_schema",
                 { force: "cascade" },
-                (t) => {
-                  (t as PgTableDefinition).enum("current_mood", {
-                    enum_type: "mood_in_test_schema",
-                  });
+                (t: PgTableDefinition) => {
+                  t.enum("current_mood", { enum_type: "mood_in_test_schema" });
                 },
               );
             });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2397,10 +2397,6 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     const rename = options.rename ?? {};
 
     let definition!: SQLite3TableDefinition;
-    // Rails forwards the WHOLE options hash, `:rename` included
-    // (sqlite3_adapter.rb:601-602): SQLite3 widens `valid_table_definition_options`
-    // with `:rename` (sqlite3/schema_statements.rb:131-133) so it survives
-    // `validate_create_table_options!` and reaches SQLite3::TableDefinition.
     await this.createTable(to, { ...options, id: false }, async (td) => {
       definition = td as SQLite3TableDefinition;
       if (Array.isArray(fromPrimaryKey)) definition.primaryKeys(fromPrimaryKey);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2394,11 +2394,14 @@ WHERE type = 'table' AND name = ${this.quote(tableName)}
     block?: (definition: SQLite3TableDefinition) => void,
   ): Promise<void> {
     const fromPrimaryKey = await this.primaryKey(from);
-    const { rename: _rename, ...createOptions } = options;
     const rename = options.rename ?? {};
 
     let definition!: SQLite3TableDefinition;
-    await this.createTable(to, { ...createOptions, id: false }, async (td) => {
+    // Rails forwards the WHOLE options hash, `:rename` included
+    // (sqlite3_adapter.rb:601-602): SQLite3 widens `valid_table_definition_options`
+    // with `:rename` (sqlite3/schema_statements.rb:131-133) so it survives
+    // `validate_create_table_options!` and reaches SQLite3::TableDefinition.
+    await this.createTable(to, { ...options, id: false }, async (td) => {
       definition = td as SQLite3TableDefinition;
       if (Array.isArray(fromPrimaryKey)) definition.primaryKeys(fromPrimaryKey);
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -533,7 +533,7 @@ export class Migration {
    *   scope for the port, so the wrapper is not ported and the base
    *   `create_table` is what pairs here.
    */
-  async createTable(
+  async createTable<TD extends TableDefinition = TableDefinition>(
     name: string,
     optionsOrFn?:
       | {
@@ -548,11 +548,23 @@ export class Migration {
           collation?: string;
           as?: string;
         }
-      | ((t: TableDefinition) => void),
-    fn?: (t: TableDefinition) => void,
+      | ((t: TD) => void),
+    fn?: (t: TD) => void,
   ): Promise<void> {
     const tname = this._pt(name);
-    await this.connection.createTable(tname, optionsOrFn, fn);
+    // Ruby yields whatever `create_table_definition` built and resolves
+    // `t.enum` / `t.citext` on it at call time (migration.rb:1024-1036), so a
+    // PG migration block reaches `PostgreSQL::ColumnMethods` with no
+    // declaration. `Migration` names only the abstract `DatabaseAdapter`, whose
+    // block parameter is the abstract `TableDefinition`; under
+    // `strictFunctionTypes` a narrower block is contravariantly rejected here,
+    // which is why the forward is cast and the caller's own annotation (`TD`)
+    // is what types the block.
+    await this.connection.createTable(
+      tname,
+      optionsOrFn as Parameters<DatabaseAdapter["createTable"]>[1],
+      fn as Parameters<DatabaseAdapter["createTable"]>[2],
+    );
   }
 
   /**
@@ -908,14 +920,20 @@ export class Migration {
    *   scope for the port, so the wrapper is not ported and the base
    *   `create_join_table` is what pairs here.
    */
-  async createJoinTable(
+  async createJoinTable<TD extends TableDefinition = TableDefinition>(
     table1: string,
     table2: string,
-    options?: JoinTableOptions | ((t: TableDefinition) => void),
-    fn?: (t: TableDefinition) => void,
+    options?: JoinTableOptions | ((t: TD) => void),
+    fn?: (t: TD) => void,
   ): Promise<void> {
     table1 = this._pt(table1);
-    await this.connection.createJoinTable(table1, table2, options, fn);
+    // Same call-time resolution as `createTable` above.
+    await this.connection.createJoinTable(
+      table1,
+      table2,
+      options as Parameters<DatabaseAdapter["createJoinTable"]>[2],
+      fn as Parameters<DatabaseAdapter["createJoinTable"]>[3],
+    );
   }
 
   async dropJoinTable(

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -532,6 +532,14 @@ export class Migration {
    *   219, 262, 310, 408, 462). `Migration[x.y]` version compatibility is out of
    *   scope for the port, so the wrapper is not ported and the base
    *   `create_table` is what pairs here.
+   *
+   * Ruby resolves `t.enum` / `t.citext` on the yielded definition when the
+   * block runs (migration.rb:1024-1036), so a PG migration block reaches
+   * `PostgreSQL::ColumnMethods` with nothing declared. `Migration` names only
+   * the abstract `DatabaseAdapter`, whose block parameter is the abstract
+   * `TableDefinition`, and under `strictFunctionTypes` a narrower block is
+   * contravariantly rejected at the forward — so the caller's own annotation
+   * (`TD`) types the block and the forward carries the cast.
    */
   async createTable<TD extends TableDefinition = TableDefinition>(
     name: string,
@@ -552,14 +560,6 @@ export class Migration {
     fn?: (t: TD) => void,
   ): Promise<void> {
     const tname = this._pt(name);
-    // Ruby yields whatever `create_table_definition` built and resolves
-    // `t.enum` / `t.citext` on it at call time (migration.rb:1024-1036), so a
-    // PG migration block reaches `PostgreSQL::ColumnMethods` with no
-    // declaration. `Migration` names only the abstract `DatabaseAdapter`, whose
-    // block parameter is the abstract `TableDefinition`; under
-    // `strictFunctionTypes` a narrower block is contravariantly rejected here,
-    // which is why the forward is cast and the caller's own annotation (`TD`)
-    // is what types the block.
     await this.connection.createTable(
       tname,
       optionsOrFn as Parameters<DatabaseAdapter["createTable"]>[1],
@@ -919,6 +919,9 @@ export class Migration {
    *   219, 262, 310, 408, 462). `Migration[x.y]` version compatibility is out of
    *   scope for the port, so the wrapper is not ported and the base
    *   `create_join_table` is what pairs here.
+   *
+   * Same call-time block resolution as `createTable` above: the caller's own
+   * annotation (`TD`) types the block and the forward carries the cast.
    */
   async createJoinTable<TD extends TableDefinition = TableDefinition>(
     table1: string,
@@ -927,7 +930,6 @@ export class Migration {
     fn?: (t: TD) => void,
   ): Promise<void> {
     table1 = this._pt(table1);
-    // Same call-time resolution as `createTable` above.
     await this.connection.createJoinTable(
       table1,
       table2,

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -11,7 +11,13 @@ import {
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { stdout, stderr, setEnv, getProcessAdapter } from "@blazetrails/activesupport";
+import {
+  stdout,
+  stderr,
+  setEnv,
+  getProcessAdapter,
+  setTrailsRoot,
+} from "@blazetrails/activesupport";
 import { DatabaseTasks, DatabaseNotSupported } from "./database-tasks.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
@@ -1499,7 +1505,19 @@ describe("DatabaseTasksCheckSchemaFileTest", () => {
     );
     expect(() => DatabaseTasks.checkSchemaFile("")).toThrow(/doesn't exist yet/);
     expect(stderrWrites.join("")).toMatch(/nonexistent-awesome-file\.sql/);
+    expect(stderrWrites.join("")).toMatch(/Run `bin\/rails db:migrate`/);
+    // `defined?(::Rails.root)` is false with the seam unset (database_tasks.rb:485).
+    expect(stderrWrites.join("")).not.toMatch(/config\/application\.rb/);
     expect(exitCodes).toEqual([1, 1]);
+
+    setTrailsRoot("/apps/blog");
+    try {
+      expect(() => DatabaseTasks.checkSchemaFile("nonexistent-awesome-file.sql")).toThrow(
+        /alter \/apps\/blog\/config\/application\.rb to limit the frameworks that will be loaded\./,
+      );
+    } finally {
+      setTrailsRoot(null);
+    }
   });
 });
 

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1506,7 +1506,6 @@ describe("DatabaseTasksCheckSchemaFileTest", () => {
     expect(() => DatabaseTasks.checkSchemaFile("")).toThrow(/doesn't exist yet/);
     expect(stderrWrites.join("")).toMatch(/nonexistent-awesome-file\.sql/);
     expect(stderrWrites.join("")).toMatch(/Run `bin\/rails db:migrate`/);
-    // `defined?(::Rails.root)` is false with the seam unset (database_tasks.rb:485).
     expect(stderrWrites.join("")).not.toMatch(/config\/application\.rb/);
     expect(exitCodes).toEqual([1, 1]);
 

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -25,6 +25,7 @@ import {
   stdout,
   stderr,
   abort,
+  trailsRoot,
 } from "@blazetrails/activesupport";
 import { NoMethodError } from "@blazetrails/activemodel";
 import { ActiveRecordError, ConnectionNotDefined } from "../errors.js";
@@ -539,7 +540,14 @@ export class DatabaseTasks {
     // No blank-string special case — Rails only does File.exist?, so "" flows through
     // the same path (existsSync("") === false) and aborts with the filename in the message.
     if (!getFs().existsSync(filename)) {
-      const message = `${filename} doesn't exist yet. Run \`db:migrate\` to create it, then try again.`;
+      let message = `${filename} doesn't exist yet. Run \`bin/rails db:migrate\` to create it, then try again.`;
+      // Rails appends the second sentence `if defined?(::Rails.root)`
+      // (database_tasks.rb:485); trails' `Rails.root` seam is `trailsRoot()`,
+      // which is null when unset.
+      const root = trailsRoot();
+      if (root != null) {
+        message += ` If you do not intend to use a database, you should instead alter ${root}/config/application.rb to limit the frameworks that will be loaded.`;
+      }
       abort(message);
     }
   }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -541,9 +541,6 @@ export class DatabaseTasks {
     // the same path (existsSync("") === false) and aborts with the filename in the message.
     if (!getFs().existsSync(filename)) {
       let message = `${filename} doesn't exist yet. Run \`bin/rails db:migrate\` to create it, then try again.`;
-      // Rails appends the second sentence `if defined?(::Rails.root)`
-      // (database_tasks.rb:485); trails' `Rails.root` seam is `trailsRoot()`,
-      // which is null when unset.
       const root = trailsRoot();
       if (root != null) {
         message += ` If you do not intend to use a database, you should instead alter ${root}/config/application.rb to limit the frameworks that will be loaded.`;

--- a/packages/activerecord/src/type-caster/connection.ts
+++ b/packages/activerecord/src/type-caster/connection.ts
@@ -1,4 +1,5 @@
 import type { Type } from "@blazetrails/activemodel";
+import { toS } from "@blazetrails/activesupport";
 import { defaultValue } from "../type.js";
 
 /**
@@ -16,12 +17,12 @@ export class Connection {
     this._tableName = tableName;
   }
 
-  typeCastForDatabase(attrName: string, value: unknown): unknown {
+  typeCastForDatabase(attrName: unknown, value: unknown): unknown {
     const type = this.typeForAttribute(attrName);
     return type.serialize(value);
   }
 
-  typeForAttribute(attrName: string): Type {
+  typeForAttribute(attrName: unknown): Type {
     // `@klass.schema_cache` (type_caster/connection.rb:17) reads the pool's cache
     // without leasing a connection (connection_handling.rb:368-369). trails'
     // `Base.schemaCache()` is that pool handle, but every read on it is async and
@@ -35,7 +36,7 @@ export class Connection {
     // `getCachedColumnsHash` is a plain map read that never triggers the async
     // cache-miss path. Converging the gate waits on RFC 0023.
     const columnsHash = schemaCache?.getCachedColumnsHash?.(tableName(this));
-    const column = columnsHash?.[attrName];
+    const column = columnsHash?.[toS(attrName)];
     // Rails scopes the lookup to a leased connection —
     // `@klass.with_connection { |c| c.lookup_cast_type_from_column(column) }`
     // (type_caster/connection.rb:21). trails' `withConnection` returns a Promise

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -1,4 +1,5 @@
 import { Type, ValueType } from "@blazetrails/activemodel";
+import { toS } from "@blazetrails/activesupport";
 import { enumTypeOf } from "../enum.js";
 
 /**
@@ -23,7 +24,7 @@ export class Map {
     // mapping shape, whereas the AttributeSet carries the EnumType built from
     // the reflected column type. `whereValuesHash` / `scopeForCreate`
     // round-trip the label through the same reflected type.
-    const enumType = enumTypeOf(this._klass, String(attrName));
+    const enumType = enumTypeOf(this._klass, toS(attrName));
     if (enumType) return enumType.serialize(value);
     const type = this.typeForAttribute(attrName);
     return type.serialize(value);
@@ -36,7 +37,7 @@ export class Map {
     // attribute set, so no query-side re-wrap is needed. Rails' `to_s` lives in
     // `klass.type_for_attribute` (model_schema.rb), so callers pass the column
     // as-is — a Symbol, a String, or an Arel node.
-    return this._baseTypeForAttribute(String(name));
+    return this._baseTypeForAttribute(toS(name));
   }
 
   private _baseTypeForAttribute(name: string): Type {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -34,8 +34,8 @@ export interface TableKlass {
  * already has at `activerecord/src/type-caster/` — does not remove it.
  */
 export interface TypeCaster {
-  typeCastForDatabase(attrName: string, value: unknown): unknown;
-  typeForAttribute(name: string): unknown;
+  typeCastForDatabase(attrName: string | Node | null, value: unknown): unknown;
+  typeForAttribute(name: string | Node | null): unknown;
 }
 
 /**
@@ -221,11 +221,7 @@ export class Table extends Node {
   }
 
   typeCastForDatabase(attrName: string | Node | null, value: unknown): unknown {
-    // Rails' `name` is untyped all the way down (table.rb:100-107 hands it to a
-    // duck-typed caster). `TypeCaster` is where the string boundary lives: only
-    // a String name ever reaches a caster, since `table[Arel.star]` — the one
-    // Node-named attribute — is never type-cast.
-    return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName as string, value);
+    return (this.typeCaster as TypeCaster).typeCastForDatabase(attrName, value);
   }
 
   /** Rails: `private attr_reader :type_caster` (table.rb:115). An aliased table
@@ -234,7 +230,7 @@ export class Table extends Node {
   private readonly typeCaster: unknown;
 
   typeForAttribute(name: string | Node | null): unknown {
-    return (this.typeCaster as TypeCaster).typeForAttribute(name as string);
+    return (this.typeCaster as TypeCaster).typeForAttribute(name);
   }
 
   isAbleToTypeCast(): boolean {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1076,9 +1076,6 @@ export class ToSql extends Visitor {
       const segments = sql.split("?");
       for (let i = 0; i < segments.length; i++) {
         if (segments[i]) collector.append(segments[i]);
-        // Rails reads `o.positional_binds[bind_index]` (to_sql.rb:805) with no
-        // count check — validation belongs to the constructor
-        // (bound_sql_literal.rb:11-29) — and an out-of-range index is `nil`.
         if (i < segments.length - 1) this.visitBindValue(positionalBinds[i] ?? null, collector);
       }
     } else {
@@ -1089,8 +1086,6 @@ export class ToSql extends Visitor {
         if (m[2] !== undefined) {
           collector.append(m[2]);
         } else {
-          // `o.named_binds[$1.to_sym]` (to_sql.rb:815) is `nil` for an absent
-          // key, and `new_bind` binds it (to_sql.rb:794-795).
           this.visitBindValue(namedBinds[m[1]] ?? null, collector);
         }
       }

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -3,7 +3,6 @@ import { SQLString } from "../collectors/sql-string.js";
 import * as Nodes from "../nodes/index.js";
 import { Table } from "../table.js";
 import { Visitor, type NodeCtor } from "./visitor.js";
-import { BindError } from "../errors.js";
 import { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 
 /**
@@ -1075,16 +1074,12 @@ export class ToSql extends Visitor {
     if (o.positionalBinds) {
       const positionalBinds = o.positionalBinds;
       const segments = sql.split("?");
-      const expected = segments.length - 1;
-      if (positionalBinds.length !== expected) {
-        throw new BindError(
-          `wrong number of bind variables (${positionalBinds.length} for ${expected})`,
-          sql,
-        );
-      }
       for (let i = 0; i < segments.length; i++) {
         if (segments[i]) collector.append(segments[i]);
-        if (i < positionalBinds.length) this.visitBindValue(positionalBinds[i], collector);
+        // Rails reads `o.positional_binds[bind_index]` (to_sql.rb:805) with no
+        // count check — validation belongs to the constructor
+        // (bound_sql_literal.rb:11-29) — and an out-of-range index is `nil`.
+        if (i < segments.length - 1) this.visitBindValue(positionalBinds[i] ?? null, collector);
       }
     } else {
       const namedBinds = o.namedBinds ?? {};
@@ -1094,11 +1089,9 @@ export class ToSql extends Visitor {
         if (m[2] !== undefined) {
           collector.append(m[2]);
         } else {
-          const name = m[1];
-          if (!(name in namedBinds)) {
-            throw new BindError(`missing value for :${name}`, sql);
-          }
-          this.visitBindValue(namedBinds[name], collector);
+          // `o.named_binds[$1.to_sym]` (to_sql.rb:815) is `nil` for an absent
+          // key, and `new_bind` binds it (to_sql.rb:794-795).
+          this.visitBindValue(namedBinds[m[1]] ?? null, collector);
         }
       }
     }

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1033,11 +1033,6 @@ export function dbCommand(): Command {
     .description("Show migration status")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
-      // Rails' `db:migrate:status` is a bare delegation to
-      // `DatabaseTasks.migrate_status` inside `with_temporary_pool_for_each`
-      // (`railties/databases.rake:229-233`) — the missing-table abort, the
-      // `database:` header and the column widths all live in
-      // `tasks/database_tasks.rb:302-315`.
       await forEachDatabase(opts, async (ctx) => {
         await withPrefixedStdout(ctx.prefix, () => DatabaseTasks.migrateStatus());
       });

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -1033,30 +1033,13 @@ export function dbCommand(): Command {
     .description("Show migration status")
     .option("--database <name>", "Target a specific named database")
     .action(async (opts: DatabaseOpts) => {
-      await forEachDatabase(opts, async ({ adapter, raw, name, prefix }) => {
-        const mDirs = await migrationsDirsForConfig(raw);
-        const migrationContext = migrationContextFor(adapter, mDirs);
-
-        // `DatabaseTasks.migrate_status` aborts before reading
-        // schema_migrations when the table is not there yet
-        // (`tasks/database_tasks.rb:303-305`) — `Kernel.abort` writes the
-        // message to stderr and exits non-zero.
-        if (!(await migrationContext.schemaMigration.tableExists())) {
-          console.error(`${prefix}Schema migrations table does not exist yet.`);
-          setExitCode(1);
-          return;
-        }
-
-        const statuses = await migrationContext.migrationsStatus();
-
-        console.log("");
-        console.log(`${prefix}Status   Migration ID    Migration Name`);
-        console.log(`${prefix}--------------------------------------------------`);
-        for (const s of statuses) {
-          const statusStr = s.status === "up" ? "  up  " : " down ";
-          console.log(`${prefix}${statusStr}   ${s.version.padEnd(16)}${s.name}`);
-        }
-        console.log("");
+      // Rails' `db:migrate:status` is a bare delegation to
+      // `DatabaseTasks.migrate_status` inside `with_temporary_pool_for_each`
+      // (`railties/databases.rake:229-233`) — the missing-table abort, the
+      // `database:` header and the column widths all live in
+      // `tasks/database_tasks.rb:302-315`.
+      await forEachDatabase(opts, async (ctx) => {
+        await withPrefixedStdout(ctx.prefix, () => DatabaseTasks.migrateStatus());
       });
     });
 


### PR DESCRIPTION
Bundle of 7 RFC 0051 / RFC 0124 surfaced-deviation stories. Six converge; one is blocked on a falsified premise (below).

### `Table`'s type-caster delegations (RFC 0124)
`arel/table.ts`'s `TypeCaster` interface declared both members as taking `string`, forcing an `as string` cast on the name PR #7074 widened to `string | Node | null`. Rails hands `name` to a duck-typed `@type_caster` untouched (`arel/table.rb:100-107`). The interface now admits the name `Table` actually holds, both casts are gone, and each implementor resolves the null arm explicitly through Ruby's `to_s` — `""`, not `"null"` — matching `active_model/attribute_registration.rb:44` (`TypeCaster::Map`) and `type_caster/connection.rb:19` (`attr_name.to_s`).

### `visit_Arel_Nodes_BoundSqlLiteral` re-validation (RFC 0124)
Deleted the bind-count guard and the `missing value for :name` guard. Rails' visitor (`arel/visitors/to_sql.rb:770-822`) validates nothing — `BoundSqlLiteral`'s constructor (`bound_sql_literal.rb:11-29`) owns that, and it keeps it. An absent named bind now binds `nil` (`to_sql.rb:815` → `:794-795`), and an out-of-range positional index binds `nil` (`:805`).

### `check_schema_file`'s abort message (RFC 0051)
Restored `bin/rails db:migrate` and the conditional `Rails.root` sentence (`tasks/database_tasks.rb:482-488`). The `defined?(::Rails.root)` arm is ported through the `trailsRoot()` seam, which is `null` when unset. `DatabaseTasksCheckSchemaFileTest` keeps its Rails test name and now covers both arms.

### `Migration#createTable`'s block parameter (RFC 0051)
PR #7024 made the adapter-level `createTable` yield the receiver's own definition type; the Migration-level surface still typed the block as the abstract `TableDefinition`, so `t.enum(...)` inside a `Schema.define` block needed `(t as PgTableDefinition)`. `createTable` / `createJoinTable` are now generic in the definition type, so the caller's own annotation types the block and the cast at `adapters/postgresql/enum.test.ts:339` is deleted. `Migration` names only the abstract `DatabaseAdapter`, so the forward to the connection carries the contravariance cast, justified at the call site. `changeTable` yields `Table`, a different type family, and is untouched.

### SQLite3 `copy_table` (RFC 0051)
`copyTable` no longer strips `rename` out of the options it forwards. Rails forwards the whole hash (`sqlite3_adapter.rb:601-602`) precisely because SQLite3 widens `valid_table_definition_options` with `:rename` (`sqlite3/schema_statements.rb:131-133`) so it survives validation and reaches `SQLite3::TableDefinition`. trails' ported `validTableDefinitionOptions` override was dead for its only Rails caller; it is now exercised.

### trailties `db migrate:status` (RFC 0051)
The action is now the trails spelling of `railties/databases.rake:229-233` — a bare `DatabaseTasks.migrateStatus()` inside the per-database pool — with no duplicate header, column widths, status literals or table-exists guard. The `database:` header line trailties omitted now appears, and the widths come from `tasks/database_tasks.rb:308-314`. The multi-DB `[name]` prefix still comes from `withPrefixedStdout`.

### Blocked: PostgreSQL's `dropTable` override
The story's premise is falsified. Rails **does** define `drop_table` for PostgreSQL, at `connection_adapters/postgresql/schema_statements.rb:57-60` — one statement for all `table_names` plus `' CASCADE' if options[:force] == :cascade`. The story's grep covered `connection_adapters/postgresql*.rb` and missed the `postgresql/` subdirectory. Rails has three `drop_table` bodies (`abstract/schema_statements.rb:540`, `postgresql/schema_statements.rb:57`, `abstract_mysql_adapter.rb:354`) and trails has three; deleting the PG one would drop `CASCADE` on PG and diverge. The residual TS-only duplication is the `*table_names, **options, &block` parse Ruby gets free from the signature. Blocked with that citation rather than ratified.

Closes-story: table-type-caster-delegations-cast-away-the-null-name
Closes-story: check-schema-file-message-drops-bin-rails-and-the-rails-root-sentence
Closes-story: migration-create-table-callback-yields-abstract-table-definition
Closes-story: sqlite-copy-table-strips-rename-from-create-table-options
Closes-story: trailties-migrate-status-duplicates-database-tasks-migrate-status
Closes-story: bound-sql-literal-visitor-revalidates-what-the-ctor-owns
