### PR TITLE
refactor(activerecord): let TimeZoneConverter#serialize delegate as Rails does (RFC 0112)

### DIFF
--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -56,6 +56,7 @@ export function serializeCastValue<T>(this: TimeValueHost, value: T): T {
  * `respond_to?(:nsec)` else arm and passes through.
  */
 type NsecBearing =
+  | TimeWithZone
   | Temporal.Instant
   | Temporal.PlainDateTime
   | Temporal.ZonedDateTime
@@ -306,6 +307,7 @@ export const TimeValue = {
 
 function respondToNsec(value: unknown): value is NsecBearing {
   return (
+    value instanceof TimeWithZone ||
     value instanceof Temporal.Instant ||
     value instanceof Temporal.PlainDateTime ||
     value instanceof Temporal.ZonedDateTime ||
@@ -315,6 +317,7 @@ function respondToNsec(value: unknown): value is NsecBearing {
 
 /** `Time#nsec` — the fraction of the second, always in `0...1_000_000_000`. */
 function nsec(value: NsecBearing): bigint {
+  if (value instanceof TimeWithZone) return BigInt(value.nsec);
   if (value instanceof Temporal.Instant) {
     return ((value.epochNanoseconds % NANOS_PER_SECOND) + NANOS_PER_SECOND) % NANOS_PER_SECOND;
   }
@@ -325,8 +328,21 @@ function nsec(value: NsecBearing): bigint {
   );
 }
 
-/** `Time#change(nsec:)` — replaces the sub-second fraction, leaving the second. */
+/**
+ * `Time#change(nsec:)` — replaces the sub-second fraction, leaving the second.
+ * `TimeWithZone#change` (time_with_zone.rb:390-410) is the Ruby receiver here,
+ * but trails' port of it is millisecond-granular, so the fraction is replaced on
+ * the UTC instant and re-wrapped in the receiver's zone — the same value Ruby
+ * answers, without the lossy hop.
+ */
 function changeNsec<T extends NsecBearing>(value: T, newNsec: bigint): T {
+  if (value instanceof TimeWithZone) {
+    const utc = value.utc().toTime().toInstant();
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochNanoseconds(utc.epochNanoseconds - nsec(value) + newNsec),
+      value.timeZone,
+    ) as T;
+  }
   if (value instanceof Temporal.Instant) {
     return Temporal.Instant.fromEpochNanoseconds(
       value.epochNanoseconds - nsec(value) + newNsec,

--- a/packages/activemodel/src/type/helpers/time-value.ts
+++ b/packages/activemodel/src/type/helpers/time-value.ts
@@ -328,20 +328,10 @@ function nsec(value: NsecBearing): bigint {
   );
 }
 
-/**
- * `Time#change(nsec:)` — replaces the sub-second fraction, leaving the second.
- * `TimeWithZone#change` (time_with_zone.rb:390-410) is the Ruby receiver here,
- * but trails' port of it is millisecond-granular, so the fraction is replaced on
- * the UTC instant and re-wrapped in the receiver's zone — the same value Ruby
- * answers, without the lossy hop.
- */
+/** `Time#change(nsec:)` — replaces the sub-second fraction, leaving the second. */
 function changeNsec<T extends NsecBearing>(value: T, newNsec: bigint): T {
   if (value instanceof TimeWithZone) {
-    const utc = value.utc().toTime().toInstant();
-    return new TimeWithZone(
-      Temporal.Instant.fromEpochNanoseconds(utc.epochNanoseconds - nsec(value) + newNsec),
-      value.timeZone,
-    ) as T;
+    return value.change({ nsec: Number(newNsec) }) as T;
   }
   if (value instanceof Temporal.Instant) {
     return Temporal.Instant.fromEpochNanoseconds(

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.trails.test.ts
@@ -169,21 +169,25 @@ describe("TimeZoneConverter#serialize containers", () => {
   const instant = Temporal.Instant.from("2020-06-15T10:00:00Z");
   const twz = () => new TimeWithZone(instant, zone);
 
-  it("extracts TimeWithZone bounds out of a range", () => {
+  it("forwards TimeWithZone range bounds to the subtype untouched", () => {
     const converter = TimeZoneConverter.wrap(new RangeType(new Types.DateTimeType({})));
     const serialized = converter.serialize(new Range(twz(), twz(), true)) as Range;
-    expect(serialized.begin).toBeInstanceOf(Temporal.Instant);
-    expect((serialized.begin as Temporal.Instant).epochNanoseconds).toBe(instant.epochNanoseconds);
+    expect(serialized.begin).toBeInstanceOf(TimeWithZone);
+    expect((serialized.begin as TimeWithZone).utc().toTime().toInstant().epochNanoseconds).toBe(
+      instant.epochNanoseconds,
+    );
   });
 
-  it("extracts TimeWithZone bounds out of an array of ranges", () => {
+  it("forwards TimeWithZone bounds through an array of ranges", () => {
     const converter = TimeZoneConverter.wrap(
       new ArrayType(new RangeType(new Types.DateTimeType({}))),
     );
     const serialized = converter.serialize([new Range(twz(), twz(), true)]) as { values: Range[] };
     const begin = serialized.values[0].begin;
-    expect(begin).toBeInstanceOf(Temporal.Instant);
-    expect((begin as Temporal.Instant).epochNanoseconds).toBe(instant.epochNanoseconds);
+    expect(begin).toBeInstanceOf(TimeWithZone);
+    expect((begin as TimeWithZone).utc().toTime().toInstant().epochNanoseconds).toBe(
+      instant.epochNanoseconds,
+    );
   });
 
   it("leaves an infinite range bound untouched", () => {

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -108,23 +108,31 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return this.convertTimeToTimeZone(this._subtype.deserialize(value));
   }
 
+  /**
+   * Rails defines no `serialize` on `TimeZoneConverter`: `DelegateClass(Type::Value)`
+   * forwards it to the subtype untouched (time_zone_conversion.rb:8-52), which
+   * handles a `TimeWithZone` because it `acts_like?(:time)`. TS has no
+   * `method_missing`, so the forward is spelled out — but it stays a forward.
+   */
   override serialize(value: unknown): unknown {
-    // Rails' DelegateClass forwards serialize to the subtype, which calls
-    // cast_value on it. In Ruby, TimeWithZone acts_like?(:time) so AR's
-    // DateTime type can handle it. In TS, DateTime.castValue() can't parse
-    // a TimeWithZone — extract the UTC Temporal.Instant first.
-    return this._subtype.serialize(this._resolveForSerialize(value));
+    return this._subtype.serialize(value);
   }
 
+  /**
+   * Rails' `SerializeCastValue.serialize` deliberately refuses the fast path for
+   * a DelegateClass instance — `type.equal?(type.itself_if_serialize_cast_value_compatible)`
+   * is false because the delegator forwards the message to the subtype
+   * (serialize_cast_value.rb:25-33) — so the subtype decides between its own
+   * `serialize_cast_value` and `serialize`.
+   */
   override serializeCastValue(value: unknown): unknown {
-    const resolved = this._resolveForSerialize(value);
     const sub = this._subtype as ValueTypeInstance;
     if (typeof sub.itselfIfSerializeCastValueCompatible === "function") {
       return sub.itselfIfSerializeCastValueCompatible()
-        ? sub.serializeCastValue(resolved as any)
-        : this._subtype.serialize(resolved);
+        ? sub.serializeCastValue(value as any)
+        : this._subtype.serialize(value);
     }
-    return this._subtype.serialize(resolved);
+    return this._subtype.serialize(value);
   }
 
   // Rails' DelegateClass(Type::Value) auto-forwards these to the subtype; the
@@ -170,18 +178,6 @@ export class TimeZoneConverter extends ValueType<unknown> {
     if (subsec < 0n) subsec += 1_000_000_000n;
     const roundedOff = subsec % mod;
     return ns - roundedOff;
-  }
-
-  // Rails has no such hop: DelegateClass forwards serialize straight to the
-  // subtype, whose cast_value handles a TimeWithZone because it acts_like?(:time).
-  // Containers take the subtype's own `map` hook, the one `cast` and
-  // `convert_time_to_time_zone` end in (value.rb:117-119, oid/range.rb:50-54,
-  // oid/array.rb:67-69).
-  private _resolveForSerialize(value: unknown): unknown {
-    if (value instanceof TimeWithZone) return value.utc().toTime().toInstant();
-    if (value instanceof Temporal.Instant) return value;
-    if (typeof value === "number" && !Number.isFinite(value)) return value;
-    return this.map(value, (v) => this._resolveForSerialize(v));
   }
 
   override equals(other: Type): boolean {

--- a/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-converter.test.ts
@@ -126,28 +126,33 @@ describe("TimeZoneConverterTest", () => {
     expect(twz.hour).toBe(10);
   });
 
-  it("serialize extracts UTC from TimeWithZone before delegating to subtype", () => {
+  it("serialize forwards the TimeWithZone to the subtype untouched", () => {
     setZone("Eastern Time (US & Canada)");
     const converter = new TimeZoneConverter(new DateTime());
     const instant = Temporal.Instant.from("2024-06-15T14:00:00Z");
     const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
     const twz = new TimeWithZone(instant, eastern);
-    // 14:00 UTC displayed as 10:00 EDT; serialize (value_for_database) returns the
-    // cast UTC Temporal.Instant — the adapter renders the SQL literal downstream.
+    // Rails' DelegateClass forwards `serialize` to the subtype, whose
+    // `ActiveModel::Type::Value#serialize` is the identity — value_for_database
+    // IS the TimeWithZone, and `quoted_date` getutc's it downstream.
     const result = converter.serialize(twz);
-    expect(result).toBeInstanceOf(Temporal.Instant);
-    expect((result as Temporal.Instant).toString()).toBe("2024-06-15T14:00:00Z");
+    expect(result).toBeInstanceOf(TimeWithZone);
+    expect((result as TimeWithZone).utc().toTime().toInstant().toString()).toBe(
+      "2024-06-15T14:00:00Z",
+    );
   });
 
-  it("serialize round-trips: deserialize then serialize returns the cast UTC value", () => {
+  it("serialize round-trips: deserialize then serialize returns the cast value", () => {
     setZone("Eastern Time (US & Canada)");
     const converter = new TimeZoneConverter(new DateTime());
     const deserialized = converter.deserialize("2024-06-15 14:00:00");
     expect(deserialized).toBeInstanceOf(TimeWithZone);
     const serialized = converter.serialize(deserialized);
-    // value_for_database is the cast UTC Temporal.Instant, not a SQL string.
-    expect(serialized).toBeInstanceOf(Temporal.Instant);
-    expect((serialized as Temporal.Instant).toString()).toBe("2024-06-15T14:00:00Z");
+    // value_for_database is the cast TimeWithZone, not a SQL string.
+    expect(serialized).toBeInstanceOf(TimeWithZone);
+    expect((serialized as TimeWithZone).utc().toTime().toInstant().toString()).toBe(
+      "2024-06-15T14:00:00Z",
+    );
   });
 
   it("falls back to ActiveRecord.default_timezone when the subtype has no is_utc?", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting-helpers.trails.test.ts
@@ -16,6 +16,7 @@ import { NotImplementedError } from "../../errors.js";
 import { describe, expect, it } from "vitest";
 import { Temporal } from "@blazetrails/date";
 import { BinaryData } from "@blazetrails/activemodel";
+import { TimeWithZone, TimeZone } from "@blazetrails/activesupport";
 import {
   quote,
   quoteTableName,
@@ -44,6 +45,19 @@ describe("quotedDate", () => {
   it("formats a Temporal.PlainTime (normalised to 2000-01-01 date)", () => {
     const v = Temporal.PlainTime.from("14:23:55");
     expect(quotedDate(v)).toBe("2000-01-01 14:23:55");
+  });
+
+  it("formats a TimeWithZone through its UTC instant", () => {
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    const v = new TimeWithZone(Temporal.Instant.from("2026-04-26T14:23:55Z"), eastern);
+    expect(quotedDate(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("quote and type_cast route a TimeWithZone through quotedDate", () => {
+    const eastern = TimeZone.find("Eastern Time (US & Canada)")!;
+    const v = new TimeWithZone(Temporal.Instant.from("2026-04-26T14:23:55Z"), eastern);
+    expect(quote.call(quotingHost(), v)).toBe("'2026-04-26 14:23:55'");
+    expect(typeCast.call(quotingHost(), v)).toBe("2026-04-26 14:23:55");
   });
 
   it("formats a Temporal.ZonedDateTime via its instant", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -480,7 +480,7 @@ export function quotedDate(
     | Temporal.PlainTime,
 ): string {
   // Rails: `value.acts_like?(:time)` (abstract/quoting.rb:185-191), which an
-  // `ActiveSupport::TimeWithZone` answers true (time_with_zone.rb:52-54). Both
+  // `ActiveSupport::TimeWithZone` answers true (time_with_zone.rb:504-506). Both
   // the `getutc` and the `getlocal` arm name the same instant, and rendering it
   // in `default_timezone` is what `formatInstantForSql` already does.
   if (value instanceof TimeWithZone) value = value.utc().toTime().toInstant();

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -15,7 +15,7 @@
  */
 
 import { Temporal } from "@blazetrails/date";
-import { BigDecimal } from "@blazetrails/activesupport";
+import { BigDecimal, TimeWithZone } from "@blazetrails/activesupport";
 import { Attribute as ModelAttribute, BinaryData, type Type } from "@blazetrails/activemodel";
 import type { TypeMap } from "../../type/type-map.js";
 import { NotImplementedError } from "../../errors.js";
@@ -69,6 +69,7 @@ export interface QuotingDispatchHost {
 export type QuotedTimeValue = TimeValue | Temporal.PlainTime | Temporal.PlainDateTime;
 
 type TemporalDateLike =
+  | TimeWithZone
   | Temporal.Instant
   | Temporal.ZonedDateTime
   | Temporal.PlainDateTime
@@ -151,6 +152,7 @@ export function quote(this: QuotingDispatchHost, value: unknown): string {
   if (value instanceof TimeValue || value instanceof Temporal.PlainTime)
     return `'${this.quotedTime(value)}'`;
   if (
+    value instanceof TimeWithZone ||
     value instanceof Temporal.Instant ||
     value instanceof Temporal.PlainDateTime ||
     value instanceof Temporal.PlainDate ||
@@ -208,6 +210,7 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   if (value instanceof TimeValue || value instanceof Temporal.PlainTime)
     return this.quotedTime(value);
   if (
+    value instanceof TimeWithZone ||
     value instanceof Temporal.Instant ||
     value instanceof Temporal.PlainDateTime ||
     value instanceof Temporal.PlainDate ||
@@ -469,12 +472,18 @@ export function isSqlLiteral(value: unknown): value is { value: string } {
  */
 export function quotedDate(
   value:
+    | TimeWithZone
     | Temporal.Instant
     | Temporal.ZonedDateTime
     | Temporal.PlainDateTime
     | Temporal.PlainDate
     | Temporal.PlainTime,
 ): string {
+  // Rails: `value.acts_like?(:time)` (abstract/quoting.rb:185-191), which an
+  // `ActiveSupport::TimeWithZone` answers true (time_with_zone.rb:52-54). Both
+  // the `getutc` and the `getlocal` arm name the same instant, and rendering it
+  // in `default_timezone` is what `formatInstantForSql` already does.
+  if (value instanceof TimeWithZone) value = value.utc().toTime().toInstant();
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);
   if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -26,7 +26,7 @@ import { Rational, Temporal } from "@blazetrails/date";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { Value as TimeValue } from "../../type/time.js";
 import { BinaryData } from "@blazetrails/activemodel";
-import { toS } from "@blazetrails/activesupport";
+import { toS, TimeWithZone } from "@blazetrails/activesupport";
 
 // Rails MySQL overrides unquoted_true/false (1/0) but NOT quoted_true/false,
 // which inherit the abstract "TRUE"/"FALSE" (mysql/quoting.rb).
@@ -218,12 +218,17 @@ export function columnNameWithOrderMatcher(): RegExp {
  */
 export function quotedDate(
   value:
+    | TimeWithZone
     | Temporal.Instant
     | Temporal.ZonedDateTime
     | Temporal.PlainDateTime
     | Temporal.PlainDate
     | Temporal.PlainTime,
 ): string {
+  // Rails: the inherited `quoted_date` normalises an `acts_like?(:time)` value
+  // through `getutc`/`getlocal` (abstract/quoting.rb:185-191); an
+  // `ActiveSupport::TimeWithZone` takes that arm (time_with_zone.rb:52-54).
+  if (value instanceof TimeWithZone) value = value.utc().toTime().toInstant();
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);
   if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());
   if (value instanceof Temporal.PlainDateTime) return formatPlainDateTimeForSql(value);

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -227,7 +227,7 @@ export function quotedDate(
 ): string {
   // Rails: the inherited `quoted_date` normalises an `acts_like?(:time)` value
   // through `getutc`/`getlocal` (abstract/quoting.rb:185-191); an
-  // `ActiveSupport::TimeWithZone` takes that arm (time_with_zone.rb:52-54).
+  // `ActiveSupport::TimeWithZone` takes that arm (time_with_zone.rb:504-506).
   if (value instanceof TimeWithZone) value = value.utc().toTime().toInstant();
   if (value instanceof Temporal.Instant) return formatInstantForSql(value);
   if (value instanceof Temporal.ZonedDateTime) return formatInstantForSql(value.toInstant());

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -29,7 +29,7 @@ import { Data as BitData } from "./oid/bit.js";
 import { Range, rangeBoundLiteral } from "./oid/range.js";
 import { Data as XmlData } from "./oid/xml.js";
 import { Utils } from "./utils.js";
-import { toS } from "@blazetrails/activesupport";
+import { toS, TimeWithZone } from "@blazetrails/activesupport";
 
 // Rails inherits from StandardError — use plain Error in TS for
 // parity. JS's `RangeError` is a built-in that extends Error; it
@@ -427,12 +427,17 @@ export function checkIntegerRange(value: bigint | number): void {
  */
 export function quotedDate(
   value:
+    | TimeWithZone
     | Temporal.Instant
     | Temporal.ZonedDateTime
     | Temporal.PlainDateTime
     | Temporal.PlainDate
     | Temporal.PlainTime,
 ): string {
+  // Rails: the inherited `quoted_date` normalises an `acts_like?(:time)` value
+  // through `getutc`/`getlocal` (abstract/quoting.rb:185-191); an
+  // `ActiveSupport::TimeWithZone` takes that arm (time_with_zone.rb:52-54).
+  if (value instanceof TimeWithZone) value = value.utc().toTime().toInstant();
   if (value instanceof Temporal.Instant) return formatInstantForSqlPostgres(value);
   if (value instanceof Temporal.ZonedDateTime)
     return formatInstantForSqlPostgres(value.toInstant());

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -436,7 +436,7 @@ export function quotedDate(
 ): string {
   // Rails: the inherited `quoted_date` normalises an `acts_like?(:time)` value
   // through `getutc`/`getlocal` (abstract/quoting.rb:185-191); an
-  // `ActiveSupport::TimeWithZone` takes that arm (time_with_zone.rb:52-54).
+  // `ActiveSupport::TimeWithZone` takes that arm (time_with_zone.rb:504-506).
   if (value instanceof TimeWithZone) value = value.utc().toTime().toInstant();
   if (value instanceof Temporal.Instant) return formatInstantForSqlPostgres(value);
   if (value instanceof Temporal.ZonedDateTime)

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -24,7 +24,7 @@ import { Value as TimeValue } from "../../type/time.js";
 import { Temporal } from "@blazetrails/date";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { BinaryData } from "@blazetrails/activemodel";
-import { toS } from "@blazetrails/activesupport";
+import { toS, TimeWithZone } from "@blazetrails/activesupport";
 
 export function quotedTrue(): string {
   return "1";
@@ -119,6 +119,7 @@ export function quoteTableNameForAssignment(_table: string, attr: string): strin
  */
 export function quotedDate(
   value:
+    | TimeWithZone
     | Temporal.Instant
     | Temporal.ZonedDateTime
     | Temporal.PlainDateTime

--- a/packages/activesupport/src/time-with-zone.trails.test.ts
+++ b/packages/activesupport/src/time-with-zone.trails.test.ts
@@ -40,6 +40,22 @@ describe("TimeWithZone sub-millisecond precision", () => {
     expect(subMs().xmlschema(6)).toBe("1999-12-31T19:00:00.123456-05:00");
     expect(subMs().xmlschema(9)).toBe("1999-12-31T19:00:00.123456789-05:00");
   });
+
+  it("change(nsec:) keeps every nanosecond digit", () => {
+    expect(subMs().change({ nsec: 987654321 }).nsec).toBe(987654321);
+  });
+
+  it("change(usec:) keeps every microsecond digit", () => {
+    expect(subMs().change({ usec: 987654 }).nsec).toBe(987654000);
+  });
+
+  it("change of an unrelated component carries the fraction through", () => {
+    expect(subMs().change({ year: 2020 }).nsec).toBe(123456789);
+  });
+
+  it("change of a lower component still zeroes the fraction", () => {
+    expect(subMs().change({ hour: 3 }).nsec).toBe(0);
+  });
 });
 
 // `to_fs` resolves through `Time::DATE_FORMATS` (time_with_zone.rb:212-220), so

--- a/packages/activesupport/src/time-with-zone.ts
+++ b/packages/activesupport/src/time-with-zone.ts
@@ -868,17 +868,26 @@ export class TimeWithZone {
     const min = options.min ?? (options.hour !== undefined ? 0 : l.minute);
     const sec =
       options.sec ?? (options.hour !== undefined || options.min !== undefined ? 0 : l.second);
+    // Ruby carries the whole fraction into `new_sec` as a Rational
+    // (calculations.rb:132-141), so `change` is nanosecond-exact. `Date.UTC` and
+    // `TimeZone#local` are millisecond-granular, so the fraction is split: the
+    // millisecond half goes through them and `subMsNsec` is added back to the
+    // resulting instant, which is exact because a zone offset is whole seconds.
     let ms = l.millisecond;
+    let subMsNsec = l.nsec % 1_000_000;
     if (options.usec !== undefined) {
       ms = Math.floor(options.usec / 1000);
+      subMsNsec = (options.usec % 1000) * 1_000;
     } else if (options.nsec !== undefined) {
       ms = Math.floor(options.nsec / 1_000_000);
+      subMsNsec = options.nsec % 1_000_000;
     } else if (
       options.hour !== undefined ||
       options.min !== undefined ||
       options.sec !== undefined
     ) {
       ms = 0;
+      subMsNsec = 0;
     }
 
     // `periods.include?(period) ? period : nil` (time_with_zone.rb:406): the
@@ -895,12 +904,26 @@ export class TimeWithZone {
       (p) =>
         p.observedUtcOffset === this.period.observedUtcOffset && p.isDst() === this.period.isDst(),
     );
-    if (!period) return this._timeZone.local(year, month, day, hour, min, sec, ms);
+    if (!period) {
+      const base = this._timeZone.local(year, month, day, hour, min, sec, ms);
+      return subMsNsec === 0 ? base : this._withSubMsNsec(base, subMsNsec);
+    }
     return new TimeWithZone(
-      Temporal.Instant.fromEpochMilliseconds(
-        newTime.epochMilliseconds - period.observedUtcOffset * 1000,
+      Temporal.Instant.fromEpochNanoseconds(
+        BigInt(newTime.epochMilliseconds - period.observedUtcOffset * 1000) * 1_000_000n +
+          BigInt(subMsNsec),
       ),
       this._timeZone,
+    );
+  }
+
+  /** @internal Adds back the sub-millisecond half of a {@link change} fraction. */
+  private _withSubMsNsec(base: TimeWithZone, subMsNsec: number): TimeWithZone {
+    return new TimeWithZone(
+      Temporal.Instant.fromEpochNanoseconds(
+        base.utc().toTime().toInstant().epochNanoseconds + BigInt(subMsNsec),
+      ),
+      base.timeZone,
     );
   }
 


### PR DESCRIPTION
Rails' `TimeZoneConverter` is a `DelegateClass(Type::Value)` and defines no
`serialize` / `serialize_cast_value` of its own
(`activerecord/lib/active_record/attribute_methods/time_zone_conversion.rb:8-52`):
both forward straight to the subtype, which handles a `TimeWithZone` because it
`acts_like?(:time)`.

trails carried a `_resolveForSerialize` pre-walk plus the local `isRangeLike` /
`mapRange` / `RangeLike` trio that stripped a `TimeWithZone` down to a
`Temporal.Instant` before delegating — the last holdout of the re-derived
container dispatch PR #6485 removed from `cast` and `deserialize`.

- `serialize` / `serializeCastValue` are now thin DelegateClass forwards that
  pass the value untouched (TS has no `method_missing`, so the forward is
  spelled out). `serializeCastValue` lets the *subtype* choose between its own
  `serialize_cast_value` and `serialize`, which is what Rails'
  `SerializeCastValue.serialize` does for a delegator
  (`activemodel/lib/active_model/type/serialize_cast_value.rb:25-33`).
- `_resolveForSerialize`, `isRangeLike`, `mapRange` and `RangeLike` are deleted.
- `Helpers::TimeValue#apply_seconds_precision` now recognises a `TimeWithZone`
  receiver (`time_value.rb:24-34` — Ruby reaches `nsec` / `change(nsec:)` on it
  because it is a `::Time`-alike), so dropping the pre-walk does not drop the
  column-precision truncation the extracted `Temporal.Instant` used to get.
- `TimeWithZone#change` itself is now nanosecond-exact, so `changeNsec` calls
  `value.change({ nsec })` the way `apply_seconds_precision` does rather than
  hand-rolling a second nsec-setting path beside it. Ruby carries the whole
  fraction into `new_sec` as a Rational (`core_ext/time/calculations.rb:132-141`);
  the port was millisecond-granular because `Date.UTC` / `TimeZone#local` take a
  millisecond, so the fraction is split — the millisecond half goes through the
  existing construction and the sub-millisecond remainder is added back to the
  instant, exact because a zone offset is whole seconds. The six `end_of_*`
  readers get their `nsec: 999999999` honored as a side effect.
- The `TimeWithZone` is instead taken where Rails takes it: `quoted_date`'s
  `acts_like?(:time)` arm (`abstract/quoting.rb:185-191`), whose `getutc` /
  `getlocal` name the same instant that `formatInstantForSql` already renders in
  `default_timezone`. Added to the abstract `quotedDate` plus the `quote` /
  `type_cast` dispatch (`abstract/quoting.rb:83, 96-104`), and to the PG and
  MySQL `quotedDate` overrides so their BC-suffixing / microsecond-bounded
  formatters still apply.

#7097 landed a partial convergence of this same story while this branch was
open — it routed the pre-walk through the subtype's `map` hook and removed
`isRangeLike` / `mapRange` / `RangeLike`, but kept `_resolveForSerialize`. This
finishes it: the hop Rails does not have is gone entirely.

`with-clause-uses-bespoke-ctes-not-with-values` needed no work: `_ctes` /
`upsertCte` and the `Nodes.Cte` build sites were already removed by #6607, which
converged `with_values` to Rails' hash store — `buildWith` is the only producer
of the WITH clause and it calls `buildWithValueFromHash`. Marked done against
#6607.

Closes-story: time-zone-converter-serialize-rederives-container-walk
