### PR TITLE
fix(parity): follow ActiveSupport::Concern's hook in the extra-surface allow-set (RFC 0115)

### DIFF
--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
     "novel": 372,
-    "total": 1318
+    "total": 1170
   },
   "arel": {
     "novel": 0,

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -209,7 +209,7 @@ describe("buildReport — ActiveSupport::Concern allow-set", () => {
    * Rails: `mixin.rb` defines `module Mixin; extend ActiveSupport::Concern;
    * included do extend Namer end; module ClassMethods; def validates; end; end;
    * end`, and `host.rb` does `include Mixin`. Ruby's Concern hook
-   * (activesupport/lib/active_support/concern.rb:139-143) gives the host both
+   * (activesupport/lib/active_support/concern.rb:137-138) gives the host both
    * `Mixin::ClassMethods#validates` and `Namer#model_name` as CLASS methods,
    * neither of which appears in the host's own `includes`.
    */

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -204,6 +204,185 @@ describe("buildGlobalRubyCandidates", () => {
   });
 });
 
+describe("buildReport — ActiveSupport::Concern allow-set", () => {
+  /**
+   * Rails: `mixin.rb` defines `module Mixin; extend ActiveSupport::Concern;
+   * included do extend Namer end; module ClassMethods; def validates; end; end;
+   * end`, and `host.rb` does `include Mixin`. Ruby's Concern hook
+   * (activesupport/lib/active_support/concern.rb:139-143) gives the host both
+   * `Mixin::ClassMethods#validates` and `Namer#model_name` as CLASS methods,
+   * neither of which appears in the host's own `includes`.
+   */
+  function makeManifests(hostIncludes: string[]): { ruby: ApiManifest; ts: ApiManifest } {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Host": rubyClass({
+              name: "Host",
+              file: "host.rb",
+              includes: hostIncludes,
+            }),
+          },
+          modules: {
+            "ActiveModel::Mixin": {
+              name: "Mixin",
+              file: "mixin.rb",
+              includes: [],
+              extends: ["ActiveSupport::Concern", "ActiveModel::Namer"],
+              instanceMethods: [],
+              classMethods: [],
+            },
+            "ActiveModel::Mixin::ClassMethods": {
+              name: "ClassMethods",
+              file: "mixin.rb",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("validates")],
+              classMethods: [],
+            },
+            "ActiveModel::Namer": {
+              name: "Namer",
+              file: "naming.rb",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("model_name")],
+              classMethods: [],
+            },
+          },
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Host: {
+              name: "Host",
+              file: "host.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [method("validates"), method("modelName")],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    return { ruby, ts };
+  }
+
+  const run = (hostIncludes: string[]): string[] => {
+    const { ruby, ts } = makeManifests(hostIncludes);
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    return (report.packages[0]?.extraFiles[0]?.extras ?? []).map((e) => e.name);
+  };
+
+  it("allows a Concern's ClassMethods and its included-block extends on the includer", () => {
+    expect(run(["ActiveModel::Mixin"])).toEqual([]);
+  });
+
+  it("does not allow them on a class that does not include the Concern", () => {
+    expect(run([]).sort()).toEqual(["modelName", "validates"]);
+  });
+});
+
+describe("buildReport — hook-injected mixins", () => {
+  /**
+   * `ActiveModel::Callbacks.extended(base)` runs
+   * `base.class_eval { include ActiveSupport::Callbacks }`
+   * (activemodel/lib/active_model/callbacks.rb:66-70) — a `self.extended` body
+   * the static extractor cannot follow.
+   */
+  it("credits ActiveSupport::Callbacks against a host that extends ActiveModel::Callbacks", () => {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            "ActiveModel::Host": {
+              name: "Host",
+              file: "host.rb",
+              includes: [],
+              extends: ["ActiveModel::Callbacks"],
+              instanceMethods: [],
+              classMethods: [],
+            },
+          },
+          modules: {
+            "ActiveModel::Callbacks": {
+              name: "Callbacks",
+              file: "callbacks.rb",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [],
+            },
+          },
+        },
+        activesupport: {
+          classes: {},
+          modules: {
+            "ActiveSupport::Callbacks": {
+              name: "Callbacks",
+              file: "callbacks.rb",
+              includes: [],
+              extends: ["Concern"],
+              instanceMethods: [method("run_callbacks")],
+              classMethods: [],
+            },
+            "ActiveSupport::Callbacks::ClassMethods": {
+              name: "ClassMethods",
+              file: "callbacks.rb",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("set_callback")],
+              classMethods: [],
+            },
+          },
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Host: {
+              name: "Host",
+              file: "host.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("runCallbacks")],
+              classMethods: [method("setCallback")],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: "activemodel",
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    expect(report.packages[0]?.extraFiles ?? []).toEqual([]);
+  });
+});
+
 describe("buildReport — novel vs moved classification", () => {
   function makeManifests(): { ruby: ApiManifest; ts: ApiManifest } {
     // Rails: foo.rb defines `bar`; baz.rb defines `quux`.

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -161,6 +161,24 @@ const AMBIENT_RAILTIE_MIXINS: Record<string, { includes: string[] }> = {
 };
 
 /**
+ * Mixins a module injects into its host from a `self.extended` / `self.included`
+ * hook body rather than a lexical `include` in the host's own source — the same
+ * blind spot as `AMBIENT_RAILTIE_MIXINS`, one level closer in.
+ *
+ *   - `ActiveModel::Callbacks.extended(base)` runs
+ *     `base.class_eval { include ActiveSupport::Callbacks }`
+ *     (activemodel/lib/active_model/callbacks.rb:66-70), so every host that
+ *     `extend`s it answers `run_callbacks` / `set_callback` / `skip_callback` /
+ *     `reset_callbacks`. `ActiveModel::Validations`' `included` block extends it
+ *     (validations.rb:42), which is how `ActiveModel::Model` gets them.
+ */
+const HOOK_INJECTED_MIXINS: Record<string, { includes: string[] }> = {
+  "ActiveModel::Callbacks": {
+    includes: ["ActiveSupport::Callbacks"],
+  },
+};
+
+/**
  * Methods a Rails file's host class/module gains by including a mixin whose
  * SOURCE file is on `UNPORTED_FILES` — so `collectAllowedNames`'s `walkMixin`
  * skips the mixin (mirroring `compare.flattenIncludedMethodInfos` at
@@ -1214,6 +1232,8 @@ function collectAllowedNames(
     for (const c of candidates) allowed.add(c);
   };
 
+  const CONCERN = "ActiveSupport::Concern";
+
   // Ruby-side walk: a duplicated short name is disambiguated by the enclosing
   // namespace inside `resolveModuleName`, so this needs no declaring-file hint
   // the way the TS sites do (compare.ts `resolveEntityByDeclaringFile`).
@@ -1226,6 +1246,7 @@ function collectAllowedNames(
     // because the same name can ALSO be a vendored core_ext reopening, which
     // contributes its own `def`s through the walk below.
     for (const name of CORE_MIXIN_METHODS[fqn] ?? []) addRubyName(name);
+    for (const inc of HOOK_INJECTED_MIXINS[fqn]?.includes ?? []) walkMixin(inc, fqn);
     // Fall back to the cross-package map: a railtie-injected mixin (see
     // AMBIENT_RAILTIE_MIXINS) or a fully-qualified cross-gem include lives
     // in another package's modules, not this package's.
@@ -1246,8 +1267,22 @@ function collectAllowedNames(
     // methods on the module itself stay on the module (Ruby `include`
     // semantics; matches compare.flattenIncludedMethodInfos).
     addMethods(mod.instanceMethods, fqn);
-    // Chain `include`s only — a module's own `extend` doesn't propagate
-    // (Ruby singleton-class semantics).
+    // `include M` where `M extend ActiveSupport::Concern` also runs
+    // `base.extend M::ClassMethods` and the `included` block
+    // (activesupport/lib/active_support/concern.rb:139-143), so the includer
+    // answers both as class methods. Neither reaches the host through its own
+    // `includes` — the static extractor files `M::ClassMethods` as a separate
+    // entity, and it flattens `included do extend X end` into `M`'s `extends`.
+    // Both are gated on the Concern: a plain module's body `extend` really is
+    // singleton-only and must not propagate.
+    // Spelled `ActiveSupport::Concern` from another gem and bare `Concern` from
+    // inside `module ActiveSupport` (callbacks.rb:65); `moduleFqnByShort` is the
+    // HOST package's map, so it cannot requalify the bare one.
+    const isConcern = (ext: string): boolean => ext === CONCERN || ext === "Concern";
+    if ((mod.extends ?? []).some(isConcern)) {
+      walkMixin(`${fqn}::ClassMethods`, fqn);
+      for (const ext of mod.extends ?? []) if (!isConcern(ext)) walkMixin(ext, fqn);
+    }
     for (const inc of mod.includes ?? []) walkMixin(inc, fqn);
   };
 

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1269,7 +1269,7 @@ function collectAllowedNames(
     addMethods(mod.instanceMethods, fqn);
     // `include M` where `M extend ActiveSupport::Concern` also runs
     // `base.extend M::ClassMethods` and the `included` block
-    // (activesupport/lib/active_support/concern.rb:139-143), so the includer
+    // (activesupport/lib/active_support/concern.rb:137-138), so the includer
     // answers both as class methods. Neither reaches the host through its own
     // `includes` — the static extractor files `M::ClassMethods` as a separate
     // entity, and it flattens `included do extend X end` into `M`'s `extends`.
@@ -1277,8 +1277,11 @@ function collectAllowedNames(
     // singleton-only and must not propagate.
     // Spelled `ActiveSupport::Concern` from another gem and bare `Concern` from
     // inside `module ActiveSupport` (callbacks.rb:65); `moduleFqnByShort` is the
-    // HOST package's map, so it cannot requalify the bare one.
-    const isConcern = (ext: string): boolean => ext === CONCERN || ext === "Concern";
+    // HOST package's map, so it cannot requalify the bare one. Ruby's own
+    // lexical lookup is the guard on the bare spelling: it only resolves to
+    // `ActiveSupport::Concern` inside `ActiveSupport`.
+    const isConcern = (ext: string): boolean =>
+      ext === CONCERN || (ext === "Concern" && fqn.startsWith("ActiveSupport::"));
     if ((mod.extends ?? []).some(isConcern)) {
       walkMixin(`${fqn}::ClassMethods`, fqn);
       for (const ext of mod.extends ?? []) if (!isConcern(ext)) walkMixin(ext, fqn);


### PR DESCRIPTION
## What

`activemodel/model.ts` scored 61 `moved` names on `pnpm parity:api:extra`. That
number was two populations, and this PR separates them — with no `packages/**`
change at all.

### 1. The allow-set was not following `ActiveSupport::Concern`

`include M` where `M extend ActiveSupport::Concern` also runs
`base.extend M::ClassMethods` and the `included` block
(`activesupport/lib/active_support/concern.rb:137-138`). The static Ruby
extractor files `M::ClassMethods` as its own entity, and it flattens
`included do extend X end` into `M`'s `extends` list — so neither reached the
includer through `walkMixin`. `ActiveModel::Model` therefore scored `validates`,
`validators`, `validatorsOn`, `clearValidatorsBang`, `validatesEach`,
`modelName`, `lookupAncestors`, `humanAttributeName`, `i18nScope` and
`defineModelCallbacks` as drift, on a class whose Ruby counterpart genuinely
answers all ten (`activemodel/lib/active_model/validations.rb:38-52`,
`api.rb:59-68`).

Both are gated on the Concern: a plain module's body `extend` really is
singleton-only and must not propagate.

### 2. `ActiveModel::Callbacks.extended` — the same blind spot, one level in

`ActiveModel::Callbacks.extended(base)` runs
`base.class_eval { include ActiveSupport::Callbacks }`
(`activemodel/lib/active_model/callbacks.rb:66-70`), which is how a
`Validations`-including class answers `run_callbacks` / `set_callback` /
`skip_callback` / `reset_callbacks`. A `self.extended` body is exactly as
invisible to a static extractor as a railtie `on_load` block, so it joins as
`HOOK_INJECTED_MIXINS`, the sibling table to `AMBIENT_RAILTIE_MIXINS`.

### 3. What is left is the real deviation

`model.ts`: **61 → 45 moved**. activerecord's extra total: **1318 → 1170**
(mark narrowed with `parity:api:extra:tighten`; the gate never widens).

The 45 left are exactly the ActiveRecord-shaped mixin set trails hoists onto
`ActiveModel::Model` — Attributes, AttributeRegistration, AttributeMethods,
Dirty, Serialization, Serializers::JSON, Validations::Callbacks — which Rails
composes on `ActiveRecord::Base`, not on `ActiveModel::Model`.

## Scope

The story asked for the relocation too (`model.ts` at 0 moved, ≤ 200 lines).
That does not fit here and is not a diff-size preference: ~55 files under
`packages/activemodel/src/**` declare `class X extends Model` and read those
members off the inherited surface, where Rails' own activemodel tests compose
the mixins per test class. Each needs its own `include(X, Attributes)` plus the
`interface X extends …` merge that types it.

So the story was re-scoped to the measurement half (prose edit, tasks repo), and
the relocation is filed with the full per-mixin inventory and the Rails host
each mixin belongs to:
`0115-activemodel-fidelity-convergence/relocate-active-record-shaped-mixins-off-active-model-model`.

## Verification

- `pnpm vitest run scripts/api-compare` — 1381 passed. The two new positive
  tests fail on baseline (verified by reverting `extra-surface.ts`).
- `pnpm parity:api:extra:gate` OK (arel 0/0, 62/62; activerecord 372/372,
  1170/1170).
- `pnpm parity:api:calls` / `:args` OK. `pnpm lint`, `pnpm typecheck` clean.

Closes-story: split-model-mixin-surface-to-active-model-model
