### PR TITLE
fix(activerecord): run the SchemaCache derive step through deepDeduplicate; resolve store accessors through the attribute type

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.trails.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SchemaCache, FakePool } from "./schema-cache.js";
 import { IndexDefinition } from "./abstract/schema-definitions.js";
+import { Column } from "./column.js";
+import { SqlTypeMetadata } from "./sql-type-metadata.js";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -105,5 +107,44 @@ describe("SchemaCacheIndexDefinitionRoundTripTest", () => {
     expect(index).toBeInstanceOf(IndexDefinition);
     expect(index.orders).toBe("desc");
     expect(index.columnOptions()).toEqual(live.columnOptions());
+  });
+});
+
+describe("SchemaCacheDeepDeduplicateTest", () => {
+  function makeColumn(name: string, sqlType: string): Column {
+    return new Column(name, null, new SqlTypeMetadata({ sqlType, type: sqlType }), true);
+  }
+
+  it("the derive step shares structurally identical columns between tables", () => {
+    // `derive_columns_hash_and_deduplicate_values` (`schema_cache.rb:440-446`)
+    // runs every cache through `deep_deduplicate`, whose `Deduplicable` arm is
+    // `-value` — the registry lookup that collapses equal value objects onto
+    // one frozen instance (`deduplicable.rb:18`).
+    const cache = new SchemaCache();
+    cache.initWith({
+      columns: new Map([
+        ["people", [makeColumn("id", "integer")]],
+        ["places", [makeColumn("id", "integer")]],
+      ]),
+    });
+
+    const columns = (cache as unknown as { _columns: Map<string, Column[]> })._columns;
+    expect(columns.get("people")![0]).toBe(columns.get("places")![0]);
+    expect(Object.isFrozen(columns.get("people")![0])).toBe(true);
+  });
+
+  it("deduplication leaves indexes as IndexDefinition instances", () => {
+    const cache = new SchemaCache();
+    cache.initWith({
+      indexes: new Map([
+        ["people", [new IndexDefinition("people", "index_people_on_id", true, ["id"])]],
+      ]),
+    });
+
+    const [index] = (cache as unknown as { _indexes: Map<string, IndexDefinition[]> })._indexes.get(
+      "people",
+    )!;
+    expect(index).toBeInstanceOf(IndexDefinition);
+    expect(index.name).toBe("index_people_on_id");
   });
 });

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -226,8 +226,7 @@ export class SchemaCache {
 
     this._version = (coder["version"] as string | number) ?? null;
 
-    // `unless coder["deduplicated"]` (`schema_cache.rb:289-291`) — a dump that
-    // already interned its values is taken as-is, identity and all.
+    // `unless coder["deduplicated"]` (`schema_cache.rb:289-291`).
     if (coder["deduplicated"] == null || coder["deduplicated"] === false) {
       this.deriveColumnsHashAndDeduplicateValues();
     }
@@ -1019,17 +1018,14 @@ export function deepDeduplicate<T>(value: T): T {
     ) as unknown as T;
   }
   if (Array.isArray(value)) return value.map((i) => deepDeduplicate(i)) as unknown as T;
-  if (isDeduplicable(value)) return deduplicate(value) as unknown as T;
-  return value;
-}
-
-/** @internal */
-function isDeduplicable(value: unknown): value is Deduplicable {
-  return (
+  if (
     value !== null &&
     typeof value === "object" &&
-    typeof (value as Deduplicable).deduplicateKey === "function"
-  );
+    typeof (value as unknown as Deduplicable).deduplicateKey === "function"
+  ) {
+    return deduplicate(value as unknown as Deduplicable) as unknown as T;
+  }
+  return value;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -8,6 +8,8 @@
 import { getFs, getPath } from "@blazetrails/activesupport";
 import { Gzip } from "@blazetrails/activesupport/gzip";
 import { Column } from "./column.js";
+import { deduplicate } from "./deduplicable.js";
+import type { Deduplicable } from "./deduplicable.js";
 import type { ColumnCoder } from "./column.js";
 import { Column as MysqlColumn } from "./mysql/column.js";
 import { Column as PostgresqlColumn } from "./postgresql/column.js";
@@ -224,7 +226,11 @@ export class SchemaCache {
 
     this._version = (coder["version"] as string | number) ?? null;
 
-    this.deriveColumnsHashAndDeduplicateValues();
+    // `unless coder["deduplicated"]` (`schema_cache.rb:289-291`) — a dump that
+    // already interned its values is taken as-is, identity and all.
+    if (coder["deduplicated"] == null || coder["deduplicated"] === false) {
+      this.deriveColumnsHashAndDeduplicateValues();
+    }
   }
 
   isCached(tableName: string): boolean {
@@ -425,8 +431,8 @@ export class SchemaCache {
     return withConnection(pool, async (connection) => {
       if (typeof connection.indexes === "function") {
         if (await this.dataSourceExists(connection, tableName)) {
-          const idx = await connection.indexes(tableName);
-          this._indexes.set(tableName, idx);
+          const idx = deepDeduplicate(await connection.indexes(tableName));
+          this._indexes.set(deepDeduplicate(tableName), idx);
           return idx;
         }
       }
@@ -565,16 +571,12 @@ export class SchemaCache {
   }
 
   /**
-   * Rebuild `_columnsHash` from `_columns`, the tail of both load paths
-   * (`initWith` and `marshalLoad`).
-   *
-   * @missingRailsCall deep_deduplicate — PERMANENT: Per-site verified (RFC 0106 wave 4b):
-   *   schema_cache.rb:441-445 calls `deep_deduplicate` to intern strings with
-   *   Ruby's `-@`; JS has no string-interning primitive and identical string
-   *   literals are already shared, so trails derives `columnsHash` only
-   *   (schema-cache.ts:617-627).
+   * Mirrors `SchemaCache#derive_columns_hash_and_deduplicate_values`
+   * (`schema_cache.rb:440-446`), the tail of both load paths (`initWith` and
+   * `marshalLoad`).
    */
   private deriveColumnsHashAndDeduplicateValues(): void {
+    this._columns = deepDeduplicate(this._columns);
     this._columnsHash.clear();
     for (const [table, cols] of this._columns) {
       const hash: Record<string, Column> = {};
@@ -583,6 +585,9 @@ export class SchemaCache {
       }
       this._columnsHash.set(table, hash);
     }
+    this._primaryKeys = deepDeduplicate(this._primaryKeys);
+    this._dataSourceExists = deepDeduplicate(this._dataSourceExists);
+    this._indexes = deepDeduplicate(this._indexes);
   }
 
   clear(): void {
@@ -996,24 +1001,35 @@ export class FakePool {
 }
 
 /**
- * Recursively deep-clone arrays and plain objects. Rails uses `-value` (String#+@)
- * to intern strings; TS has no string interning, so primitives are returned as-is
- * and only arrays/objects are cloned (no identity preservation).
- *
- * Mirrors: ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate (private)
+ * Mirrors: ActiveRecord::ConnectionAdapters::SchemaCache#deep_deduplicate
+ * (`schema_cache.rb:448-459`, private). Ruby's Hash arm is a `Map` here — the
+ * shape every cache in this file uses. Ruby's `-value` on a String is
+ * interning, which JS strings already have, so only the `Deduplicable` arm has
+ * work to do: it routes through the registry so structurally identical values
+ * become one shared, frozen object. A value that is neither (an
+ * `IndexDefinition`, say — not `Deduplicable` in Rails either) falls through
+ * `else` and is returned untouched, class and all.
  *
  * @internal
  */
 export function deepDeduplicate<T>(value: T): T {
-  if (Array.isArray(value)) return value.map((i) => deepDeduplicate(i)) as unknown as T;
-  if (value !== null && typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[deepDeduplicate(k)] = deepDeduplicate(v);
-    }
-    return out as unknown as T;
+  if (value instanceof Map) {
+    return new Map(
+      [...value].map(([k, v]) => [deepDeduplicate(k), deepDeduplicate(v)]),
+    ) as unknown as T;
   }
+  if (Array.isArray(value)) return value.map((i) => deepDeduplicate(i)) as unknown as T;
+  if (isDeduplicable(value)) return deduplicate(value) as unknown as T;
   return value;
+}
+
+/** @internal */
+function isDeduplicable(value: unknown): value is Deduplicable {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as Deduplicable).deduplicateKey === "function"
+  );
 }
 
 /**

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -450,8 +450,7 @@ export function store(
 
 /**
  * Returns the HashAccessor class for a given store attribute column.
- * Raises ConfigurationError if the column is not a declared store and the
- * attribute type has no accessor.
+ * Raises ConfigurationError unless the attribute's type responds to `accessor`.
  *
  * Mirrors: ActiveRecord::Store#store_accessor_for (private)
  *

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -23,45 +23,6 @@ interface CoderLike {
 }
 
 /**
- * Per-class registry mapping store-attribute name to its IndifferentCoder.
- * Populated by store() to wire implicit serialize semantics.
- *
- * @internal
- */
-const _storeCoders = new WeakMap<typeof Base, Map<string, IndifferentCoder>>();
-
-/**
- * Trails-only seam with no Rails counterpart. Rails gets implicit store
- * serialization inside `ActiveRecord::Store::ClassMethods#store`
- * (store.rb:106-109), which builds the coder and hands it straight to
- * `serialize store_attribute, coder: IndifferentCoder.new(...)` (store.rb:108),
- * installing it as the attribute's type; trails resolves the coder separately
- * at read time, so the mapping needs its own per-class registry. Not a writer
- * for any Ruby attribute.
- *
- * @internal
- */
-export function setStoreCoder(klass: typeof Base, attr: string, coder: IndifferentCoder): void {
-  let map = _storeCoders.get(klass);
-  if (!map) {
-    map = new Map();
-    _storeCoders.set(klass, map);
-  }
-  map.set(attr, coder);
-}
-
-/** @internal */
-export function getStoreCoder(klass: typeof Base, attr: string): IndifferentCoder | undefined {
-  let cls: typeof Base | null = klass;
-  while (cls && typeof cls === "function" && cls !== Function.prototype) {
-    const coder = _storeCoders.get(cls)?.get(attr);
-    if (coder) return coder;
-    cls = Object.getPrototypeOf(cls) as typeof Base | null;
-  }
-  return undefined;
-}
-
-/**
  * Wraps a column coder to ensure the deserialized value is a
  * HashWithIndifferentAccess and the serialized form is a plain hash.
  *
@@ -449,13 +410,6 @@ function dig(obj: unknown, key: string): unknown {
  *   store(User, 'settings', { accessors: ['theme', 'language'] })
  *   store(User, 'settings', { accessors: ['theme'], prefix: true })
  *   store(User, 'settings', { accessors: ['theme'], coder: JSON })
- *
- * @missingRailsArgs serialize — CONVERGEABLE: store.rb:108 passes the coder
- * inline as `coder: IndifferentCoder.new(store_attribute, coder)`. trails has to
- * hoist it into a local because the same instance is also handed to the
- * trails-only `_storeCoders` registry (see `setStoreCoder`), which exists only
- * because the read path resolves the coder separately from the attribute type.
- * Converges once that registry goes away.
  */
 export function store(
   modelClass: typeof Base,
@@ -475,21 +429,15 @@ export function store(
         `but got ${typeof coder}.`,
     );
   }
-  const indifferentCoder = new IndifferentCoder(storeAttribute, coder as CoderLike | null);
-  setStoreCoder(modelClass, storeAttribute, indifferentCoder);
-  // Structured column types (json/jsonb/hstore) have a type-level accessor and
-  // handle their own cast/serialize. Only patch readAttribute for plain text/string
-  // columns that have no type-level accessor.
-  const colType = (modelClass as any).typeForAttribute?.(storeAttribute);
-  if (!colType || typeof colType.accessor !== "function") {
-    if (!serialize) {
-      throw new ConfigurationError(
-        `store() requires serialize() to be registered before use. ` +
-          `Ensure base.ts (or the activerecord index) is imported before calling store().`,
-      );
-    }
-    serialize(modelClass, storeAttribute, { coder: indifferentCoder as any });
+  if (!serialize) {
+    throw new ConfigurationError(
+      `store() requires serialize() to be registered before use. ` +
+        `Ensure base.ts (or the activerecord index) is imported before calling store().`,
+    );
   }
+  serialize(modelClass, storeAttribute, {
+    coder: new IndifferentCoder(storeAttribute, coder as CoderLike | null) as any,
+  });
 
   if (options.accessors !== undefined) {
     storeAccessor(modelClass, storeAttribute, {
@@ -510,23 +458,15 @@ export function store(
  * @internal
  */
 export function storeAccessorFor(this: Base, storeAttribute: string): typeof HashAccessor {
-  const modelClass = this.constructor as typeof Base;
-  // Rails dispatches via type_for_attribute(attr).accessor — check the type first.
-  const type = (modelClass as any).typeForAttribute?.(storeAttribute);
-  if (type && typeof type.accessor === "function") {
-    const accessor = type.accessor();
-    if (accessor && typeof accessor.read === "function" && typeof accessor.write === "function") {
-      return accessor as typeof HashAccessor;
-    }
+  const type = this.typeForAttribute(storeAttribute) as { accessor?: () => unknown };
+  if (typeof type?.accessor !== "function") {
+    throw new ConfigurationError(
+      `the column '${storeAttribute}' has not been configured as a store. ` +
+        `Please make sure the column is declared serializable via 'ActiveRecord.store' or, ` +
+        `if your database supports it, use a structured column type like hstore or json.`,
+    );
   }
-  // Check IndifferentCoder registered by store() (covers both standalone and Base.store()) — returns IndifferentHashAccessor.
-  const coder = getStoreCoder(modelClass, storeAttribute);
-  if (coder) return coder.accessor();
-  throw new ConfigurationError(
-    `the column '${storeAttribute}' has not been configured as a store. ` +
-      `Please make sure the column is declared serializable via 'ActiveRecord.store' or, ` +
-      `if your database supports it, use a structured column type like hstore or json.`,
-  );
+  return type.accessor() as typeof HashAccessor;
 }
 
 /**


### PR DESCRIPTION
Bundle of 4 RFC 0112 stories. Two were already converged on `main` and are marked done against the PRs that did the work (#6801, #7087); the two remaining ship here.

## SchemaCache derive step never calls deepDeduplicate

`derive_columns_hash_and_deduplicate_values` (`schema_cache.rb:440-446`) deep-deduplicates all four caches before exposing them; trails' port only rebuilt `_columnsHash`. It now routes `_columns`, `_primaryKeys`, `_dataSourceExists` and `_indexes` through the ported helper in Rails' order, and `indexes` deep-deduplicates both the reflected rows and the table-name key (`schema_cache.rb:367`).

`deepDeduplicate` itself was a recursive object clone, which would have flattened `Column` and `IndexDefinition` instances into plain objects the moment the derive step started calling it. It now mirrors the Ruby case statement (`schema_cache.rb:448-459`): the Hash arm is a `Map` here, Array recurses, a `Deduplicable` routes through the registry (`deduplicable.rb:18`) so structurally equal value objects collapse onto one frozen instance, and anything else — an `IndexDefinition`, which is not `Deduplicable` in Rails either — falls through `else` untouched, class and all. The #5890 round-trip tests keep passing unchanged.

`initWith` also picks up the `unless coder["deduplicated"]` guard (`schema_cache.rb:289-291`), which trails had dropped; without it the derive step re-interns a dump that already declared itself deduplicated.

## store_accessor_for resolves through the attribute type only

`store()` skipped `serialize` whenever the column type already carried an accessor, so the `IndifferentCoder` never became the attribute's type and the read path needed a second resolution route — the trails-only per-class `_storeCoders` registry. It now hands the coder to `serialize` unconditionally, exactly as `store.rb:106-109` does.

With that, `storeAccessorFor` collapses to Rails' one lookup plus guard (`store.rb:219-225`), and `_storeCoders` / `setStoreCoder` / `getStoreCoder` delete along with it — three exported names of invented surface, plus the `@missingRailsArgs serialize` receipt that existed only to describe the hoist.

## Already on main

- `store-accessor-assignment-still-needs-a-descriptor-walk` — `findPrototypeSetter` and the store-accessor arm that called it are gone as of #6801; `_assignAttribute` now lives in ActiveModel and its remaining descriptor walk is the general `Object#public_method` port, separately justified at the call site.
- `two-env-resolvers-databasetasks-env-vs-currentenv` — `DatabaseConfigurations.currentEnv()` no longer exists; `DatabaseTasks.env` reads `DatabaseConfigurations.defaultEnv`, the single resolver, mirroring `DEFAULT_ENV.call`. The `TRAILS_ENV`-with-`defaultEnv`-unassigned regression test is `database-configurations.test.ts:241`.

## Verification

`pnpm typecheck`, `parity:api:calls` (OK), `parity:api:calls:args` (OK), `parity:api:extra --package activerecord`; `store.test.ts`, `serialized-attribute.test.ts`, `schema-cache.test.ts`, `schema-cache.trails.test.ts` green.

Closes-story: schema-cache-derive-step-skips-deep-deduplicate
Closes-story: store-accessor-for-resolves-through-the-attribute-type-only
