### PR TITLE
refactor(arel): extract Arel.arelNode, give Fragments its own hash/eql/initialize_copy, and base every clone on Object#clone

### DIFF
--- a/packages/arel/src/arel.ts
+++ b/packages/arel/src/arel.ts
@@ -10,7 +10,8 @@
  * side effects. `index.ts` re-exports this module, so `Arel.sql` keeps its
  * public name and path.
  */
-import type { Node } from "./nodes/node.js";
+import { _Attribute } from "./node-slots.js";
+import { Node } from "./nodes/node.js";
 import { SqlLiteral } from "./nodes/sql-literal.js";
 import { BoundSqlLiteral } from "./nodes/bound-sql-literal.js";
 
@@ -56,6 +57,24 @@ export function sql(
  */
 export function star(): SqlLiteral {
   return sql("*", { retryable: true });
+}
+
+/**
+ * Arel.arelNode() — is `value` something an Arel node slot accepts?
+ *
+ * Mirrors: Arel.arel_node? (arel.rb:64-66). The `Attribute` arm goes through
+ * the node-slots late binding: `attributes/attribute.ts` imports half the node
+ * tree, so a value import of it here would close a cycle over this module's
+ * `sql-literal.js` / `bound-sql-literal.js` edges.
+ *
+ * @internal
+ */
+export function arelNode(value: unknown): boolean {
+  return (
+    value instanceof Node ||
+    (_Attribute !== undefined && value instanceof _Attribute) ||
+    value instanceof SqlLiteral
+  );
 }
 
 /**

--- a/packages/arel/src/arel.ts
+++ b/packages/arel/src/arel.ts
@@ -1,8 +1,10 @@
 /**
  * The bare `Arel.*` module functions (arel.rb:31-72).
  *
- * This file deliberately imports nothing at runtime beyond
- * `nodes/sql-literal.js` and `nodes/bound-sql-literal.js`, both leaves. Ruby
+ * This file deliberately imports nothing at runtime beyond `nodes/node.js`,
+ * `nodes/sql-literal.js`, `nodes/bound-sql-literal.js` and the zero-import
+ * `node-slots.js` — `node.ts` reaches only `node-slots.js` and
+ * `collectors/sql-string.js`, so all four are leaves. Ruby
  * resolves `Arel.sql` when the calling method runs, so a Rails body anywhere in the package may name it;
  * in ESM every import is eager, and re-importing them from `index.ts` — which
  * re-exports `select-manager.js`, `visitors/index.js` and friends — would

--- a/packages/arel/src/clone-support.trails.test.ts
+++ b/packages/arel/src/clone-support.trails.test.ts
@@ -1,0 +1,62 @@
+// Trails-only cases with no Rails counterpart: Ruby gets `Object#clone`'s
+// copy-every-ivar semantics from core, so no Rails test asserts them. In TS
+// each `clone()` has to build the copy itself, and these pin the two ways that
+// can silently diverge — a field the body forgot to copy, and a bound instance
+// property carried over still closed over the original (RFC 0124).
+import { describe, it, expect } from "vitest";
+import { Table, Nodes, SelectManager } from "./index.js";
+import { objectClone } from "./clone-support.js";
+
+describe("Arel clone", () => {
+  const users = new Table("users");
+
+  it("carries a field the clone body does not name", () => {
+    const cases: object[] = [
+      new Nodes.Case(users.get("id")),
+      new Nodes.SelectCore(),
+      new Nodes.SelectStatement(),
+      new Nodes.InsertStatement(),
+      new Nodes.UpdateStatement(),
+      new Nodes.DeleteStatement(),
+      new Nodes.Equality(users.get("id"), 1),
+      new Nodes.Fragments([]),
+      new SelectManager(users),
+    ];
+
+    for (const node of cases) {
+      (node as { unnamedField?: string }).unnamedField = "carried";
+      const copy = (node as { clone(): object }).clone();
+      expect(Object.getPrototypeOf(copy)).toBe(Object.getPrototypeOf(node));
+      expect((copy as { unnamedField?: string }).unnamedField).toBe("carried");
+    }
+  });
+
+  it("gives Case#when on the clone the clone's own conditions", () => {
+    const node = new Nodes.Case(users.get("id"));
+    node.when(1, 2);
+    const copy = node.clone();
+    copy.when(3, 4);
+
+    expect(node.conditions.length).toBe(1);
+    expect(copy.conditions.length).toBe(2);
+  });
+
+  // NamedFunction has no `initialize_copy`, so Ruby clones it with bare
+  // `Object#clone` — `objectClone` is what that spells here.
+  it("gives NamedFunction#over on the clone the clone as its operand", () => {
+    const node = new Nodes.NamedFunction("row_number", []);
+    const copy = objectClone(node);
+
+    expect(node.over().left).toBe(node);
+    expect(copy.over().left).toBe(copy);
+  });
+
+  it("gives Fragments its own values array", () => {
+    const node = new Nodes.Fragments([]);
+    const copy = node.clone();
+    copy.values.push(new Nodes.SqlLiteral("x"));
+
+    expect(node.values.length).toBe(0);
+    expect(copy.values.length).toBe(1);
+  });
+});

--- a/packages/arel/src/clone-support.ts
+++ b/packages/arel/src/clone-support.ts
@@ -1,0 +1,36 @@
+// Ruby's `Object#clone` / `#clone` on a slot value, which the arel
+// `initialize_copy` bodies are written on top of.
+//
+// Ruby allocates a copy of the same class carrying EVERY ivar and then runs
+// `initialize_copy` on it, so a Rails `initialize_copy` only has to name the
+// slots it duplicates — a field nobody thought about still rides along. JS has
+// no such primitive, so every arel `clone()` starts from `objectClone(this)`
+// and then does exactly what its Ruby `initialize_copy` does.
+//
+// This file has no Rails counterpart because Ruby gets both functions from
+// core; it is not a trails abstraction over a Rails one.
+
+/**
+ * Ruby `Object#clone`: a copy of the same class carrying every own property.
+ *
+ * @internal
+ */
+export function objectClone<T extends object>(self: T): T {
+  return Object.assign(Object.create(Object.getPrototypeOf(self) as object) as T, self);
+}
+
+/**
+ * Ruby `#clone` on whatever occupies a node slot: an object that defines its
+ * own `clone` runs it (Ruby would run its `initialize_copy` the same way), an
+ * Array copies, a non-object is returned as-is, and anything else gets the
+ * shallow same-class copy `Object#clone` is.
+ *
+ * @internal
+ */
+export function cloneSlot<T>(value: T): T {
+  if (Array.isArray(value)) return [...value] as T;
+  if (typeof value !== "object" || value === null) return value;
+  const cloneable = value as { clone?: () => T };
+  if (typeof cloneable.clone === "function") return cloneable.clone();
+  return objectClone(value as object) as T;
+}

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -1,6 +1,7 @@
 import type { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import type { Temporal } from "@blazetrails/date";
 import { include } from "@blazetrails/activesupport";
+import { cloneSlot, objectClone } from "../clone-support.js";
 import { _Attribute, _Equality, _In } from "../node-slots.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
@@ -104,21 +105,6 @@ export const FetchAttribute = {
   },
 };
 
-// Ruby `Object#clone` on whatever occupies a Binary slot: a node that defines
-// its own `clone` runs it (Ruby would run its `initialize_copy` the same way),
-// an Array copies, and anything else gets the shallow same-class copy Ruby's
-// `Object#clone` is. Note the shallow arm carries over an own property holding
-// a bound function — the trails idiom for a Ruby `include` override, e.g.
-// `NamedFunction#over` — still bound to the ORIGINAL; give such a node its own
-// `clone` before putting it through here.
-function cloneSlot(value: NodeOrValue): NodeOrValue {
-  if (Array.isArray(value)) return [...value] as NodeOrValue;
-  const cloneable = value as { clone?: () => NodeOrValue };
-  if (typeof cloneable.clone === "function") return cloneable.clone();
-  if (typeof value !== "object" || value === null) return value;
-  return Object.assign(Object.create(Object.getPrototypeOf(value) as object) as object, value);
-}
-
 export class Binary extends NodeExpression {
   left: NodeOrValue;
   right: NodeOrValue;
@@ -133,7 +119,7 @@ export class Binary extends NodeExpression {
   // runs for `#clone` — the two slots are duplicated so a cloned node's array
   // or node halves are not shared with the original.
   clone(): this {
-    const copy = Object.assign(Object.create(Object.getPrototypeOf(this) as object) as this, this);
+    const copy = objectClone(this);
     if (this.left != null && this.left !== false) copy.left = cloneSlot(this.left);
     if (this.right != null && this.right !== false) copy.right = cloneSlot(this.right);
     return copy;

--- a/packages/arel/src/nodes/bound-sql-literal.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.ts
@@ -1,3 +1,5 @@
+import { ArgumentError } from "@blazetrails/activesupport";
+import { arelNode } from "../arel.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { BindError } from "../errors.js";
@@ -78,9 +80,9 @@ export class BoundSqlLiteral extends NodeExpression {
   // Param widened to `unknown` so the runtime guard is reachable from typed
   // callers too (matches Rails' runtime-validation intent).
   plus(other: unknown): Fragments {
-    if (!(other instanceof Node)) {
-      throw new TypeError("Expected Arel node");
+    if (!arelNode(other)) {
+      throw new ArgumentError("Expected Arel node");
     }
-    return new Fragments([this, other]);
+    return new Fragments([this, other as Node]);
   }
 }

--- a/packages/arel/src/nodes/case.ts
+++ b/packages/arel/src/nodes/case.ts
@@ -1,3 +1,4 @@
+import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -26,16 +27,16 @@ export class Case extends NodeExpression {
     this.default = defaultValue ?? null;
   }
 
-  // Property-form override (vs. `when(...) {}`): Predications.when is
-  // mixed into NodeExpression as a property via Included<>, and Case
-  // overrides with self-mutating semantics (Rails: builds When clauses
-  // on this.conditions, returns self).
-  when = (condition: Node | unknown, result?: Node | unknown): this => {
+  // Overrides the mixed-in Predications.when with Case's self-mutating
+  // semantics (case.rb:13-16). A prototype method, not an own property: an own
+  // property would be copied by `objectClone` still closed over the ORIGINAL,
+  // so a cloned Case's `#when` would mutate the original's conditions.
+  when(condition: Node | unknown, result?: Node | unknown): this {
     const whenNode = buildQuoted(condition);
     const thenNode = buildQuoted(result === undefined ? null : result);
     this.conditions.push(new When(whenNode, thenNode));
     return this;
-  };
+  }
 
   else(result: Node | unknown): this {
     this.default = new Else(buildQuoted(result === undefined ? null : result));
@@ -79,21 +80,13 @@ export class Case extends NodeExpression {
   // Mirrors Arel::Nodes::Case#initialize_copy (case.rb:29-33), which Ruby runs
   // for `#clone`: each of the three slots is itself cloned, so a cloned Case
   // shares no sub-node with the original.
-  clone(): Case {
-    const copy = new Case();
-    if (this.case) copy.case = cloneShallow(this.case);
+  clone(): this {
+    const copy = objectClone(this);
+    if (this.case) copy.case = cloneSlot(this.case);
     copy.conditions = this.conditions.map((x) => x.clone());
-    if (this.default) copy.default = cloneShallow(this.default);
+    if (this.default) copy.default = cloneSlot(this.default);
     return copy;
   }
-}
-
-// Ruby `Object#clone` on the `@case` and `@default` slots — the same narrowing
-// `cloneSlot` in binary.ts makes, for the same reason.
-function cloneShallow<T extends object>(node: T): T {
-  const cloneable = node as { clone?: () => T };
-  if (typeof cloneable.clone === "function") return cloneable.clone();
-  return Object.assign(Object.create(Object.getPrototypeOf(node) as object) as object, node);
 }
 
 export class When extends Binary {}

--- a/packages/arel/src/nodes/delete-statement.ts
+++ b/packages/arel/src/nodes/delete-statement.ts
@@ -1,3 +1,4 @@
+import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 
 /**
@@ -27,16 +28,12 @@ export class DeleteStatement extends Node {
     this.key = null;
   }
 
-  clone(): DeleteStatement {
-    const copy = new DeleteStatement();
-    copy.relation = this.relation;
-    copy.wheres = [...this.wheres];
-    copy.orders = [...this.orders];
-    copy.groups = [...this.groups];
-    copy.havings = [...this.havings];
-    copy.limit = this.limit;
-    copy.offset = this.offset;
-    copy.key = this.key;
+  // Mirrors Arel::Nodes::DeleteStatement#initialize_copy
+  // (delete_statement.rb:20-24), which Ruby runs for `#clone`.
+  clone(): this {
+    const copy = objectClone(this);
+    if (this.relation) copy.relation = cloneSlot(this.relation);
+    if (this.wheres) copy.wheres = [...this.wheres];
     return copy;
   }
 }

--- a/packages/arel/src/nodes/fragments.test.ts
+++ b/packages/arel/src/nodes/fragments.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ArgumentError } from "@blazetrails/activesupport";
 import { sql, Nodes } from "../index.js";
 import type { Node } from "./node.js";
 import { uniq } from "../test-helpers/uniq.js";
@@ -32,7 +33,7 @@ describe("FragmentsTest", () => {
 
     it("fails if joined with something that is not an Arel node", () => {
       const fragments = new Nodes.Fragments();
-      expect(() => fragments.plus("Not a node")).toThrow(TypeError);
+      expect(() => fragments.plus("Not a node")).toThrow(ArgumentError);
     });
   });
 });

--- a/packages/arel/src/nodes/fragments.ts
+++ b/packages/arel/src/nodes/fragments.ts
@@ -1,3 +1,6 @@
+import { ArgumentError } from "@blazetrails/activesupport";
+import { arelNode } from "../arel.js";
+import { objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 
 /**
@@ -6,11 +9,48 @@ import { Node } from "./node.js";
  * Mirrors: Arel::Nodes::Fragments
  */
 export class Fragments extends Node {
-  readonly values: Node[];
+  values: Node[];
 
   constructor(values: Node[] = []) {
     super();
     this.values = values;
+  }
+
+  // Mirrors Arel::Nodes::Fragments#hash (fragments.rb:17-19) — `[@values].hash`,
+  // so `values` alone keys it, not every field the way Node#hash does.
+  override hash(): number {
+    let h = 0x811c9dc5;
+    for (const value of this.values) {
+      const valueHash =
+        value instanceof Node
+          ? value.hash()
+          : typeof value === "string"
+            ? stringHash(value)
+            : stringHash(String(value));
+      h ^= valueHash;
+      h = Math.imul(h, 0x01000193);
+    }
+    return h >>> 0;
+  }
+
+  // Mirrors Arel::Nodes::Fragments#eql? / #== (fragments.rb:28-32) — the class
+  // and `values` alone, not Node#eql's serialization of every field.
+  override eql(other: unknown): boolean {
+    return (
+      other instanceof Fragments &&
+      this.constructor === other.constructor &&
+      this.values.length === other.values.length &&
+      this.values.every((value, i) => valueEql(value, other.values[i]))
+    );
+  }
+
+  // Mirrors Arel::Nodes::Fragments#initialize_copy (fragments.rb:13-15), which
+  // Ruby runs for `#clone`: the array itself is copied so a cloned Fragments
+  // does not share it with the original.
+  clone(): this {
+    const copy = objectClone(this);
+    copy.values = [...this.values];
+    return copy;
   }
 
   join(node: Node): Fragments {
@@ -22,9 +62,25 @@ export class Fragments extends Node {
   // param is `unknown` so the Rails guard stays reachable from typed callers
   // — the same shape BoundSqlLiteral#plus already uses.
   plus(other: unknown): Fragments {
-    if (!(other instanceof Node)) {
-      throw new TypeError("Expected Arel node");
+    if (!arelNode(other)) {
+      throw new ArgumentError("Expected Arel node");
     }
-    return new Fragments([...this.values, other]);
+    return new Fragments([...this.values, other as Node]);
   }
+}
+
+// Ruby `Array#==` compares elements with `==`, which on an arel node is its
+// own `eql?` (node.rb aliases the two).
+function valueEql(left: unknown, right: unknown): boolean {
+  if (left instanceof Node) return left.eql(right);
+  return left === right;
+}
+
+function stringHash(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
 }

--- a/packages/arel/src/nodes/insert-statement.ts
+++ b/packages/arel/src/nodes/insert-statement.ts
@@ -1,3 +1,4 @@
+import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 
 /**
@@ -11,17 +12,6 @@ import { Node } from "./node.js";
  * the field type widens to "Node-or-SelectManager-shape-or-null".
  */
 export type InsertSelectSource = Node | { ast: Node; toSql: () => string } | null;
-
-// Ruby `Object#clone` on whatever occupies a statement slot — the same
-// narrowing `Binary`'s own slot copy makes, for the same reason (see
-// `cloneSlot` in binary.ts).
-function cloneSlotValue<T>(value: T): T {
-  if (Array.isArray(value)) return [...value] as T;
-  const cloneable = value as { clone?: () => T };
-  if (typeof cloneable?.clone === "function") return cloneable.clone();
-  if (typeof value !== "object" || value === null) return value;
-  return Object.assign(Object.create(Object.getPrototypeOf(value) as object) as object, value) as T;
-}
 
 export class InsertStatement extends Node {
   relation: Node | null;
@@ -37,14 +27,13 @@ export class InsertStatement extends Node {
     this.select = null;
   }
 
-  clone(): InsertStatement {
-    const copy = new InsertStatement();
-    copy.relation = this.relation;
+  // Mirrors Arel::Nodes::InsertStatement#initialize_copy
+  // (insert_statement.rb:16-21), which Ruby runs for `#clone`.
+  clone(): this {
+    const copy = objectClone(this);
     copy.columns = [...this.columns];
-    // insert_statement.rb:16-21 clones both slots when present — a cloned
-    // statement must not share its values/select node with the original.
-    copy.values = this.values ? cloneSlotValue(this.values) : this.values;
-    copy.select = this.select ? cloneSlotValue(this.select) : this.select;
+    if (this.values) copy.values = cloneSlot(this.values);
+    if (this.select) copy.select = cloneSlot(this.select);
     return copy;
   }
 }

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -19,14 +19,14 @@ export class NamedFunction extends Function {
   }
 
   /**
-   * Apply a window to this function call. Property-form override (vs.
-   * `over(...) {}`) — the inherited WindowPredications.over is mixed
-   * into Function as a property via Included<>, and NamedFunction's
-   * version widens the signature to accept Window/NamedWindow/string.
+   * Apply a window to this function call. Overrides the mixed-in
+   * WindowPredications.over, widening the signature to accept
+   * Window/NamedWindow/string. A prototype method, not an own property: an own
+   * property would be copied by `objectClone` still closed over the ORIGINAL.
    *
    * Mirrors: `OVER` support on Arel functions.
    */
-  over = (window?: Window | NamedWindow | string | null): Over => {
+  over(window?: Window | NamedWindow | string | null): Over {
     if (!window) return new Over(this, null);
     if (typeof window === "string") return new Over(this, new SqlLiteral(window));
     if (window instanceof NamedWindow) {
@@ -34,5 +34,5 @@ export class NamedFunction extends Function {
       return new Over(this, new SqlLiteral(`"${escaped}"`));
     }
     return new Over(this, window);
-  };
+  }
 }

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -55,10 +55,20 @@ export abstract class NodeExpression extends Node {
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
 type _Expressions = import("../expressions.js").ExpressionsModule;
+/**
+ * `when` is lifted out of the mapped `Included<>` shape and restated in method
+ * syntax for the same reason AliasPredication/OrderPredications use their
+ * module interfaces: `Case` overrides it with a method declaration (case.rb:13),
+ * and a property-typed base member makes that a TS2425 error.
+ */
+interface _PredicationsWhen {
+  when(right: unknown): import("./case.js").Case;
+}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface NodeExpression
   extends
-    Included<typeof import("../predications.js").Predications>,
+    Omit<Included<typeof import("../predications.js").Predications>, "when">,
+    _PredicationsWhen,
     Included<typeof import("../math.js").Math>,
     _Expressions,
     _AliasPredication,

--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -1,3 +1,4 @@
+import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 import { JoinSource } from "./join-source.js";
 import type { OptimizerHints } from "./unary.js";
@@ -52,17 +53,16 @@ export class SelectCore extends Node {
     this.from = value;
   }
 
-  clone(): SelectCore {
-    const c = new SelectCore();
-    c.source = this.source.clone();
-    c.projections = [...this.projections];
-    c.wheres = [...this.wheres];
-    c.groups = [...this.groups];
-    c.havings = [...this.havings];
-    c.windows = [...this.windows];
-    c.setQuantifier = this.setQuantifier;
-    c.optimizerHints = this.optimizerHints;
-    c.comment = this.comment;
-    return c;
+  // Mirrors Arel::Nodes::SelectCore#initialize_copy (select_core.rb:35-43),
+  // which Ruby runs for `#clone`.
+  clone(): this {
+    const copy = objectClone(this);
+    if (this.source) copy.source = cloneSlot(this.source);
+    copy.projections = [...this.projections];
+    copy.wheres = [...this.wheres];
+    copy.groups = [...this.groups];
+    copy.havings = [...this.havings];
+    copy.windows = [...this.windows];
+    return copy;
   }
 }

--- a/packages/arel/src/nodes/select-statement.ts
+++ b/packages/arel/src/nodes/select-statement.ts
@@ -1,3 +1,4 @@
+import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { SelectCore } from "./select-core.js";
@@ -29,14 +30,12 @@ export class SelectStatement extends NodeExpression {
     this.with = null;
   }
 
-  clone(): SelectStatement {
-    const copy = new SelectStatement();
-    copy.cores = this.cores.map((c) => c.clone());
-    copy.orders = [...this.orders];
-    copy.limit = this.limit;
-    copy.offset = this.offset;
-    copy.lock = this.lock;
-    copy.with = this.with;
+  // Mirrors Arel::Nodes::SelectStatement#initialize_copy
+  // (select_statement.rb:19-23), which Ruby runs for `#clone`.
+  clone(): this {
+    const copy = objectClone(this);
+    copy.cores = this.cores.map((x) => x.clone());
+    copy.orders = this.orders.map((x) => cloneSlot(x));
     return copy;
   }
 }

--- a/packages/arel/src/nodes/sql-literal.test.ts
+++ b/packages/arel/src/nodes/sql-literal.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { ArgumentError } from "@blazetrails/activesupport";
 import { fakeRecordConnection } from "../test-helpers/connection.js";
 import { sql, Nodes, Visitors } from "../index.js";
 import { mustBeLike } from "../test-helpers/must-be-like.js";
@@ -77,7 +78,7 @@ describe("SqlLiteralTest", () => {
 
     it("fails if joined with something that is not an Arel node", () => {
       const literal = sql("SELECT *");
-      expect(() => literal.plus("Not a node")).toThrow(TypeError);
+      expect(() => literal.plus("Not a node")).toThrow(ArgumentError);
     });
   });
 });

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -1,4 +1,5 @@
-import { isBlank, type Included } from "@blazetrails/activesupport";
+import { ArgumentError, isBlank, type Included } from "@blazetrails/activesupport";
+import { arelNode } from "../arel.js";
 import { Node } from "./node.js";
 import { Fragments } from "./fragments.js";
 import { buildQuoted } from "./casted.js";
@@ -91,10 +92,10 @@ export class SqlLiteral extends Node {
   // callers, as on BoundSqlLiteral#plus.
   /** @internal */
   plus(other: unknown): Fragments {
-    if (!(other instanceof Node)) {
-      throw new TypeError("Expected Arel node");
+    if (!arelNode(other)) {
+      throw new ArgumentError("Expected Arel node");
     }
-    return this.join(other);
+    return new Fragments([this, other as Node]);
   }
 }
 

--- a/packages/arel/src/nodes/update-statement.ts
+++ b/packages/arel/src/nodes/update-statement.ts
@@ -1,3 +1,4 @@
+import { objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 
 /**
@@ -29,17 +30,12 @@ export class UpdateStatement extends Node {
     this.key = null;
   }
 
-  clone(): UpdateStatement {
-    const copy = new UpdateStatement();
-    copy.relation = this.relation;
-    copy.values = [...this.values];
+  // Mirrors Arel::Nodes::UpdateStatement#initialize_copy
+  // (update_statement.rb:21-25), which Ruby runs for `#clone`.
+  clone(): this {
+    const copy = objectClone(this);
     copy.wheres = [...this.wheres];
-    copy.orders = [...this.orders];
-    copy.groups = [...this.groups];
-    copy.havings = [...this.havings];
-    copy.limit = this.limit;
-    copy.offset = this.offset;
-    copy.key = this.key;
+    copy.values = [...this.values];
     return copy;
   }
 }

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -485,16 +485,9 @@ export class SelectManager extends TreeManager {
     return this.createAnd(exprs as Node[]);
   }
 
-  // Mirrors Arel::TreeManager#initialize_copy (tree_manager.rb:60-63) and
-  // Arel::SelectManager#initialize_copy (select_manager.rb:14-17), which Ruby
-  // runs for `#clone`: the copy gets its own AST, and `core` re-reads the
-  // copied cores rather than pointing back at the original's.
-  clone(): SelectManager {
-    const copy = new SelectManager();
-    copy.ast = this.ast.clone();
-    return copy;
-  }
-
+  // Arel::SelectManager#initialize_copy (select_manager.rb:14-17) re-seats
+  // `@ctx` on the copied AST's last core; this getter derives that on every
+  // read, so the copy TreeManager#clone makes is already correct.
   private get core(): SelectCore {
     return this.ast.cores[this.ast.cores.length - 1];
   }

--- a/packages/arel/src/tree-manager.ts
+++ b/packages/arel/src/tree-manager.ts
@@ -1,5 +1,6 @@
 import { ArelEngine, Node, _engine } from "./nodes/node.js";
 import { _Dot } from "./node-slots.js";
+import { cloneSlot, objectClone } from "./clone-support.js";
 import { PlainString } from "./collectors/plain-string.js";
 import { Limit, Offset } from "./nodes/unary.js";
 import { buildQuoted } from "./nodes/casted.js";
@@ -79,6 +80,15 @@ export abstract class TreeManager {
   /** Mirrors: Arel::TreeManager#to_sql (arel/tree_manager.rb:53). */
   toSql(engine: ArelEngine | null = _engine.current): string {
     return this.ast.toSql(engine);
+  }
+
+  // Mirrors Arel::TreeManager#initialize_copy (tree_manager.rb:60-63), which
+  // Ruby runs for `#clone`: the AST is duplicated so a cloned manager does not
+  // share it with the original.
+  clone(): this {
+    const copy = objectClone(this);
+    copy.ast = cloneSlot(this.ast);
+    return copy;
   }
 }
 

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1,3 +1,4 @@
+import { arelNode } from "../arel.js";
 import { Node } from "../nodes/node.js";
 import { SQLString } from "../collectors/sql-string.js";
 import * as Nodes from "../nodes/index.js";
@@ -1667,14 +1668,14 @@ export class ToSql extends Visitor {
     //
     // Each non-Arel scalar is wrapped in `@connection.cast_bound_value(value)`
     // before `add_bind`, mirroring Rails' `new_bind` lambda (to_sql.rb:775-778).
-    if (value instanceof Node) {
-      this.visit(value, collector);
+    if (arelNode(value)) {
+      this.visit(value as Node, collector);
     } else if (Array.isArray(value)) {
       if (value.length === 0) {
         // Rails (to_sql.rb:779): `collector << @connection.quote(nil)` — empty
         // list → NULL.
         collector.append(this.quote(null));
-      } else if (value.every((v) => !(v instanceof Node))) {
+      } else if (!value.some((v) => arelNode(v))) {
         collector.addBinds(
           value.map((v) => this.connection.castBoundValue(v)),
           null,
@@ -1687,8 +1688,8 @@ export class ToSql extends Visitor {
         // `addBind` directly instead of recursing through `visitBindValue`.
         value.forEach((v, i) => {
           if (i > 0) collector.append(", ");
-          if (v instanceof Node) {
-            this.visit(v, collector);
+          if (arelNode(v)) {
+            this.visit(v as Node, collector);
           } else {
             collector.addBind(this.connection.castBoundValue(v), this.bindBlock());
           }


### PR DESCRIPTION
Three RFC 0124 deviations, converged together because they meet in the same files.

### `Arel.arel_node?` (arel.rb:64-66)

Had no TS counterpart; its three arms were inlined as a bare `other instanceof Node` at the three `#+` guards, which only accepts `Attribute` and `SqlLiteral` by the coincidence that trails makes both `Node` subclasses. `arelNode` now lives in `arel.ts` beside `sql` / `star` / `fetchAttribute` and spells all three arms (the `Attribute` arm through the node-slots late binding, since `attributes/attribute.ts` would close a cycle). `SqlLiteral#plus` (sql_literal.rb:25-29), `Fragments#plus` (fragments.rb:22-26) and `BoundSqlLiteral#plus` call it, and now raise Rails' `ArgumentError` rather than `TypeError`.

Making the predicate exist surfaced a fourth call site the call-parity gate flagged: `visit_Arel_Nodes_BoundSqlLiteral`'s `new_bind` lambda (to_sql.rb:774-795) calls it three times, so `visitBindValue` does too. `parity:api:calls` drops 290 → 289.

### `Fragments` (fragments.rb:13-32)

Ported three of six members. It now declares the `hash` / `eql?` fragments.rb:17-19,28-32 define — keyed on `values` ALONE, not `Node#eql`'s serialization of every field — plus the `initialize_copy` copy of the array (fragments.rb:13-15), which needed `values` to stop being `readonly`, as Rails' ivar is.

### Every arel `clone()`

Ruby's `Object#clone` allocates a copy carrying every ivar, then runs `initialize_copy`. Each arel clone instead built a **fresh** instance and copied a hand-written field list, so a field added to one of these classes — or on a subclass — was silently dropped, and three of them also diverged from their Ruby `initialize_copy` (`DeleteStatement` never cloned `@relation`; `SelectStatement` shallow-copied `@orders` where Rails maps `#clone` over it).

`objectClone` / `cloneSlot` in the new `clone-support.ts` spell the two Ruby core primitives (no Rails counterpart because Ruby gets both from core, not from Arel). `Binary`, `Case`, `SelectCore`, `{Delete,Insert,Update,Select}Statement` and `TreeManager` now each copy every own property, then do exactly what their `initialize_copy` does. `SelectManager#clone` goes away: `select_manager.rb:14-17` only re-seats `@ctx`, which `#core` derives on every read, so `TreeManager#clone` (tree_manager.rb:60-63) is the whole port — and `Insert`/`Update`/`DeleteManager` get it for free, as they do in Ruby.

`Case#when` and `NamedFunction#over` become prototype methods. As bound own properties they were carried into a generic copy still closed over the ORIGINAL — a cloned `Case`'s `#when` pushed onto the original's conditions. A prototype method on the subclass shadows the mixed-in one just as well; `NodeExpression`'s mixin interface lifts `when` out of the mapped `Included<>` shape and restates it in method syntax, the shape AliasPredication and OrderPredications already use for their overridden members.

### Verification

- `pnpm vitest run packages/arel/src` — 1448 passed; `packages/activerecord/src/relation` + `clone.test.ts` — 1236 passed.
- `parity:api` arel 957/957 (100%); `parity:api:extra:gate` OK (arel novel 0/0, total 62/62); `parity:api:calls` OK; `parity:api:calls:args` OK. No baseline row added.
- `clone-support.trails.test.ts` pins all three clone hazards directly; each case fails on the pre-change code.

Closes-story: arel-node-predicate-inlined-at-three-call-sites
Closes-story: fragments-lacks-initialize-copy-hash-and-eql
Closes-story: node-clone-builds-a-fresh-instance-not-a-copy