### PR TITLE
refactor(activerecord): inline SchemaDumper#table's column half, retiring emitTable (RFC 0051)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.trails.test.ts
@@ -83,7 +83,7 @@ describe("SchemaDumper schemaDefault with adapter type deserialize", () => {
 });
 
 // Story 3.3-U1: columnSpec must emit directly-emittable TypeScript-DSL text
-// (not Ruby schema.rb syntax) so a later story (3.3-U3) can route emitTable
+// (not Ruby schema.rb syntax) so the base `table` can route its column loop
 // through it via formatColspec. These pin the prerequisite.
 describe("SchemaDumper columnSpec emits TS-DSL-emittable text", () => {
   const dumper = SchemaDumper.create(emptySource) as any;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -14,7 +14,7 @@
 
 import { SchemaDumper as BaseSchemaDumper } from "../../schema-dumper.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
-import type { ColumnInfo, IndexInfo, SchemaSource } from "../../schema-dumper.js";
+import type { ColumnInfo, SchemaSource } from "../../schema-dumper.js";
 
 /**
  * Column-shaped interface these helpers depend on.
@@ -173,7 +173,7 @@ export class SchemaDumper extends BaseSchemaDumper {
   // Rails `schema_default` / `schema_expression` live in
   // `connection_adapters/abstract/schema_dumper.rb`, so the ports stay in this
   // file (the parity:api-mapped location) — the sole definitions, consumed by
-  // the single `emitTable`/`columnSpec` dispatch. `_adapter` is a trails-only
+  // the base `table`'s `columnSpec` dispatch. `_adapter` is a trails-only
   // helper on the base (it reaches base-private `_source`).
 
   /**
@@ -218,128 +218,5 @@ export class SchemaDumper extends BaseSchemaDumper {
       return adapter.isValidType(type);
     }
     return true;
-  }
-
-  /**
-   * The single `emitTable`, routed through `columnSpec` so per-dialect
-   * `prepareColumnOptions` overrides (schemaType, schemaLimit, schemaPrecision,
-   * schemaDefault, etc.) take effect. Mirrors the column-emission half of Rails'
-   * `SchemaDumper#table`, whose `@connection.column_spec` is the adapter's
-   * mixed-in method. Every dump reaches it — the single dumper class assigns this
-   * onto its prototype, including the mock-source paths.
-   *
-   * Builds into a local buffer so a raise mid-table discards the partial
-   * `create_table` body (Rails writes into its own `tbl` StringIO and only prints
-   * it on success — schema_dumper.rb:220-224). On any error we emit the "Could
-   * not dump table" comment instead of the table.
-   * @internal
-   */
-  protected emitTable(
-    stream: string[],
-    tableName: string,
-    columns: ColumnInfo[],
-    indexes: IndexInfo[],
-    adapterTableOpts: Record<string, unknown> = {},
-    inlineConstraints: string[] = [],
-  ): void {
-    const body: string[] = [];
-    try {
-      // Rails validates every column's type before emitting the body
-      // (schema_dumper.rb:196), raising on an unmapped/composite type whose
-      // DSL type is nil so `valid_type?` is false. This includes the PK column.
-      for (const col of columns) {
-        if (!this.validType(col.type)) {
-          const err = new Error(`Unknown type '${col.sqlType ?? ""}' for column '${col.name}'`);
-          // Rails raises a StandardError; surface that class in the comment.
-          err.name = "StandardError";
-          throw err;
-        }
-      }
-      this.emitTableBody(body, tableName, columns, indexes, adapterTableOpts, inlineConstraints);
-    } catch (e) {
-      const cls = e instanceof Error ? e.name : "StandardError";
-      const message = e instanceof Error ? e.message : String(e);
-      stream.push(
-        `# Could not dump table ${JSON.stringify(tableName)} because of following ${cls}`,
-      );
-      stream.push(`#   ${message}`);
-      return;
-    }
-    for (const line of body) stream.push(line);
-  }
-
-  /** @internal */
-  protected emitTableBody(
-    stream: string[],
-    tableName: string,
-    columns: ColumnInfo[],
-    indexes: IndexInfo[],
-    adapterTableOpts: Record<string, unknown> = {},
-    inlineConstraints: string[] = [],
-  ): void {
-    const pkColumns = this.resolvePrimaryKeyColumns(tableName, columns);
-    const hasCompositePk = pkColumns.length > 1;
-    const pkColumn = pkColumns[0];
-    // The single-PK column name Rails skips in the column loop (`next if column.name == pk`).
-    // Composite PKs (Rails Array case) and PK-less tables never skip a column.
-    const singlePkName = !hasCompositePk && pkColumn ? pkColumn.name : undefined;
-    const stripped = this.removePrefixAndSuffix(tableName);
-
-    const tableOpts: Record<string, unknown> = {};
-    if (hasCompositePk) {
-      // Rails (Array case) emits only `primary_key: [...]` — schema_dumper.rb:182.
-      tableOpts["primaryKey"] = JSON.stringify(pkColumns.map((c) => c.name));
-    } else if (!pkColumn) {
-      tableOpts["id"] = "false";
-    } else {
-      // Rails (String case): print `primary_key: <name>` for a non-"id" key, then the
-      // column spec unless empty. Mirrors schema_dumper.rb:170-179.
-      if (pkColumn.name !== "id") tableOpts["primaryKey"] = JSON.stringify(pkColumn.name);
-      const pkSpec = this.columnSpecForPrimaryKey(pkColumn);
-      if (Object.keys(pkSpec).length > 0) {
-        if (Object.keys(pkSpec).every((k) => k === "id" || k === "default")) {
-          Object.assign(tableOpts, pkSpec);
-        } else {
-          const { id: idType, ...rest } = pkSpec as { id?: unknown } & Record<string, unknown>;
-          tableOpts["id"] = { ...(idType != null ? { type: idType } : {}), ...rest };
-        }
-      }
-    }
-    if (typeof adapterTableOpts.charset === "string")
-      tableOpts["charset"] = JSON.stringify(adapterTableOpts.charset);
-    if (typeof adapterTableOpts.collation === "string")
-      tableOpts["collation"] = JSON.stringify(adapterTableOpts.collation);
-    if (typeof adapterTableOpts.options === "string")
-      tableOpts["options"] = JSON.stringify(adapterTableOpts.options);
-    if (typeof adapterTableOpts.comment === "string" && adapterTableOpts.comment.trim().length > 0)
-      tableOpts["comment"] = JSON.stringify(adapterTableOpts.comment);
-    tableOpts["force"] = '"cascade"';
-
-    stream.push(
-      `  await ctx.createTable(${JSON.stringify(stripped)}, { ${this.formatColspec(tableOpts)} }, (t) => {`,
-    );
-
-    for (const col of columns) {
-      if (col.name === singlePkName) continue;
-
-      const [dslType, spec] = this.columnSpec(col);
-      const optStr = Object.keys(spec).length > 0 ? `, { ${this.formatColspec(spec)} }` : "";
-      const typeName = String(dslType);
-
-      if (this._isDslHelper(typeName)) {
-        stream.push(`    t.${typeName}(${JSON.stringify(col.name)}${optStr});`);
-      } else if ((col as any).isEnum && typeName === "enum") {
-        stream.push(`    t.enum(${JSON.stringify(col.name)}${optStr});`);
-      } else {
-        const colType = typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
-        stream.push(
-          `    t.column(${JSON.stringify(col.name)}, ${JSON.stringify(colType)}${optStr});`,
-        );
-      }
-    }
-
-    for (const line of inlineConstraints) stream.push(line);
-    stream.push("  });");
-    this.indexesInCreate(tableName, stream, indexes);
   }
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.trails.test.ts
@@ -195,26 +195,26 @@ describe("MySQL::SchemaDumper", () => {
     );
   });
 
-  describe("fetchTableOptions", () => {
+  describe("tableOptions", () => {
     it("populates tableCollationCache when collation is present", async () => {
       const d = make();
       d.connection = {
         tableOptions: async () => ({ charset: "utf8mb4", collation: "utf8mb4_bin" }),
       };
-      await (d as any).fetchTableOptions("users");
+      await (d as any).tableOptions("users");
       expect(d.tableCollationCache["users"]).toBe("utf8mb4_bin");
     });
 
     it("does not populate tableCollationCache when no collation in options", async () => {
       const d = make();
       d.connection = { tableOptions: async () => ({ charset: "utf8mb4" }) };
-      await (d as any).fetchTableOptions("users");
+      await (d as any).tableOptions("users");
       expect(Object.hasOwn(d.tableCollationCache, "users")).toBe(false);
     });
 
     it("returns empty object when connection is absent", async () => {
       const d = make();
-      expect(await (d as any).fetchTableOptions("users")).toEqual({});
+      expect(await (d as any).tableOptions("users")).toEqual({});
     });
 
     it("falls back to SHOW TABLE STATUS for collation when not in options", async () => {
@@ -224,7 +224,7 @@ describe("MySQL::SchemaDumper", () => {
         internalExecQuery: async () => Result.fromRowHashes([{ Collation: "utf8mb4_general_ci" }]),
         quote: (v) => `'${String(v)}'`,
       };
-      await (d as any).fetchTableOptions("users");
+      await (d as any).tableOptions("users");
       expect(d.tableCollationCache["users"]).toBe("utf8mb4_general_ci");
     });
   });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -74,7 +74,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  protected override async fetchTableOptions(tableName: string): Promise<Record<string, unknown>> {
+  protected override async tableOptions(tableName: string): Promise<Record<string, unknown>> {
     if (!this.connection) return {};
     const opts = await this.connection.tableOptions(tableName);
     if (Object.hasOwn(opts, "collation")) {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -227,18 +227,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /**
-   * Emit PG exclusion/unique constraints as post-block ctx.add*Constraint()
-   * calls — these methods are PG-specific and not on the abstract TableDefinition
-   * passed to the createTable callback, so they cannot be inlined as t.* calls.
-   * @internal
-   */
-  override async table(tableName: string, stream: string[]): Promise<void> {
-    await super.table(tableName, stream);
-    await this.exclusionConstraintsInCreate(tableName, stream);
-    await this.uniqueConstraintsInCreate(tableName, stream);
-  }
-
-  /**
    * @internal
    *
    * @missingRailsCall any? — PERMANENT: Per-site verified (RFC 0106 wave 4b):
@@ -246,7 +234,10 @@ export class SchemaDumper extends AbstractSchemaDumper {
    *   trails guards with `.length === 0` on the JS array — `Enumerable#any?`
    *   without a block is not a ported method name.
    */
-  protected async exclusionConstraintsInCreate(table: string, stream: string[]): Promise<void> {
+  protected override async exclusionConstraintsInCreate(
+    table: string,
+    stream: string[],
+  ): Promise<void> {
     const adapter = this.pgAdapter();
     const constraints: ExclusionConstraintDefinition[] =
       this._cachedExclConstraints ??
@@ -273,7 +264,10 @@ export class SchemaDumper extends AbstractSchemaDumper {
    *   the same guard at postgresql/schema_dumper.rb:65 — `Enumerable#any?`
    *   without a block is a `.length` check on the JS array.
    */
-  protected async uniqueConstraintsInCreate(table: string, stream: string[]): Promise<void> {
+  protected override async uniqueConstraintsInCreate(
+    table: string,
+    stream: string[],
+  ): Promise<void> {
     const adapter = this.pgAdapter();
     const constraints: UniqueConstraintDefinition[] =
       this._cachedUniqConstraints ??
@@ -294,7 +288,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  protected override async fetchTableOptions(tableName: string): Promise<Record<string, unknown>> {
+  protected override async tableOptions(tableName: string): Promise<Record<string, unknown>> {
     const adapter = this.pgAdapter();
     if (!adapter?.tableOptions) return {};
     return adapter.tableOptions(tableName);

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -348,7 +348,7 @@ describe("SchemaDumperAdapterTest", () => {
     expect(result).not.toContain("ar_internal_metadata");
   }, 60000);
 
-  it("emitTable forwards comment from fetchTableOptions into createTable options", async () => {
+  it("emitTable forwards comment from tableOptions into createTable options", async () => {
     // Subclasses the ConnectionAdapters dumper directly — that's where emitTable
     // (the single column_spec dispatch) lives; the bare base delegates to it.
     const { SchemaDumper: TopLevelDumper } =
@@ -360,9 +360,7 @@ describe("SchemaDumperAdapterTest", () => {
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     class CommentDumper extends TopLevelDumper {
-      protected override async fetchTableOptions(
-        _tableName: string,
-      ): Promise<Record<string, unknown>> {
+      protected override async tableOptions(_tableName: string): Promise<Record<string, unknown>> {
         return { comment: "user accounts" };
       }
     }
@@ -382,7 +380,7 @@ describe("SchemaDumperAdapterTest", () => {
       lookupCastTypeFromColumn: () => new ValueType(),
     };
     class MysqlDumper extends TopLevelDumper {
-      protected override async fetchTableOptions(_t: string): Promise<Record<string, unknown>> {
+      protected override async tableOptions(_t: string): Promise<Record<string, unknown>> {
         return { charset: "utf8mb4", collation: "utf8mb4_bin" };
       }
     }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -794,8 +794,8 @@ export abstract class SchemaDumper {
         let pkcolspec = this.columnSpecForPrimaryKey(pkcol as Column);
         if (Object.keys(pkcolspec).length > 0) {
           if (!Object.keys(pkcolspec).every((k) => k === "id" || k === "default")) {
-            const { id: id_, ...rest } = pkcolspec;
-            pkcolspec = { id: { ...(id_ != null ? { type: id_ } : {}), ...rest } };
+            const { id: type, ...rest } = pkcolspec;
+            pkcolspec = { id: { ...(type != null ? { type } : {}), ...rest } };
           }
           opts.push(this.formatColspec(pkcolspec));
         }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -21,7 +21,7 @@
 
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { Column } from "./connection-adapters/abstract/schema-dumper.js";
-import { isBlank } from "@blazetrails/activesupport";
+import { isBlank, isPresent } from "@blazetrails/activesupport";
 import { ActiveRecordError } from "./errors.js";
 import type { Base } from "./base.js";
 import type { Type } from "@blazetrails/activemodel";
@@ -441,7 +441,7 @@ export abstract class SchemaDumper {
 
   /**
    * Per-table primary-key column order from `@connection.primary_key(table)`.
-   * Populated by `table()` before column iteration so `emitTable` can render
+   * Populated by `table()` before column iteration so it can render
    * `primaryKey: [...]` (and pick the single-PK column) in PK definition order
    * rather than introspection/declaration order. Mirrors Rails' reliance on
    * `@connection.primary_key(table)`, which already returns columns in key order.
@@ -563,7 +563,7 @@ export abstract class SchemaDumper {
     // (PostgreSQLAdapter, SQLite3Adapter) implement `tables()` /
     // `columns()` / `indexes()` and so also satisfy the SchemaSource
     // duck type. The adapter-bridging path (AdapterSchemaSource)
-    // does the column normalization expected by emitTable — skipping
+    // does the column normalization expected by `table` — skipping
     // it would leak raw adapter column shapes (e.g. `scale: null`)
     // into dumps.
     if (isDatabaseAdapter(pool)) {
@@ -619,7 +619,7 @@ export abstract class SchemaDumper {
     // Instantiate the adapter-specific subclass when the adapter exposes
     // createSchemaDumper() (PostgreSQLAdapter and Mysql2Adapter). Otherwise
     // `create` resolves to the ConnectionAdapters subclass via its redirect —
-    // the single emitTable/columnSpec dispatch, never the bare base.
+    // the single columnSpec dispatch, never the bare base.
     let dumper: SchemaDumper;
     if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
       dumper = (source as any).createSchemaDumper({}) as SchemaDumper;
@@ -739,76 +739,24 @@ export abstract class SchemaDumper {
   }
 
   /**
+   * Mirrors `def table(table, stream)` (schema_dumper.rb:157-229) — the whole
+   * `create_table` block is emitted here, as in Rails: the header and primary
+   * key, `format_options(table_options)`, the per-column loop, then the
+   * in-create index/constraint calls.
+   *
    * @internal
    *
-   * @missingRailsCall column_spec — CONVERGEABLE: verified at schema_dumper.rb:158-243 —
-   *   Rails' `table` emits the columns inline; the port's `table` hands that
-   *   half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall column_spec_for_primary_key — CONVERGEABLE: verified at
-   *   schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the
-   *   port's `table` hands that half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall exclusion_constraints_in_create — CONVERGEABLE: verified at
-   *   schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the
-   *   port's `table` hands that half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall format_colspec — CONVERGEABLE: verified at schema_dumper.rb:158-243 —
-   *   Rails' `table` emits the columns inline; the port's `table` hands that
-   *   half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall format_options — CONVERGEABLE: verified at schema_dumper.rb:158-243 —
-   *   Rails' `table` emits the columns inline; the port's `table` hands that
-   *   half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall indexes_in_create — CONVERGEABLE: verified at schema_dumper.rb:158-243 —
-   *   Rails' `table` emits the columns inline; the port's `table` hands that
-   *   half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall table_options — CONVERGEABLE: verified at schema_dumper.rb:158-243 —
-   *   Rails' `table` emits the columns inline; the port's `table` hands that
-   *   half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall unique_constraints_in_create — CONVERGEABLE: verified at
-   *   schema_dumper.rb:158-243 — Rails' `table` emits the columns inline; the
-   *   port's `table` hands that half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
-   * @missingRailsCall valid_type? — CONVERGEABLE: verified at schema_dumper.rb:158-243 —
-   *   Rails' `table` emits the columns inline; the port's `table` hands that
-   *   half to `emitTable`
-   *   (connection-adapters/abstract/schema-dumper.ts:238-351), which makes this
-   *   call. The gate credits same-FILE helpers only, so the delegation reads as
-   *   an omission. Convergence is RFC 0051 story
-   *   `inline-schema-dumper-table-retire-emit-table`.
+   * @missingRailsArgs indexes_in_create — PERMANENT: `indexes_in_create` reads
+   *   `@connection.indexes(table)` itself (schema_dumper.rb:245); that read is
+   *   async in trails while `indexesInCreate` is sync, so the list is awaited
+   *   here and passed as a third argument.
    */
   async table(table: string, stream: string[]): Promise<void> {
-    // Mirrors Rails' reliance on `@connection.primary_key(table)`: capture the
-    // authoritative PK column order before iterating columns so `emitTable` /
-    // `resolvePrimaryKeyColumns` render composite/promoted keys in key order.
+    // Rails reads `@connection.supports_virtual_columns?` and
+    // `@connection.primary_key(table)` inline (schema_dumper.rb:164,
+    // abstract/schema_dumper.rb:47). Both are async in trails while the
+    // column-spec chain below is sync, so they are resolved here — the one
+    // async point above the emission — and read back synchronously.
     const adapter = this._adapter();
     if (adapter && typeof adapter.supportsVirtualColumns === "function") {
       try {
@@ -824,32 +772,111 @@ export abstract class SchemaDumper {
         // Live introspection is best-effort; fall through to declaration order.
       }
     }
-    this.tableName = table;
+
+    const columns = await this._source.columns(table, this.primaryKeyOrderCache[table]);
     try {
-      const columns = await this._source.columns(table, this.primaryKeyOrderCache[table]);
-      const rawIndexes = await this._source.indexes(table);
-      const indexes = await this.filterIndexesForDump(table, rawIndexes);
-      const adapterTableOpts = await this.fetchTableOptions(table);
-      const inlineLines: string[] = [];
-      const remaining = await this.gatherInlineConstraints(table, inlineLines);
-      this.emitTable(stream, table, columns, indexes, adapterTableOpts, inlineLines);
-      if (remaining && remaining.length > 0) stream.push("", ...remaining);
+      this.tableName = table;
+
+      const tbl: string[] = [];
+
+      // first dump primary key column
+      const pk = this.resolvePrimaryKeyColumns(table, columns);
+
+      const stripped = this.removePrefixAndSuffix(table);
+      const opts: string[] = [];
+      if (pk.length > 1) {
+        // Rails' Array case (schema_dumper.rb:181-182).
+        opts.push(`primaryKey: ${JSON.stringify(pk.map((c) => c.name))}`);
+      } else if (pk.length === 1) {
+        // Rails' String case (schema_dumper.rb:170-179).
+        const pkcol = pk[0];
+        if (pkcol.name !== "id") opts.push(`primaryKey: ${JSON.stringify(pkcol.name)}`);
+        let pkcolspec = this.columnSpecForPrimaryKey(pkcol as Column);
+        if (Object.keys(pkcolspec).length > 0) {
+          if (!Object.keys(pkcolspec).every((k) => k === "id" || k === "default")) {
+            const { id: id_, ...rest } = pkcolspec;
+            pkcolspec = { id: { ...(id_ != null ? { type: id_ } : {}), ...rest } };
+          }
+          opts.push(this.formatColspec(pkcolspec));
+        }
+      } else {
+        opts.push("id: false");
+      }
+
+      const tableOptions = await this.tableOptions(table);
+      if (isPresent(tableOptions)) {
+        opts.push(this.formatOptions(tableOptions));
+      }
+
+      opts.push('force: "cascade"');
+      tbl.push(
+        `  await ctx.createTable(${JSON.stringify(stripped)}, { ${opts.join(", ")} }, (t) => {`,
+      );
+
+      // The single-PK column name Rails skips in the column loop
+      // (`next if column.name == pk`). Composite PKs (Rails' Array case) and
+      // PK-less tables never skip a column.
+      const singlePkName = pk.length === 1 ? pk[0].name : undefined;
+
+      // then dump all non-primary key columns
+      for (const column of columns) {
+        if (!this.validType(column.type))
+          throw new Error(
+            `Unknown type '${(column as Column).sqlType ?? ""}' for column '${column.name}'`,
+          );
+        if (column.name === singlePkName) continue;
+
+        const [type, colspec] = this.columnSpec(column as Column);
+        const optStr =
+          Object.keys(colspec).length > 0 ? `, { ${this.formatColspec(colspec)} }` : "";
+        if (this._isDslHelper(type)) {
+          tbl.push(`    t.${type}(${JSON.stringify(column.name)}${optStr});`);
+        } else if ((column as { isEnum?: boolean }).isEnum && type === "enum") {
+          tbl.push(`    t.enum(${JSON.stringify(column.name)}${optStr});`);
+        } else {
+          const colType = type === "enum" ? ((column as Column).sqlType ?? type) : type;
+          tbl.push(
+            `    t.column(${JSON.stringify(column.name)}, ${JSON.stringify(colType)}${optStr});`,
+          );
+        }
+      }
+
+      // Rails emits the in-create index/constraint calls inside the block, on
+      // the `t` builder (schema_dumper.rb:209-212). trails' DSL exposes
+      // `addIndex` / `addExclusionConstraint` / `addUniqueConstraint` on `ctx`
+      // rather than on the `TableDefinition` the callback receives, so those
+      // three land after the block. They are called here, in Rails' order, and
+      // write into their own buffers; only the emission point moves.
+      const indexLines: string[] = [];
+      const indexes = await this.filterIndexesForDump(table, await this._source.indexes(table));
+      this.indexesInCreate(table, indexLines, indexes);
+
+      const remaining = await this.checkConstraintsInCreate(table, tbl);
+
+      const constraintLines: string[] = [];
+      if (adapter?.supportsExclusionConstraints?.())
+        await this.exclusionConstraintsInCreate?.(table, constraintLines);
+      if (adapter?.supportsUniqueConstraints?.())
+        await this.uniqueConstraintsInCreate?.(table, constraintLines);
+
+      tbl.push("  });");
+      tbl.push(...indexLines);
+      if (remaining && remaining.length > 0) tbl.push("", ...remaining);
+      tbl.push(...constraintLines);
+
+      stream.push(...tbl);
+    } catch (e) {
+      // Rails prints `e.class` (schema_dumper.rb:221). The raise above is a bare
+      // `raise StandardError` (`:196`), and JS' root `Error` is the analogue of
+      // Ruby's rescuable root, so an unnamed Error prints as StandardError; a
+      // subclass that carries its own Rails class name on `name` keeps it.
+      const cls = e instanceof Error && e.name !== "Error" ? e.name : "StandardError";
+      const message = e instanceof Error ? e.message : String(e);
+      stream.push(`# Could not dump table ${JSON.stringify(table)} because of following ${cls}`);
+      stream.push(`#   ${message}`);
     } finally {
       this.tableName = undefined;
     }
-  }
-
-  /**
-   * Collect inline constraint lines (check / exclusion / unique) to emit
-   * inside the createTable block. Subclasses override to add adapter-specific
-   * constraints. Base implementation handles check constraints.
-   * @internal
-   */
-  protected async gatherInlineConstraints(
-    tableName: string,
-    stream: string[],
-  ): Promise<string[] | undefined> {
-    return this.checkConstraintsInCreate(tableName, stream);
   }
 
   /**
@@ -926,8 +953,13 @@ export abstract class SchemaDumper {
     return indexes;
   }
 
-  /** @internal */
-  protected fetchTableOptions(_tableName: string): Promise<Record<string, unknown>> {
+  /**
+   * Mirrors the `@connection.table_options(table)` read at schema_dumper.rb:185.
+   * Dialects whose adapter exposes table options override this; the default is
+   * Rails' `AbstractAdapter#table_options`, which returns nothing.
+   * @internal
+   */
+  protected tableOptions(_tableName: string): Promise<Record<string, unknown>> {
     return Promise.resolve({});
   }
 
@@ -988,25 +1020,19 @@ export abstract class SchemaDumper {
    */
   protected abstract validType(type: string | null | undefined): boolean;
 
-  /** @internal */
-  protected abstract emitTable(
-    stream: string[],
-    tableName: string,
-    columns: ColumnInfo[],
-    indexes: IndexInfo[],
-    adapterTableOpts?: Record<string, unknown>,
-    inlineConstraints?: string[],
-  ): void;
+  /**
+   * Rails defines `exclusion_constraints_in_create` / `unique_constraints_in_create`
+   * only on the PostgreSQL dumper and calls them from this base's `table`, behind
+   * `@connection.supports_exclusion_constraints?` / `supports_unique_constraints?`
+   * (schema_dumper.rb:211-212). The optional declarations are the TS spelling of
+   * that: no base implementation, resolved by dynamic dispatch when the dialect
+   * has one.
+   * @internal
+   */
+  protected exclusionConstraintsInCreate?(table: string, stream: string[]): Promise<void>;
 
   /** @internal */
-  protected abstract emitTableBody(
-    stream: string[],
-    tableName: string,
-    columns: ColumnInfo[],
-    indexes: IndexInfo[],
-    adapterTableOpts?: Record<string, unknown>,
-    inlineConstraints?: string[],
-  ): void;
+  protected uniqueConstraintsInCreate?(table: string, stream: string[]): Promise<void>;
 
   /** @internal */
   protected abstract columnSpec(column: Column): [string, Record<string, unknown>];
@@ -1028,10 +1054,10 @@ export abstract class SchemaDumper {
    * inside `schema_type_with_virtual` (abstract/schema_dumper.rb:47).
    *
    * trails' predicate is async (it awaits `databaseVersion`) while the
-   * column-spec chain below it is synchronous — `emitTable` is also reached from
-   * the sync mock-source dump path, which raises on any Promise. So the answer
-   * is resolved once in `table()`, the one async point above the emitter, and
-   * read synchronously where Ruby reads the connection.
+   * column-spec chain below it is synchronous, and the emission is also reached
+   * from the sync mock-source dump path, which raises on any Promise. So the
+   * answer is resolved once at the top of `table()`, the one async point above
+   * the emission, and read synchronously where Ruby reads the connection.
    * @internal
    */
   protected supportsVirtualColumns = false;
@@ -1235,7 +1261,7 @@ export abstract class SchemaDumper {
   /**
    * Returns true when `dslType` is a TableDefinition helper method
    * (e.g. `"string"`, `"integer"`, `"virtual"`, `"serial"`). Used by the
-   * adapter subclass's `emitTable` override to dispatch column lines.
+   * `table`'s column loop to dispatch column lines.
    * @internal
    */
   protected _isDslHelper(dslType: string): boolean {

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -774,6 +774,15 @@ export abstract class SchemaDumper {
     }
 
     const columns = await this._source.columns(table, this.primaryKeyOrderCache[table]);
+
+    // Rails calls `@connection.table_options(table)` at schema_dumper.rb:187,
+    // AFTER `column_spec_for_primary_key`. trails has to read it before the
+    // column-spec chain: MySQL's `schemaCollation` compares against the table
+    // collation, which Rails fetches lazily inside `schema_collation`
+    // (mysql/schema_dumper.rb:66-71) — an async query here, so `tableOptions`
+    // is what prefills that cache, and the primary key's own collation would
+    // otherwise be compared against a cold one.
+    const tableOptions = await this.tableOptions(table);
     try {
       this.tableName = table;
 
@@ -803,7 +812,6 @@ export abstract class SchemaDumper {
         opts.push("id: false");
       }
 
-      const tableOptions = await this.tableOptions(table);
       if (isPresent(tableOptions)) {
         opts.push(this.formatOptions(tableOptions));
       }

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -775,16 +775,19 @@ export abstract class SchemaDumper {
 
     const columns = await this._source.columns(table, this.primaryKeyOrderCache[table]);
 
-    // Rails calls `@connection.table_options(table)` at schema_dumper.rb:187,
-    // AFTER `column_spec_for_primary_key`. trails has to read it before the
-    // column-spec chain: MySQL's `schemaCollation` compares against the table
-    // collation, which Rails fetches lazily inside `schema_collation`
-    // (mysql/schema_dumper.rb:66-71) — an async query here, so `tableOptions`
-    // is what prefills that cache, and the primary key's own collation would
-    // otherwise be compared against a cold one.
-    const tableOptions = await this.tableOptions(table);
     try {
       this.tableName = table;
+
+      // Rails calls `@connection.table_options(table)` at schema_dumper.rb:187,
+      // AFTER `column_spec_for_primary_key`. trails has to read it before the
+      // column-spec chain: MySQL's `schemaCollation` compares against the table
+      // collation, which Rails fetches lazily inside `schema_collation`
+      // (mysql/schema_dumper.rb:66-71) — an async query here, so `tableOptions`
+      // is what prefills that cache, and the primary key's own collation would
+      // otherwise be compared against a cold one. It stays inside the `begin`,
+      // where Rails makes the call, so a failing options query still degrades to
+      // the one-table "Could not dump" comment (`:220-224`).
+      const tableOptions = await this.tableOptions(table);
 
       const tbl: string[] = [];
 

--- a/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
+++ b/scripts/api-compare/call-mismatches-exclude/activerecord/schema-dumper.json
@@ -1,0 +1,9 @@
+[
+  {
+    "package": "activerecord",
+    "tsFile": "schema-dumper.ts",
+    "rubyName": "table",
+    "call": "order:tableOptions,removePrefixAndSuffix",
+    "reason": "Rails calls `@connection.table_options(table)` at `schema_dumper.rb:187`, after `remove_prefix_and_suffix`; trails must read it before the column-spec chain because it prefills the table-collation cache that MySQL's `schemaCollation` compares against — Rails fetches that lazily inside `schema_collation` (`mysql/schema_dumper.rb:66-71`), which is an async query in trails and cannot be issued from the sync spec chain."
+  }
+]


### PR DESCRIPTION
Rails' `SchemaDumper#table` (schema_dumper.rb:157-229) emits the whole
`create_table` block inline. The port split that in two, handing the emission
half to an abstract `emitTable` / `emitTableBody` in
connection-adapters/abstract/schema-dumper.ts — a pair with no Rails
counterpart, and the reason nine `@missingRailsCall` receipts sat on `table`.

`table` now emits the block itself, in Rails' branch order: the header and
primary key via `columnSpecForPrimaryKey` / `formatColspec`,
`formatOptions(tableOptions)`, the per-column `validType` / `columnSpec` loop,
then `indexesInCreate`, `checkConstraintsInCreate`,
`exclusionConstraintsInCreate` and `uniqueConstraintsInCreate`.

- `emitTable` / `emitTableBody` deleted, along with the base's abstract
  declarations and the invented `gatherInlineConstraints` seam.
- `fetchTableOptions` renamed to `tableOptions`, the name of the
  `@connection.table_options(table)` read at schema_dumper.rb:185.
- PostgreSQL's `table` override is gone; its exclusion/unique constraint
  emitters are now dispatched from the base, behind
  `supports_exclusion_constraints?` / `supports_unique_constraints?` as Rails
  guards them (schema_dumper.rb:211-212).
- The nine `@missingRailsCall` receipts on `table` are deleted; both call gates
  are green.

The three `ctx.add*` emitters still write after the block rather than inside
it — trails' DSL exposes them on `ctx`, not on the `TableDefinition` the
callback receives — but the calls themselves are made from `table`, in Rails'
order. Dump output is unchanged.

Closes-story: inline-schema-dumper-table-retire-emit-table