### PR TITLE
refactor(activerecord): route TimeZoneConverter#serialize through the subtype's map hook (RFC 0112)

### DIFF
--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.trails.test.ts
@@ -10,6 +10,8 @@ import { Temporal } from "@blazetrails/date";
 import { Base } from "../index.js";
 import { fixtures } from "../test-fixtures.js";
 import { loadSchemaFromAdapter } from "../model-schema.js";
+import { Array as ArrayType } from "../connection-adapters/postgresql/oid/array.js";
+import { Range, RangeType } from "../connection-adapters/postgresql/oid/range.js";
 import { TimeZoneConverter } from "./time-zone-conversion.js";
 
 fixtures({});
@@ -159,5 +161,34 @@ describe("TimeZoneConverter#isChanged", () => {
 
   it("null vs TimeWithZone is changed", () => {
     expect(converter().isChanged(null, twz(MS1))).toBe(true);
+  });
+});
+
+describe("TimeZoneConverter#serialize containers", () => {
+  const zone = new TimeZone("Europe/Paris");
+  const instant = Temporal.Instant.from("2020-06-15T10:00:00Z");
+  const twz = () => new TimeWithZone(instant, zone);
+
+  it("extracts TimeWithZone bounds out of a range", () => {
+    const converter = TimeZoneConverter.wrap(new RangeType(new Types.DateTimeType({})));
+    const serialized = converter.serialize(new Range(twz(), twz(), true)) as Range;
+    expect(serialized.begin).toBeInstanceOf(Temporal.Instant);
+    expect((serialized.begin as Temporal.Instant).epochNanoseconds).toBe(instant.epochNanoseconds);
+  });
+
+  it("extracts TimeWithZone bounds out of an array of ranges", () => {
+    const converter = TimeZoneConverter.wrap(
+      new ArrayType(new RangeType(new Types.DateTimeType({}))),
+    );
+    const serialized = converter.serialize([new Range(twz(), twz(), true)]) as { values: Range[] };
+    const begin = serialized.values[0].begin;
+    expect(begin).toBeInstanceOf(Temporal.Instant);
+    expect((begin as Temporal.Instant).epochNanoseconds).toBe(instant.epochNanoseconds);
+  });
+
+  it("leaves an infinite range bound untouched", () => {
+    const converter = TimeZoneConverter.wrap(new RangeType(new Types.DateTimeType({})));
+    const serialized = converter.serialize(new Range(-Infinity, twz(), false)) as Range;
+    expect(serialized.begin).toBe(-Infinity);
   });
 });

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -178,10 +178,10 @@ export class TimeZoneConverter extends ValueType<unknown> {
   // `convert_time_to_time_zone` end in (value.rb:117-119, oid/range.rb:50-54,
   // oid/array.rb:67-69).
   private _resolveForSerialize(value: unknown): unknown {
-    const extractUtc = (v: unknown): unknown =>
-      v instanceof TimeWithZone ? v.utc().toTime().toInstant() : v;
-    if (value instanceof TimeWithZone) return extractUtc(value);
-    return this.map(value, extractUtc);
+    if (value instanceof TimeWithZone) return value.utc().toTime().toInstant();
+    if (value instanceof Temporal.Instant) return value;
+    if (typeof value === "number" && !Number.isFinite(value)) return value;
+    return this.map(value, (v) => this._resolveForSerialize(v));
   }
 
   override equals(other: Type): boolean {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -172,18 +172,14 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return ns - roundedOff;
   }
 
-  // Strips TimeWithZone from any value before DB serialization. Extracts UTC
-  // Temporal.Instant from TimeWithZone bounds in Range/Array values so the
-  // subtype's serialize (which doesn't understand TimeWithZone) receives plain
-  // Instants or timestamps.
+  // Strips TimeWithZone from any value before DB serialization, since the
+  // subtype's serialize doesn't understand TimeWithZone. Containers go through
+  // the subtype's own `map` hook, the same one `cast` and
+  // `convert_time_to_time_zone` end in (value.rb:117-119, oid/range.rb:50-54,
+  // oid/array.rb:67-69), rather than a structural range/array test here.
   private _resolveForSerialize(value: unknown): unknown {
-    const extractUtc = (v: unknown): unknown =>
-      v instanceof TimeWithZone ? v.utc().toTime().toInstant() : v;
-    if (Array.isArray(value)) {
-      return value.map((v) => (isRangeLike(v) ? mapRange(v, extractUtc) : extractUtc(v)));
-    }
-    if (isRangeLike(value)) return mapRange(value, extractUtc);
-    return extractUtc(value);
+    if (value instanceof TimeWithZone) return value.utc().toTime().toInstant();
+    return this.map(value, (v) => this._resolveForSerialize(v));
   }
 
   override equals(other: Type): boolean {
@@ -286,28 +282,6 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
   const proto = Object.getPrototypeOf(v);
   return proto === Object.prototype || proto === null;
-}
-
-interface RangeLike {
-  readonly begin: unknown;
-  readonly end: unknown;
-  readonly excludeEnd: boolean;
-  constructor: new (begin: unknown, end: unknown, excludeEnd: boolean) => RangeLike;
-}
-
-/** @internal */
-function isRangeLike(v: unknown): v is RangeLike {
-  if (v == null || typeof v !== "object" || Array.isArray(v) || isPlainObject(v)) return false;
-  return "begin" in v && "end" in v && "excludeEnd" in v;
-}
-
-/** @internal */
-function mapRange(range: RangeLike, fn: (v: unknown) => unknown): object {
-  return new (range.constructor as any)(
-    range.begin != null ? fn(range.begin) : null,
-    range.end != null ? fn(range.end) : null,
-    range.excludeEnd,
-  );
 }
 
 interface TimeZoneConversionHost {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -172,14 +172,16 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return ns - roundedOff;
   }
 
-  // Strips TimeWithZone from any value before DB serialization, since the
-  // subtype's serialize doesn't understand TimeWithZone. Containers go through
-  // the subtype's own `map` hook, the same one `cast` and
+  // Rails has no such hop: DelegateClass forwards serialize straight to the
+  // subtype, whose cast_value handles a TimeWithZone because it acts_like?(:time).
+  // Containers take the subtype's own `map` hook, the one `cast` and
   // `convert_time_to_time_zone` end in (value.rb:117-119, oid/range.rb:50-54,
-  // oid/array.rb:67-69), rather than a structural range/array test here.
+  // oid/array.rb:67-69).
   private _resolveForSerialize(value: unknown): unknown {
-    if (value instanceof TimeWithZone) return value.utc().toTime().toInstant();
-    return this.map(value, (v) => this._resolveForSerialize(v));
+    const extractUtc = (v: unknown): unknown =>
+      v instanceof TimeWithZone ? v.utc().toTime().toInstant() : v;
+    if (value instanceof TimeWithZone) return extractUtc(value);
+    return this.map(value, extractUtc);
   }
 
   override equals(other: Type): boolean {


### PR DESCRIPTION
Rails' `TimeZoneConverter` has no `Range` or `Array` branch
(`activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb:13-50`).
The container polymorphism lives entirely in `Type::Value#map`
(`activemodel/lib/active_model/type/value.rb:117-119`, identity), overridden by
`OID::Range#map` (`.../postgresql/oid/range.rb:50-54`) and `OID::Array#map`
(`.../postgresql/oid/array.rb:67-69`).

`cast` and `convertTimeToTimeZone` were already routed through that hook (#6485).
This removes the last re-derivation of it: the private `RangeLike` interface, the
`isRangeLike()` structural predicate, the `mapRange()` reconstructor (which rebuilt
through `range.constructor`) and the `Array.isArray` arm in `_resolveForSerialize`.
The serialize path now ends in the same `map` call, so a range or array column
rebuilds through its own type's override.

Both overrides were already ported and are simply now on the path:
`packages/activemodel/src/type/value.ts` (`map`),
`packages/activerecord/src/connection-adapters/postgresql/oid/range.ts` (`RangeType#map`),
`.../oid/array.ts` (`ArrayType#map`) — no new port was needed.

Gates: `pnpm parity:api:calls` OK, `pnpm parity:api:calls:args` OK,
`pnpm parity:api:extra:gate` OK, `pnpm typecheck` clean. Converter and
`oid/range` unit suites pass; the live tsrange/tstzrange PG suite is left to CI
(no local PG credentials).

Closes-story: time-zone-converter-rederives-type-value-map
