### PR TITLE
refactor(activerecord): converge four adapter deviations across sqlite3, mysql and postgresql (RFC 0051, RFC 0119)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
+import { Rational } from "@blazetrails/date";
 import { describeIfMysqlAdapter } from "./test-helper.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Post } from "../../test-helpers/models/post.js";
@@ -88,13 +89,7 @@ describeIfMysqlAdapter("AbstractMysqlAdapter", () => {
     });
 
     it("where with rational for string column using bind parameters", async () => {
-      // Tracked deviation pending convergence, RFC 0082
-      // `rational-value-quoting-analogue`: Rails passes `Rational(0)` and
-      // expects `'0.0'`, but trails has no `Rational` analogue yet, so the
-      // nearest value is a plain `Number` — which makes this case duplicate the
-      // integer one above until that story ports the class (as `BigDecimal`
-      // already is).
-      await assertQuotedAs("'0'", 0);
+      await assertQuotedAs("'0.0'", new Rational(0, 1));
     });
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bind-parameter.test.ts
@@ -1,158 +1,100 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/bind_parameter_test.rb
- *
- * Tested at the adapter (`?`-bind / driver) layer — the convention for this
- * file and its sqlite3/postgresql siblings. Rails' `assert_quoted_as` pins a
- * *relation-layer* property: `Post.where("title = ?", value).to_sql` quotes a
- * typed value against a string column as a string literal (`0.0` → `'0.0'`,
- * `false` → `'0'`) so it does NOT match numerically. That type-aware quoting
- * happens in Arel, which knows `title`'s column type; the raw `?`-bind path
- * here has no such knowledge, so mysql2 sends a JS number as a numeric literal
- * and MySQL coerces. The `where with …` cases therefore assert coercion-based
- * matching, not Arel string-quoting — a faithful `match: 0` quoting assertion
- * is unreachable at this layer (it would need a relation-level `to_sql` test).
- * The `boolean` case is the closest to Rails' intent: it exercises the real
- * `mysqlBinds` `false → 0` normalization. `rational` has no JS equivalent, so
- * it degrades to a string-equality bind.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { describeIfMysqlAdapter, leaseMysqlAdapter, Mysql2Adapter } from "./test-helper.js";
+import { describe, it, expect } from "vitest";
+import { BigDecimal } from "@blazetrails/activesupport";
+import { describeIfMysqlAdapter } from "./test-helper.js";
+import { fixtures } from "../../test-fixtures.js";
+import { Post } from "../../test-helpers/models/post.js";
+import { Topic } from "../../test-helpers/models/topic.js";
 
-describeIfMysqlAdapter("AbstractMySQLAdapter", () => {
-  let adapter: Mysql2Adapter;
-  beforeEach(async () => {
-    adapter = await leaseMysqlAdapter();
-  });
-
+describeIfMysqlAdapter("AbstractMysqlAdapter", () => {
   describe("BindParameterTest", () => {
-    beforeEach(async () => {
-      await adapter.exec(
-        "CREATE TABLE `bind_param_items` (`id` INT AUTO_INCREMENT PRIMARY KEY, `name` VARCHAR(255), `value` INT)",
-      );
-    });
+    fixtures(["topics", "posts"]);
 
-    afterEach(async () => {
-      try {
-        await adapter.exec("DROP TABLE IF EXISTS `bind_param_items`");
-      } catch {}
+    async function assertQuotedAs(expected: string, value: unknown, match = 0) {
+      const relation = Post.where("title = ?", value);
+      expect(relation.toSql()).toBe(
+        `SELECT \`posts\`.* FROM \`posts\` WHERE (title = ${expected})`,
+      );
+      if (match === 0) {
+        expect(await relation).toHaveLength(0);
+      } else {
+        expect(await relation.count()).toBe(match);
+      }
+    }
+
+    it("update question marks", async () => {
+      const str = "foo?bar";
+      const x = (await Topic.first())!;
+      x.title = str;
+      x.content = str;
+      await x.saveBang();
+      await x.reload();
+      expect(x.title).toBe(str);
+      expect(x.content).toBe(str);
     });
 
     it("create question marks", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["test?item", 42],
-      );
-      const rows = await adapter.execute("SELECT * FROM `bind_param_items`");
-      expect(rows).toHaveLength(1);
-      expect(rows[0].name).toBe("test?item");
-      expect(rows[0].value).toBe(42);
-    });
-
-    it("update question marks", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["original", 1],
-      );
-      await adapter.executeMutation("UPDATE `bind_param_items` SET `name` = ? WHERE `value` = ?", [
-        "updated?name",
-        1,
-      ]);
-      const rows = await adapter.execute("SELECT * FROM `bind_param_items` WHERE `value` = ?", [1]);
-      expect(rows[0].name).toBe("updated?name");
+      const str = "foo?bar";
+      const x = await Topic.createBang({ title: str, content: str });
+      await x.reload();
+      expect(x.title).toBe(str);
+      expect(x.content).toBe(str);
     });
 
     it("update null bytes", async () => {
       const str = "foo\0bar";
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["original", 1],
-      );
-      await adapter.executeMutation("UPDATE `bind_param_items` SET `name` = ? WHERE `value` = ?", [
-        str,
-        1,
-      ]);
-      const rows = await adapter.execute("SELECT * FROM `bind_param_items` WHERE `value` = ?", [1]);
-      expect(rows[0].name).toBe(str);
+      const x = (await Topic.first())!;
+      x.title = str;
+      x.content = str;
+      await x.saveBang();
+      await x.reload();
+      expect(x.title).toBe(str);
+      expect(x.content).toBe(str);
     });
 
     it("create null bytes", async () => {
       const str = "foo\0bar";
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        [str, 42],
-      );
-      const rows = await adapter.execute("SELECT * FROM `bind_param_items`");
-      expect(rows).toHaveLength(1);
-      expect(rows[0].name).toBe(str);
+      const x = await Topic.createBang({ title: str, content: str });
+      await x.reload();
+      expect(x.title).toBe(str);
+      expect(x.content).toBe(str);
     });
 
     it("where with string for string column using bind parameters", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["hello", 1],
-      );
-      const rows = await adapter.execute("SELECT * FROM `bind_param_items` WHERE `name` = ?", [
-        "hello",
-      ]);
-      expect(rows).toHaveLength(1);
+      await assertQuotedAs("'Welcome to the weblog'", "Welcome to the weblog", 1);
     });
 
     it("where with integer for string column using bind parameters", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["123", 1],
-      );
-      const rows = await adapter.execute(
-        "SELECT * FROM `bind_param_items` WHERE `name` = ?",
-        [123],
-      );
-      expect(rows).toHaveLength(1);
+      await assertQuotedAs("'0'", 0);
     });
 
     it("where with float for string column using bind parameters", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["1.5", 1],
-      );
-      const rows = await adapter.execute(
-        "SELECT * FROM `bind_param_items` WHERE `name` = ?",
-        [1.5],
-      );
-      expect(rows).toHaveLength(1);
+      // Tracked deviation pending convergence, RFC 0082
+      // `rational-value-quoting-analogue`: Rails passes `0.0` and expects
+      // `'0.0'`, but JS has a single `Number` type, so `0.0 === 0` and the
+      // adapter renders `'0'`. That story decides whether a Float analogue is
+      // warranted or the limitation is terminal.
+      await assertQuotedAs("'0'", 0.0);
     });
 
     it("where with boolean for string column using bind parameters", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["0", 1],
-      );
-      const rows = await adapter.execute("SELECT * FROM `bind_param_items` WHERE `name` = ?", [
-        false,
-      ]);
-      expect(rows).toHaveLength(1);
+      await assertQuotedAs("'0'", false);
     });
 
     it("where with decimal for string column using bind parameters", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["99.99", 1],
-      );
-      const rows = await adapter.execute(
-        "SELECT * FROM `bind_param_items` WHERE `name` = ?",
-        [99.99],
-      );
-      expect(rows).toHaveLength(1);
+      await assertQuotedAs("'0.0'", new BigDecimal(0));
     });
 
     it("where with rational for string column using bind parameters", async () => {
-      await adapter.executeMutation(
-        "INSERT INTO `bind_param_items` (`name`, `value`) VALUES (?, ?)",
-        ["1/3", 1],
-      );
-      const rows = await adapter.execute("SELECT * FROM `bind_param_items` WHERE `name` = ?", [
-        "1/3",
-      ]);
-      expect(rows).toHaveLength(1);
+      // Tracked deviation pending convergence, RFC 0082
+      // `rational-value-quoting-analogue`: Rails passes `Rational(0)` and
+      // expects `'0.0'`, but trails has no `Rational` analogue yet, so the
+      // nearest value is a plain `Number` — which makes this case duplicate the
+      // integer one above until that story ports the class (as `BigDecimal`
+      // already is).
+      await assertQuotedAs("'0'", 0);
     });
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { BinaryData } from "@blazetrails/activemodel";
-import { Temporal } from "@blazetrails/date";
+import { Rational, Temporal } from "@blazetrails/date";
+import { BigDecimal } from "@blazetrails/activesupport";
 import {
   quoteColumnName,
   typeCast as typeCastFn,
@@ -210,6 +211,24 @@ describe("MySQL quoting — castBoundValue", () => {
 
   it("passes strings through unchanged", () => {
     expect(castBoundValue("hello")).toBe("hello");
+  });
+
+  // A BigDecimal is Numeric in Ruby, so it lands on `when Numeric` (rb:58-59)
+  // and renders through `to_s` with no format — engineering notation, not the
+  // fixed form `when BigDecimal` (rb:60-61) asks for and never reaches. MRI:
+  // `BigDecimal("123456.789").to_s` => "0.123456789e6".
+  it("renders a BigDecimal in Ruby's engineering-notation default", () => {
+    expect(castBoundValue(new BigDecimal("123456.789"))).toBe("0.123456789e6");
+    expect(castBoundValue(new BigDecimal("1234.5"))).toBe("0.12345e4");
+    expect(castBoundValue(new BigDecimal(0))).toBe("0.0");
+  });
+
+  // rb:56-57 `when Rational then value.to_f.to_s`. Ruby's Float#to_s always
+  // carries a fractional part, so an integral value keeps its ".0".
+  it("renders a Rational as its Float to_s", () => {
+    expect(castBoundValue(new Rational(0, 1))).toBe("0.0");
+    expect(castBoundValue(new Rational(3, 2))).toBe("1.5");
+    expect(castBoundValue(new Rational(1, 3))).toBe("0.3333333333333333");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -131,19 +131,25 @@ export function unquoteIdentifier(identifier: string | null | undefined): string
  * Mirrors: MySQL::Quoting#cast_bound_value (mysql/quoting.rb:54-69).
  *
  * Ruby's `Rational` and `BigDecimal` are both `Numeric`, so `when Rational`
- * (rb:56-57) has to precede it while `when BigDecimal` (rb:60-61) is already
- * shadowed by `when Numeric` and never runs — `BigDecimal(0).to_s` is "0.0",
- * the same fixed form the dead arm asks for. The arms are ported in Rails'
- * order, which leaves that one dead here for the same reason.
+ * (rb:56-57) has to precede it, and a `BigDecimal` lands on `when Numeric`
+ * (rb:58-59) — leaving `when BigDecimal` (rb:60-61) shadowed and unreachable in
+ * Ruby too. The reachable arm is `Numeric#to_s`, which for a BigDecimal is
+ * Ruby's engineering-notation default, NOT the `"F"` form the dead arm asks
+ * for: `BigDecimal("123456.789").to_s` is `0.123456789e6` (verified on MRI).
+ * `toString` defaults to `"F"` here, so the format is passed explicitly.
  *
  * @internal
  */
 export function castBoundValue(value: unknown): unknown {
-  if (value instanceof Rational) return String(value.toF());
-  if (typeof value === "number" || typeof value === "bigint" || value instanceof BigDecimal) {
-    return String(value);
+  if (value instanceof Rational) {
+    // `Rational#to_f` is a Ruby Float, and `Float#to_s` always carries a
+    // fractional part — `Rational(0).to_f.to_s` is "0.0" where `String(0)`
+    // is "0". JS has one numeric type, so the ".0" is restored here.
+    const f = value.toF();
+    return Number.isInteger(f) ? `${f}.0` : String(f);
   }
-  if (value instanceof BigDecimal) return value.toString("F");
+  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  if (value instanceof BigDecimal) return value.toString("E");
   if (value === true) return "1";
   if (value === false) return "0";
   return value;

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -22,7 +22,8 @@ import {
   toBytes,
   type QuotingDispatchHost,
 } from "../abstract/quoting.js";
-import { Temporal } from "@blazetrails/date";
+import { Rational, Temporal } from "@blazetrails/date";
+import { BigDecimal } from "@blazetrails/activesupport";
 import { Value as TimeValue } from "../../type/time.js";
 import { BinaryData } from "@blazetrails/activemodel";
 import { toS } from "@blazetrails/activesupport";
@@ -126,9 +127,23 @@ export function unquoteIdentifier(identifier: string | null | undefined): string
   return identifier ?? null;
 }
 
-/** @internal */
+/**
+ * Mirrors: MySQL::Quoting#cast_bound_value (mysql/quoting.rb:54-69).
+ *
+ * Ruby's `Rational` and `BigDecimal` are both `Numeric`, so `when Rational`
+ * (rb:56-57) has to precede it while `when BigDecimal` (rb:60-61) is already
+ * shadowed by `when Numeric` and never runs — `BigDecimal(0).to_s` is "0.0",
+ * the same fixed form the dead arm asks for. The arms are ported in Rails'
+ * order, which leaves that one dead here for the same reason.
+ *
+ * @internal
+ */
 export function castBoundValue(value: unknown): unknown {
-  if (typeof value === "number" || typeof value === "bigint") return String(value);
+  if (value instanceof Rational) return String(value.toF());
+  if (typeof value === "number" || typeof value === "bigint" || value instanceof BigDecimal) {
+    return String(value);
+  }
+  if (value instanceof BigDecimal) return value.toString("F");
   if (value === true) return "1";
   if (value === false) return "0";
   return value;

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.trails.test.ts
@@ -1,49 +1,20 @@
 import { describe, expect, it } from "vitest";
+import type { Type } from "@blazetrails/activemodel";
 import { Array as OidArray } from "./array.js";
 import { Enum } from "./enum.js";
 import { RangeType } from "./range.js";
-import { TypeMapInitializer, type TypeMap } from "./type-map-initializer.js";
+import { HashLookupTypeMap } from "../../../type/hash-lookup-type-map.js";
+import { TypeMapInitializer } from "./type-map-initializer.js";
 import { Vector } from "./vector.js";
-
-class TestStore implements TypeMap {
-  readonly mapping = new Map<number | string, unknown>();
-
-  registerType(
-    oid: number | string,
-    type?: unknown,
-    block?: (oid: number | string, ...args: unknown[]) => unknown,
-  ): void {
-    this.mapping.set(oid, block ?? type);
-  }
-
-  aliasType(oid: number | string, targetOid: number | string): void {
-    this.mapping.set(oid, this.mapping.get(targetOid));
-  }
-
-  lookup(oid: number | string, ...args: unknown[]): unknown {
-    const value = this.mapping.get(oid);
-    if (typeof value === "function")
-      return (value as (...args: unknown[]) => unknown)(oid, ...args);
-    return value;
-  }
-
-  has(oid: number | string): boolean {
-    return this.mapping.has(oid);
-  }
-
-  keys(): Array<number | string> {
-    return [...this.mapping.keys()];
-  }
-}
 
 const integerSubtype = {
   cast: (value: unknown) => (value == null ? null : Number(value)),
   serialize: (value: unknown) => (value == null ? null : Number(value)),
-};
+} as unknown as Type;
 
 describe("PostgreSQL::OID::TypeMapInitializer", () => {
   it("registers arrays, ranges, enums, domains, mapped types, and composites", () => {
-    const store = new TestStore();
+    const store = new HashLookupTypeMap();
     store.registerType("int4", integerSubtype);
     store.registerType(23, integerSubtype);
 
@@ -69,11 +40,16 @@ describe("PostgreSQL::OID::TypeMapInitializer", () => {
   });
 
   it("registers array and range types lazily with lookup arguments", () => {
-    const store = new TestStore();
-    store.registerType(23, (_oid: number | string, metadata?: { scale?: number }) => ({
-      ...integerSubtype,
-      metadata,
-    }));
+    const store = new HashLookupTypeMap();
+    store.registerType(
+      23,
+      undefined,
+      (_oid, ...args) =>
+        ({
+          ...(integerSubtype as object),
+          metadata: args[0],
+        }) as unknown as Type,
+    );
 
     new TypeMapInitializer(store).run([
       row({ oid: "1007", typname: "_int4", typinput: "array_in", typelem: "23" }),
@@ -90,7 +66,7 @@ describe("PostgreSQL::OID::TypeMapInitializer", () => {
   });
 
   it("skips array registration when element OID is not in the store", () => {
-    const store = new TestStore();
+    const store = new HashLookupTypeMap();
     store.registerType("numeric", integerSubtype);
 
     // Process only the array row (element OID 1700 not yet keyed in the store).
@@ -108,7 +84,7 @@ describe("PostgreSQL::OID::TypeMapInitializer", () => {
   });
 
   it("builds query condition fragments", () => {
-    const store = new TestStore();
+    const store = new HashLookupTypeMap();
     store.registerType("int4", integerSubtype);
     store.registerType(23, integerSubtype);
     const initializer = new TypeMapInitializer(store);

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::TypeMapInitializer
  */
 
-import type { Type } from "@blazetrails/activemodel";
+import { ArgumentError, type Type } from "@blazetrails/activemodel";
 
 import { HashLookupTypeMap } from "../../../type/hash-lookup-type-map.js";
 import { Array as OidArray } from "./array.js";
@@ -155,7 +155,7 @@ export class TypeMapInitializer {
   }
 
   private assertValidRegistration(oid: number | string, oidType: unknown): number {
-    if (oidType == null) throw new Error(`can't register nil type for OID ${oid}`);
+    if (oidType == null) throw new ArgumentError(`can't register nil type for OID ${oid}`);
     return toInt(oid);
   }
 }

--- a/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/oid/type-map-initializer.ts
@@ -4,32 +4,13 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::PostgreSQL::OID::TypeMapInitializer
  */
 
+import type { Type } from "@blazetrails/activemodel";
+
+import { HashLookupTypeMap } from "../../../type/hash-lookup-type-map.js";
 import { Array as OidArray } from "./array.js";
 import { Enum } from "./enum.js";
 import { RangeType, type RangeSubtype } from "./range.js";
 import { Vector } from "./vector.js";
-
-/**
- * The oid-keyed store this initializer populates.
- *
- * @noRailsEquivalent CONVERGEABLE (story:
- * converge-pg-type-map-initializer-onto-ported-type-map). Rails passes a real
- * `ActiveRecord::Type::HashLookupTypeMap`; trails ports the `Type::TypeMap`
- * base (`type/type-map.ts`) but not that oid-keyed subclass, so the shape
- * stands in until it exists.
- */
-export interface TypeMap {
-  registerType(
-    oid: number | string,
-    type?: unknown,
-    block?: (oid: number | string, ...args: unknown[]) => unknown,
-  ): void;
-  /** @internal */
-  aliasType(oid: number | string, targetOid: number | string): void;
-  lookup?(oid: number | string, ...args: unknown[]): unknown;
-  has?(oid: number | string): boolean;
-  keys?(): Array<number | string>;
-}
 
 export interface PgTypeRow {
   oid: number | string;
@@ -50,15 +31,15 @@ export interface PgTypeRow {
 }
 
 export class TypeMapInitializer {
-  private store: TypeMap;
+  private store: HashLookupTypeMap;
 
-  constructor(store: TypeMap) {
+  constructor(store: HashLookupTypeMap) {
     this.store = store;
   }
 
   run(records: PgTypeRow[]): void {
-    const nodes = records.filter((row) => !this.storeHas(toInt(row.oid)));
-    const mapped = extract(nodes, (row) => this.storeHas(row.typname));
+    const nodes = records.filter((row) => !this.store.isKey(toInt(row.oid)));
+    const mapped = extract(nodes, (row) => this.store.isKey(row.typname));
     const ranges = extract(nodes, (row) => row.typtype === "r");
     const enums = extract(nodes, (row) => row.typtype === "e");
     const domains = extract(nodes, (row) => row.typtype === "d");
@@ -81,7 +62,7 @@ export class TypeMapInitializer {
     // Divergence: Rails interpolates type names unescaped (they're internal
     // keys, not user input). We single-quote-escape defensively since the
     // output is still SQL and the cost is negligible.
-    const knownTypeNames = this.storeKeys().map((key) => `'${String(key).replace(/'/g, "''")}'`);
+    const knownTypeNames = this.store.keys().map((key) => `'${String(key).replace(/'/g, "''")}'`);
     return `WHERE\n  t.typname IN (${knownTypeNames.join(", ")})\n`;
   }
 
@@ -90,7 +71,7 @@ export class TypeMapInitializer {
   }
 
   queryConditionsForArrayTypes(): string {
-    const knownTypeOids = this.storeKeys().filter((key) => typeof key !== "string");
+    const knownTypeOids = this.store.keys().filter((key) => typeof key !== "string");
     // Divergence: Rails emits `t.typelem IN ()` for an empty OID set, which
     // is invalid SQL. We short-circuit to `WHERE 1=0` to return zero rows
     // instead of erroring.
@@ -119,7 +100,7 @@ export class TypeMapInitializer {
   }
 
   private registerDomainType(row: PgTypeRow): void {
-    const baseType = this.storeLookup(toInt(row.typbasetype));
+    const baseType = this.store.lookup(toInt(row.typbasetype));
     if (baseType) {
       this.register(row.oid, baseType);
     } else {
@@ -128,7 +109,7 @@ export class TypeMapInitializer {
   }
 
   private registerCompositeType(row: PgTypeRow): void {
-    const subtype = this.storeLookup(toInt(row.typelem));
+    const subtype = this.store.lookup(toInt(row.typelem));
     if (subtype) this.register(row.oid, new Vector(row.typdelim, subtype));
   }
 
@@ -146,15 +127,11 @@ export class TypeMapInitializer {
 
   private register(
     oid: number | string,
-    oidType: unknown | ((oid: number | string, ...args: unknown[]) => unknown),
+    oidType: Type | ((oid: number | string, ...args: unknown[]) => Type),
   ): void {
     oid = this.assertValidRegistration(oid, oidType);
     if (typeof oidType === "function") {
-      this.store.registerType(
-        oid,
-        undefined,
-        oidType as (oid: number | string, ...args: unknown[]) => unknown,
-      );
+      this.store.registerType(oid, undefined, oidType);
     } else {
       this.store.registerType(oid, oidType);
     }
@@ -168,32 +145,16 @@ export class TypeMapInitializer {
   private registerWithSubtype(
     oid: number | string,
     targetOid: number,
-    block: (subtype: OidSubtype) => unknown,
+    block: (subtype: OidSubtype) => Type,
   ): void {
-    if (this.storeHas(targetOid)) {
+    if (this.store.isKey(targetOid)) {
       this.register(oid, (_oid: number | string, ...args: unknown[]) =>
-        block(this.storeLookup(targetOid, ...args) as OidSubtype),
+        block(this.store.lookup(targetOid, ...args) as OidSubtype),
       );
     }
   }
 
-  private storeHas(key: number | string): boolean {
-    if (this.store.has) return this.store.has(key);
-    return this.storeKeys().includes(key);
-  }
-
-  private storeKeys(): Array<number | string> {
-    return this.store.keys?.() ?? [];
-  }
-
-  private storeLookup(key: number | string, ...args: unknown[]): unknown {
-    return this.store.lookup?.(key, ...args);
-  }
-
-  private assertValidRegistration(
-    oid: number | string,
-    oidType: unknown | ((oid: number | string, ...args: unknown[]) => unknown),
-  ): number {
+  private assertValidRegistration(oid: number | string, oidType: unknown): number {
     if (oidType == null) throw new Error(`can't register nil type for OID ${oid}`);
     return toInt(oid);
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -8,7 +8,6 @@
  *          ActiveRecord::ConnectionAdapters::PostgreSQL (top-level module)
  */
 
-import { NotImplementedError } from "../../errors.js";
 import { SchemaDumper, statelessTest } from "../../schema-dumper.js";
 import { pgDatetimeConfig } from "./pg-datetime-config.js";
 import { PostgreSQLAdapter } from "../postgresql-adapter.js";
@@ -911,12 +910,4 @@ export class AlterTable extends AbstractAlterTable {
   addUniqueConstraint(columnName: string | string[], options: UniqueConstraintOptions = {}): void {
     this.uniqueConstraintAdds.push(this._pgTd.newUniqueConstraintDefinition(columnName, options));
   }
-}
-
-/** @internal */
-function aliasedTypes(name: any, fallback: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/postgresql/schema_definitions.rb:289 cluster=pg-long-tail
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition#aliased_types is not implemented",
-  );
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-statements.ts
@@ -127,8 +127,8 @@ export async function indexes(
 
     const cols = (
       await adapter.internalExecQuery(`PRAGMA index_info(${adapter.quote(idx.name)})`, "SCHEMA")
-    ).toArray() as Array<{ name: string | null; seqno: number }>;
-    const columnNames = cols.sort((a, b) => a.seqno - b.seqno).map((c) => c.name);
+    ).toArray() as Array<{ name: string | null }>;
+    const columnNames = cols.map((c) => c.name);
 
     const orders: Record<string, string> = {};
     let columns: string[] | string;


### PR DESCRIPTION
Bundle of six RFC 0051 / RFC 0119 convergence stories. Four land here; two are
resolved without code (see below).

### 1. SQLite3 `indexes` — drop the non-Rails `seqno` sort

`sqlite3/schema_statements.rb:27-29` maps `PRAGMA index_info` rows in PRAGMA
order with no sort. The port added `.sort((a, b) => a.seqno - b.seqno)` — a
no-op in practice (SQLite documents the PRAGMA as returning one row per column
in index order) but a call Rails does not make. Dropped, and `seqno` comes out
of the row type with it. Existing multi-column / composite-PK reflection
coverage in `sqlite3-introspection.trails.test.ts` still passes.

### 2. MySQL `bind_parameter_test` — canonical fixtures and relation-layer quoting

The trails file `CREATE TABLE`d a `bind_param_items` table that exists nowhere
in Rails, and — since #5327 made it lease the ambient connection — ran that DDL
on the connection every other suite in the worker shares. It also tested the
raw `?`-bind / driver layer, so the six `where with ... for string column`
cases asserted MySQL's numeric *coercion*, the opposite of what Rails pins.

Now mirrors `bind_parameter_test.rb`: `fixtures :topics, :posts` with the
canonical `Topic` / `Post` models, a relation-layer `assertQuotedAs`
(rb:74-87) asserting both `Post.where("title = ?", value).toSql()` and the
matched row count, and the four `test_{update,create}_{question_marks,null_bytes}`
round trips that were missing entirely. The header comment calling the faithful
assertion "unreachable at this layer" is gone with the compromise.

**That surfaced a real bug.** `MySQL::Quoting#cast_bound_value`
(`mysql/quoting.rb:54-69`) has a `when Rational` arm the port omitted entirely,
and no handling for `BigDecimal` at all — so a `BigDecimal` bound against a
string column rendered `0.0` bare where Rails renders `'0.0'`.

Both arms are now ported in Rails' order. The subtlety, which review caught:
`BigDecimal < Numeric`, so a BigDecimal fires on `when Numeric` (rb:58-59) and
the literal `when BigDecimal` arm below it (rb:60-61) is dead in Ruby too — and
the arm that actually runs is `Numeric#to_s` with **no format**, Ruby's
engineering-notation default, not the `"F"` form the dead arm names.
`BigDecimal("123456.789").to_s` is `0.123456789e6` (verified on MRI), so the
port passes `"E"` explicitly rather than leaning on trails' `"F"` default. The
`Rational` arm is `to_f.to_s`, and Ruby's `Float#to_s` always carries a
fractional part, so an integral value keeps its `.0`.

Both branches are pinned in `mysql/quoting.trails.test.ts` on values that
actually distinguish the formats (`0.123456789e6`, `0.12345e4`, `1.5`,
`0.3333333333333333` — each checked against MRI), and the mirrored
`where with rational ...` case now passes a real
`Rational(0, 1)` from `@blazetrails/date` instead of a stand-in `0`, so it no
longer duplicates the integer case above it.

Verified against a local `mariadb:11`: 10/10 green, and `parity:test` scores the
file 10/10 with no wrong-describe.

### 3. PG `OID::TypeMapInitializer` — type the store on the ported class

The initializer declared a local `TypeMap` interface as its store, tagged
`@noRailsEquivalent CONVERGEABLE`, because `Type::HashLookupTypeMap` was
believed unported. It is already ported, in Rails layout, at
`type/hash-lookup-type-map.ts`. The store is now typed on it, the interface and
its tag are gone, and the three optional-member shims (`storeHas` / `storeKeys`
/ `storeLookup`) collapse into the direct `key?` / `keys` / `lookup` calls
`type_map_initializer.rb` makes. The unit test drives a real `HashLookupTypeMap`
instead of a hand-rolled double.

### 4. Delete the dead PG `aliasedTypes` `@nie` stub

Unreachable module-level stub in `postgresql/schema-definitions.ts`, shadowed by
the real class override at `:310` which matches
`postgresql/schema_definitions.rb:288-290` exactly. Deleted, along with the
now-unused `NotImplementedError` import.

### Resolved without code

- **`converge-pg-rename-table-pk-and-sequence-for-new-name`** — already landed
  in `main` as part of #7026. `renameTable` passes `newName` straight through,
  and `pkAndSequenceFor` resolves the name itself via `::regclass` with its own
  Rails `rescue nil`; there is no `renamedName` rebuild and no `.catch(() =>
  null)` left. Marked done against #7026.
- **`converge-sync-connection-lease-per-checkout-verify`** — blocked. Neither
  arm of its acceptance criteria is reachable today: `verifyBang`
  (`abstract-adapter.ts:1379`) is async because `active()` is a real backend
  round-trip where Rails' `verify!` (`abstract_adapter.rb:759`) is sync, and the
  three residual sites are structurally synchronous — the deprecated
  `.connection` getter, `Arel::Nodes::Node#toSql` (sync at 600+ call sites), and
  `leaseConnectionSync` itself. The self-heal cannot run synchronously and the
  sites cannot await. The story it named as owner,
  `retire-connection-pool-async-resolution-shims`, landed as #6095 without
  covering this. The three code comments already cite this story, which stays
  open, so `stale-story-references` stays green.

### Gates

`parity:api:calls` OK · `parity:api:calls:args` OK · `parity:api:extra:gate` OK
(activerecord novel 376→374, total 1324→1320; mark narrowed with `:tighten`) ·
`parity:test` overall non-negative · `parity:test:assertions` OK · `pnpm lint`
and `pnpm typecheck` clean · `pnpm vitest run scripts/` 2427 passed.

Closes-story: sqlite-indexes-sorts-index-info-rows-rails-does-not
Closes-story: converge-mysql-bind-parameter-test-to-relation-layer
Closes-story: converge-pg-type-map-initializer-onto-ported-type-map
Closes-story: remove-dead-pg-aliased-types-nie-stub

