### PR TITLE
chore(activerecord): diagnose leading-colon insert_all CI failure

### DIFF
--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -51,8 +51,26 @@ describe("leading-colon string writes", () => {
       const created = await Topic.create({ title: sent });
       expect((await Topic.find(created.id)).title).toBe(stored);
 
-      await Topic.insertAll([{ title: sent, author_name: "colon" }]);
+      const insertResult = await Topic.insertAll([{ title: sent, author_name: "colon" }]);
       const inserted = await Topic.where({ author_name: "colon" }).first();
+      if (inserted == null) {
+        const conn = Topic.connection as unknown as {
+          selectAll(sql: string): Promise<{ rows: unknown[] }>;
+        };
+        const raw = await conn.selectAll(
+          "SELECT id, title, author_name, type, approved FROM topics",
+        );
+        const scoped = Topic as unknown as { currentScope?(): { toSql?(): string } | null };
+        const result = insertResult as unknown as { rows?: unknown[] };
+        console.log(
+          "DIAG sent=%s insertResult=%s currentScope=%s rows=%s sql=%s",
+          sent,
+          JSON.stringify(result?.rows ?? insertResult),
+          JSON.stringify(String(scoped.currentScope?.()?.toSql?.() ?? "none")),
+          JSON.stringify(raw?.rows ?? raw),
+          await Topic.where({ author_name: "colon" }).toSql(),
+        );
+      }
       expect(inserted!.title).toBe(stored);
       await Topic.where({ author_name: "colon" }).deleteAll();
     }


### PR DESCRIPTION
Diagnostic-only push for the `Active Record SQLite Tests` red on `main` @691f6a0c.

`packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts > create and insert_all store a leading colon verbatim` fails with `TypeError: Cannot read properties of null (reading 'title')` — `Topic.insertAll` succeeds and the immediately following `Topic.where({ author_name: "colon" }).first()` returns null.

It does not reproduce in isolation, across the whole `relation/` directory, or across all 53 `Topic`-importing test files. It reproduces deterministically on CI: the SQLite lane runs `packages/activerecord/` unsharded, while the PG and MariaDB lanes run `--shard=N/2` (ci.yml:1118, ci.yml:1270) — so SQLite is the only lane where this file shares a worker and worker DB with the full file set.

This commit adds a temporary dump (insert result, current scope, raw `topics` rows, generated SQL) on the null branch so the CI log identifies the cause. It will be replaced by the actual fix.

Closes-story: red-691f6a0c