### PR TITLE
refactor(activemodel): group attribute-methods.ts into ClassMethods / InstanceMethods module objects (RFC 0115)

### DIFF
--- a/packages/activemodel/src/attribute-methods.test.ts
+++ b/packages/activemodel/src/attribute-methods.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Model } from "./index.js";
-import {
-  type AttributeMethod,
-  defineAttributeMethod,
-  generatedAttributeMethods,
-  missingAttribute,
-} from "./attribute-methods.js";
+import { type AttributeMethod, ClassMethods, InstanceMethods } from "./attribute-methods.js";
 
 describe("AttributeMethodsTest", () => {
   it("#missing_attribute applies the supplied stack to the raised error", () => {
@@ -17,11 +12,13 @@ describe("AttributeMethodsTest", () => {
     const p = new Person({ name: "test" });
     const stack = "custom backtrace line";
     const call = () =>
-      (missingAttribute as (this: unknown, attrName: string, stack?: string) => never).call(
-        p,
-        "title",
-        stack,
-      );
+      (
+        InstanceMethods.missingAttribute as (
+          this: unknown,
+          attrName: string,
+          stack?: string,
+        ) => never
+      ).call(p, "title", stack);
     let caught: Error | undefined;
     try {
       call();
@@ -42,14 +39,14 @@ describe("AttributeMethodsTest", () => {
     // `foo` reader over it. trails skips the bare pattern (readers are real
     // accessor properties), so a suffix pattern's method stands in for it.
     Person.attributeMethodSuffix("Short");
-    generatedAttributeMethods.call(Person).moduleEval((mod) => {
+    ClassMethods.generatedAttributeMethods.call(Person).moduleEval((mod) => {
       Object.defineProperty(mod, "nameShort", {
         value: () => "<3",
         writable: true,
         configurable: true,
       });
     });
-    defineAttributeMethod.call(Person, "name");
+    ClassMethods.defineAttributeMethod.call(Person, "name");
 
     expect((new Person({ name: "Alice" }) as unknown as { nameShort(): string }).nameShort()).toBe(
       "<3",

--- a/packages/activemodel/src/attribute-methods.trails.test.ts
+++ b/packages/activemodel/src/attribute-methods.trails.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  attributeMethodPatternsCache,
-  attributeMethodPatternsMatching,
-} from "./attribute-methods.js";
+import { ClassMethods } from "./attribute-methods.js";
 import { Model } from "./index.js";
 
 describe("AttributeMethodsTest (trails)", () => {
@@ -14,12 +11,12 @@ describe("AttributeMethodsTest (trails)", () => {
       }
     }
     Person.attributeMethodSuffix("Short");
-    attributeMethodPatternsMatching.call(Person, "nameShort");
-    expect(attributeMethodPatternsCache.call(Person).size).toBeGreaterThan(0);
+    ClassMethods.attributeMethodPatternsMatching.call(Person, "nameShort");
+    expect(ClassMethods.attributeMethodPatternsCache.call(Person).size).toBeGreaterThan(0);
 
     Person.aliasAttribute("nickname", "name");
 
-    expect(attributeMethodPatternsCache.call(Person).size).toBe(0);
+    expect(ClassMethods.attributeMethodPatternsCache.call(Person).size).toBe(0);
   });
 
   it("alias attribute overrides a method inherited from a parent class", () => {

--- a/packages/activemodel/src/attribute-methods.ts
+++ b/packages/activemodel/src/attribute-methods.ts
@@ -4,9 +4,10 @@
  * Mirrors: ActiveModel::AttributeMethods
  *
  * In Rails, this module's ClassMethods are mixed into the class via `include`.
- * In TS, the exported functions are `this`-typed so `extend()` / `include()`
- * can mix them onto a host class (see the bottom of model.ts) — no delegation
- * wrappers needed.
+ * In TS the two halves are the exported {@link ClassMethods} and
+ * {@link InstanceMethods} module objects, whose `this`-typed methods
+ * `extend()` / `include()` mix onto a host class (see the bottom of model.ts)
+ * — no delegation wrappers needed.
  */
 import {
   camelize,
@@ -14,6 +15,8 @@ import {
   CodeGenerator,
   include,
   included,
+  type Extended,
+  type Included,
   Module,
   NameError,
 } from "@blazetrails/activesupport";
@@ -146,128 +149,6 @@ interface ReadWriteHost {
   [key: string]: unknown;
 }
 
-export interface AttributeMethodHost {
-  attributeNames(): string[];
-  attributeMethodPatterns: AttributeMethodPattern[];
-  /** @internal Stamps read by {@link _resurrectAttributeMethods}. */
-  _patternsGeneratedFor?: Map<string, AttributeMethodPattern[]>;
-  /** @internal Stamp read by {@link _resurrectAttributeMethods}. */
-  _patternsAtLastResurrection?: AttributeMethodPattern[];
-  attributeAliases: Record<string, string>;
-  _aliasesByAttributeName: Map<string, string[]>;
-  _generatedAttributeMethods?: Module;
-}
-
-/**
- * A host class with `ActiveModel::AttributeMethods::ClassMethods`
- * (attribute_methods.rb:74) extended onto it — the `extend(Model, …)` at the
- * bottom of model.ts. Ruby reaches these by self-send from one ClassMethods
- * body to the next; naming them is what lets the ported bodies do the same.
- */
-type ClassMethods = AttributeMethodHost & {
-  attributeMethodPrefix(...prefixes: Array<string | { parameters?: string | null | false }>): void;
-  attributeMethodSuffix(...suffixes: Array<string | { parameters?: string | null | false }>): void;
-  attributeMethodAffix(
-    ...affixes: Array<{ prefix: string; suffix: string; parameters?: string | null | false }>
-  ): void;
-  aliasAttribute(newName: string, oldName: string): void;
-  eagerlyGenerateAliasAttributeMethods(newName: string, oldName: string): void;
-  defineAttributeMethods(...attrNames: string[]): void;
-  defineAttributeMethod(
-    attrName: string,
-    options?: { _owner?: Module | CodeGenerator; as?: string },
-  ): void;
-  defineAttributeMethodPattern(
-    pattern: AttributeMethodPattern,
-    attrName: string,
-    options: { owner: CodeGenerator; as: string; override?: boolean },
-  ): void;
-  undefineAttributeMethods(): void;
-  resolveAttributeName(name: string): string;
-  generatedAttributeMethods(): Module;
-  isInstanceMethodAlreadyImplemented(methodName: string): boolean;
-  attributeMethodPatternsCache(): Map<string, Array<AttributeMethod>>;
-  attributeMethodPatternsMatching(methodName: string): Array<AttributeMethod>;
-};
-
-/**
- * attribute_missing — generic dispatch for an attribute method recognized
- * through Rails' method_missing path (`matched_attribute_method`), as opposed
- * to one `define_attribute_method_pattern` has already generated: a generated
- * method sends its proxy target directly.
- *
- * Mirrors: attribute_methods.rb:520-522
- *   def attribute_missing(match, ...)
- *     __send__(match.proxy_target, match.attr_name, ...)
- *   end
- */
-export function attributeMissing(
-  this: Record<string, unknown>,
-  match: AttributeMethod,
-  ...args: unknown[]
-): unknown {
-  const target = (this as Record<string, (...a: unknown[]) => unknown>)[match.proxyTarget];
-  if (typeof target !== "function") {
-    throw new MissingAttributeError(
-      `attribute_missing dispatch failed: ${match.proxyTarget} not defined`,
-    );
-  }
-  return target.call(this, match.attrName, ...args);
-}
-
-/**
- * Mirrors: #respond_to_without_attributes? — the alias Rails captures for the
- * original `respond_to?` before overriding it (attribute_methods.rb:527-528,
- * `alias :respond_to_without_attributes? :respond_to?`). It keeps the
- * `respond_to?(method, include_private_methods = false)` signature and answers
- * whether the receiver responds to `method` at all — including attribute
- * accessors exposed as getter/setter properties, not just plain functions. The
- * `in` check mirrors Ruby `respond_to?` across the prototype chain.
- *
- * Rails' `include_private_methods` parameter is dropped: a JS receiver has no
- * string-named private methods for it to reveal, so it could never change the
- * answer. See {@link respondTo} for the branch that drops with it.
- */
-export function isRespondToWithoutAttributes(this: object, method: string): boolean {
-  return method in (this as Record<string, unknown>);
-}
-
-/**
- * @internal Rails-private helper. Mirrors: #attribute_method?
- * (attribute_methods.rb:541-543) —
- * `respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)`.
- * Ruby `Hash#include?` is key existence, so the second call is `Object.hasOwn`
- * over the hash `attributes` returns.
- */
-export function isAttributeMethod(this: InstanceHost, attrName: string): boolean {
-  return (
-    this.isRespondToWithoutAttributes("attributes") && Object.hasOwn(this.attributes, attrName)
-  );
-}
-
-/** @internal Rails-private helper. Mirrors: #matched_attribute_method */
-export function matchedAttributeMethod(
-  this: InstanceMethods,
-  methodName: string,
-): AttributeMethod | null {
-  const matches = this.constructor.attributeMethodPatternsMatching(methodName);
-  return matches.find((m) => this.isAttributeMethod(m.attrName)) ?? null;
-}
-
-/**
- * @internal Rails-private helper. Mirrors: #missing_attribute
- * Rails passes `stack` (a `caller` backtrace) so `raise` reports the call site
- * rather than this helper; JS `Error` captures its own stack, so when a `stack`
- * string is supplied we overwrite the error's stack to match Rails' intent.
- */
-export function missingAttribute(this: InstanceHost, attrName: string, stack?: string): never {
-  const err = new MissingAttributeError(
-    `missing attribute '${attrName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
-  );
-  if (stack !== undefined) err.stack = stack;
-  throw err;
-}
-
 /**
  * Ruby's `NoMethodError`, which `__send__` raises for an undefined name and
  * `method_missing`'s `else super` arm re-raises (attribute_methods.rb:507-514).
@@ -283,498 +164,625 @@ class NoMethodError extends NameError {
 }
 
 /**
- * Mirrors: attribute_methods.rb:555-558
- *   private
- *     def _read_attribute(attr)
- *       __send__(attr)
- *     end
- *
- * ActiveModel dispatches through the reader method; only ActiveRecord's
- * override goes to the attribute set (activerecord/attribute_methods/read.rb:
- * 35-37). A generated reader is an accessor property in trails (CLAUDE.md
- * § "Generated attribute readers are properties"), so `__send__(attr)` is a
- * property read rather than a call.
- *
- * A name the receiver does not answer is where Ruby's `__send__` raises
- * `NoMethodError` and `method_missing` (attribute_methods.rb:507-514) takes
- * over: a `matched_attribute_method` goes to `attribute_missing`, and anything
- * else falls to `super` and propagates. JS has no `method_missing`, so a bare
- * property read would answer `undefined` there instead — the cascade is spelled
- * out here.
- *
- * @internal Rails-private helper.
+ * The per-class state `ActiveModel::AttributeMethods` keeps — the two
+ * `class_attribute`s its `included do` block declares (attribute_methods.rb:70-73)
+ * and the ivars its ClassMethods bodies memoize into.
  */
-export function _readAttribute(this: InstanceHost, attr: string): unknown {
-  const self = this as unknown as RespondToHost & AttributeMethods;
-  if (!self.isRespondToWithoutAttributes(attr)) {
-    const match = self.matchedAttributeMethod(attr);
-    if (match) return self.attributeMissing(match);
-    throw new NoMethodError(
-      `undefined method '${attr}' for an instance of ${(this.constructor as { name?: string }).name ?? "unknown"}`,
-    );
-  }
-  return (this as unknown as Record<string, unknown>)[attr];
+export interface AttributeMethodHost {
+  attributeNames(): string[];
+  attributeMethodPatterns: AttributeMethodPattern[];
+  /** @internal Stamps read by {@link _resurrectAttributeMethods}. */
+  _patternsGeneratedFor?: Map<string, AttributeMethodPattern[]>;
+  /** @internal Stamp read by {@link _resurrectAttributeMethods}. */
+  _patternsAtLastResurrection?: AttributeMethodPattern[];
+  attributeAliases: Record<string, string>;
+  _aliasesByAttributeName: Map<string, string[]>;
+  _generatedAttributeMethods?: Module;
 }
 
 /**
- * Mirrors Rails' `attribute_method_prefix(*prefixes, parameters: nil)`
- * (attribute_methods.rb:106-109). TS forbids a keyword after a rest element, so
- * the trailing `parameters:` hash rides in the splat and is peeled off — the
- * same shape `touch(*names, time:)` uses in `activerecord/timestamp.ts`.
+ * A host class with {@link ClassMethods} (attribute_methods.rb:75-501) extended
+ * onto it — the `extend(Model, …)` at the bottom of model.ts. Ruby reaches these
+ * by self-send from one ClassMethods body to the next; deriving the shape from
+ * the module object is what lets the ported bodies do the same, with no parallel
+ * list of signatures to keep in step.
+ *
+ * Deliberately NOT exported: a declaration carrying Rails method names but no
+ * bodies outranks the file's real bodies when api-compare pairs a Ruby method
+ * against this file (RFC 0025,
+ * `api-compare-bodyless-declaration-outranks-real-body`), which would stop the
+ * bodies below being measured for call parity.
  */
-export function attributeMethodPrefix(
-  this: ClassMethods,
-  ...prefixes: Array<string | { parameters?: string | null | false }>
-): void {
-  const parameters = extractParameters(prefixes);
-  this.attributeMethodPatterns = [
-    ...this.attributeMethodPatterns,
-    ...(prefixes as string[]).map((prefix) => new AttributeMethodPattern({ prefix, parameters })),
-  ];
-  this.undefineAttributeMethods();
-}
+interface ClassMethodsHost extends AttributeMethodHost, Extended<typeof ClassMethods> {}
 
-/** Mirrors: ClassMethods#attribute_method_suffix (attribute_methods.rb:140-143). */
-export function attributeMethodSuffix(
-  this: ClassMethods,
-  ...suffixes: Array<string | { parameters?: string | null | false }>
-): void {
-  const parameters = extractParameters(suffixes);
-  this.attributeMethodPatterns = [
-    ...this.attributeMethodPatterns,
-    ...(suffixes as string[]).map((suffix) => new AttributeMethodPattern({ suffix, parameters })),
-  ];
-  this.undefineAttributeMethods();
-}
-
-/** Mirrors: ClassMethods#attribute_method_affix (attribute_methods.rb:175-178). */
-export function attributeMethodAffix(
-  this: ClassMethods,
-  ...affixes: Array<{ prefix: string; suffix: string; parameters?: string | null | false }>
-): void {
-  this.attributeMethodPatterns = [
-    ...this.attributeMethodPatterns,
-    ...affixes.map((affix) => new AttributeMethodPattern(affix)),
-  ];
-  this.undefineAttributeMethods();
-}
-
-export function aliasAttribute(this: ClassMethods, newName: string, oldName: string): void {
-  this.attributeAliases = { ...this.attributeAliases, [newName]: oldName };
-  const aliases = aliasesByAttributeName(this);
-  if (!aliases.has(oldName)) aliases.set(oldName, []);
-  aliases.get(oldName)!.push(newName);
-
-  this.eagerlyGenerateAliasAttributeMethods(newName, oldName);
-}
-
-export function eagerlyGenerateAliasAttributeMethods(
-  this: ClassMethods,
-  newName: string,
-  oldName: string,
-): void {
-  CodeGenerator.batch(this.generatedAttributeMethods(), __FILE__, __LINE__, (codeGenerator) => {
-    generateAliasAttributeMethods(this, codeGenerator, newName, oldName);
-  });
-}
-
-export function generateAliasAttributeMethods(
-  host: ClassMethods,
-  codeGenerator: CodeGenerator,
-  newName: string,
-  oldName: string,
-): void {
-  CodeGenerator.batch(codeGenerator, __FILE__, __LINE__, () => {
-    for (const pattern of host.attributeMethodPatterns) {
-      aliasAttributeMethodDefinition.call(host, codeGenerator, pattern, newName, oldName);
-    }
-    attributeMethodPatternsCache.call(host).clear();
-  });
+/** The state the module's own instance methods (attribute_methods.rb:504-590) read. */
+export interface InstanceHost {
+  _attributes?: { isKey(name: string): boolean };
+  attributes: Record<string, unknown>;
+  attributeMethodPatterns?: AttributeMethodPattern[];
+  constructor: AttributeMethodHost;
 }
 
 /**
- * Mirrors: ActiveRecord::AttributeMethods::ClassMethods#alias_attribute_method_definition
- * (activerecord/attribute_methods.rb:87-96) — the alias is generated by the
- * same pattern path as a regular attribute method, under the alias' name and
- * with the override arm on.
+ * A record with {@link InstanceMethods} included — the `include(Model, …)` at
+ * the bottom of model.ts. Unexported for the same reason as
+ * {@link ClassMethodsHost}.
  */
-export function aliasAttributeMethodDefinition(
-  this: ClassMethods,
-  codeGenerator: CodeGenerator,
-  pattern: AttributeMethodPattern,
-  newName: string,
-  oldName: string,
-): void {
-  this.defineAttributeMethodPattern(pattern, oldName, {
-    owner: codeGenerator,
-    as: newName,
-    override: true,
-  });
+interface InstanceMethodsHost extends InstanceHost, Included<typeof InstanceMethods> {
+  constructor: ClassMethodsHost;
 }
-
-export function isAttributeAlias(host: AttributeMethodHost, name: string): boolean {
-  return Object.prototype.hasOwnProperty.call(host.attributeAliases, name);
-}
-
-export function attributeAlias(host: AttributeMethodHost, name: string): string | undefined {
-  return host.attributeAliases[name];
-}
-
-export function defineAttributeMethods(this: ClassMethods, ...attrNames: string[]): void {
-  CodeGenerator.batch(this.generatedAttributeMethods(), __FILE__, __LINE__, (owner) => {
-    for (const attrName of attrNames) {
-      this.defineAttributeMethod(attrName, { _owner: owner });
-      const aliases = aliasesByAttributeName(this);
-      const attrAliases = aliases.get(attrName);
-      if (attrAliases) {
-        for (const aliasedName of attrAliases) {
-          generateAliasAttributeMethods(this, owner, aliasedName, attrName);
-        }
-      }
-    }
-  });
-}
-
-export function defineAttributeMethod(
-  this: ClassMethods,
-  attrName: string,
-  {
-    _owner = this.generatedAttributeMethods(),
-    as = attrName,
-  }: { _owner?: Module | CodeGenerator; as?: string } = {},
-): void {
-  CodeGenerator.batch(_owner, __FILE__, __LINE__, (owner) => {
-    for (const pattern of this.attributeMethodPatterns) {
-      this.defineAttributeMethodPattern(pattern, attrName, { owner, as });
-    }
-    this.attributeMethodPatternsCache().clear();
-  });
-  if (!Object.prototype.hasOwnProperty.call(this, "_patternsGeneratedFor")) {
-    this._patternsGeneratedFor = new Map(this._patternsGeneratedFor ?? []);
-  }
-  this._patternsGeneratedFor!.set(as, this.attributeMethodPatterns);
-}
-
-/**
- * Mirrors: ClassMethods#define_attribute_method_pattern
- *
- * Rails' only `override: true` caller is `alias_attribute_method_definition`
- * (activerecord/attribute_methods.rb:94), and so is trails'.
- *
- * `"define_method_#{pattern.proxy_target}"` (attribute_methods.rb:333) is
- * spelled out rather than interpolated: a proxy target ending in `=` names a
- * Ruby writer, whose bare camel spelling belongs to the reader hook of the same
- * name, so it takes the `set*` fallback docs/ruby-ts-conventions.md gives a
- * `name=` writer.
- */
-export function defineAttributeMethodPattern(
-  this: ClassMethods,
-  pattern: AttributeMethodPattern,
-  attrName: string,
-  { owner, as, override = false }: { owner: CodeGenerator; as: string; override?: boolean },
-): void {
-  const canonicalMethodName = pattern.methodName(attrName);
-  const publicMethodName = pattern.methodName(as);
-
-  // If defining a regular attribute method, we don't override methods that are
-  // explicitly defined in parent classes (attribute_methods.rb:326). The
-  // predicate is a template method: Ruby dispatches it through the class, and
-  // ActiveRecord overrides it to raise DangerousAttributeError for a name
-  // Active Record itself defines and to consult the class's own methods
-  // (activerecord/attribute_methods.rb:165-179).
-  if (this.isInstanceMethodAlreadyImplemented(publicMethodName)) {
-    if (!override) return;
-  }
-
-  // A `parameters: false` pattern emits an accessor property, and a property
-  // cannot shadow an inherited method without breaking every caller that
-  // invokes it — the third consequence in CLAUDE.md, "Generated attribute
-  // readers are properties". Rails needs no such check: `id_in_database` stays
-  // a method whether it comes from PrimaryKey or from the `_in_database`
-  // suffix, so a pk-less model (a PostgreSQL foreign table) generating over it
-  // is harmless there and is not there.
-  if (pattern.parameters === false && !override && answersWithAMethod(this, publicMethodName)) {
-    return;
-  }
-
-  const generateMethod = pattern.proxyTarget.endsWith("=")
-    ? camelize(`set_define_method_${pattern.proxyTarget.slice(0, -1)}`, false)
-    : camelize(`define_method_${pattern.proxyTarget}`, false);
-
-  const generator = (this as unknown as Record<string, unknown>)[generateMethod];
-  if (typeof generator === "function") {
-    (generator as (attrName: string, options: { owner: CodeGenerator; as: string }) => void).call(
-      this,
-      attrName,
-      { owner, as },
-    );
-  } else {
-    defineProxyCall(owner, canonicalMethodName, pattern.proxyTarget, pattern.parameters, attrName, {
-      namespace: "active_model_proxy",
-      as: publicMethodName,
-    });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Class-level Rails privates (attribute_methods.rb)
-// ---------------------------------------------------------------------------
 
 const NAME_COMPILABLE_REGEXP = /^[a-zA-Z_]\w*[!?=]?$/;
 
-export function undefineAttributeMethods(this: ClassMethods): void {
-  const mod = this.generatedAttributeMethods();
-  mod.undefMethod(...mod.instanceMethods());
-  // Clear the pattern-match cache so stale entries don't survive after patterns change.
-  // Mirrors: Rails attribute_method_patterns_cache.clear in undefine_attribute_methods.
-  // Only clear an own-property cache; don't reach up and clear a parent's cache
-  // via inherited prototype-chain lookup.
-  if (Object.hasOwn(this, "_attributeMethodPatternsCache")) {
-    (
-      this as ClassMethods & { _attributeMethodPatternsCache: Map<unknown, unknown> }
-    )._attributeMethodPatternsCache.clear();
-  }
-}
-
 /**
- * Mirrors: ClassMethods#aliases_by_attribute_name
- * (`activemodel/lib/active_model/attribute_methods.rb:382-384`), a plain
- * per-class ivar. Rails' `inherited` hook resets it on every subclass
- * (`:387-394`), so a subclass starts empty; JS has no such hook (CLAUDE.md,
- * "Module mixins"), and the own-property check is the port of that reset.
+ * Mirrors: ActiveModel::AttributeMethods::ClassMethods (attribute_methods.rb:75-501),
+ * mixed onto a host class by the `extend(Model, ClassMethods)` in model.ts.
  */
-export function aliasesByAttributeName(host: AttributeMethodHost): Map<string, string[]> {
-  if (!Object.prototype.hasOwnProperty.call(host, "_aliasesByAttributeName")) {
-    host._aliasesByAttributeName = new Map<string, string[]>();
-  }
-  return host._aliasesByAttributeName;
-}
+export const ClassMethods = {
+  /**
+   * Mirrors Rails' `attribute_method_prefix(*prefixes, parameters: nil)`
+   * (attribute_methods.rb:106-109). TS forbids a keyword after a rest element, so
+   * the trailing `parameters:` hash rides in the splat and is peeled off — the
+   * same shape `touch(*names, time:)` uses in `activerecord/timestamp.ts`.
+   */
+  attributeMethodPrefix(
+    this: ClassMethodsHost,
+    ...prefixes: Array<string | { parameters?: string | null | false }>
+  ): void {
+    const parameters = extractParameters(prefixes);
+    this.attributeMethodPatterns = [
+      ...this.attributeMethodPatterns,
+      ...(prefixes as string[]).map((prefix) => new AttributeMethodPattern({ prefix, parameters })),
+    ];
+    this.undefineAttributeMethods();
+  },
 
-/** @internal Rails-private helper. Mirrors: ClassMethods#resolve_attribute_name */
-export function resolveAttributeName(this: AttributeMethodHost, name: string): string {
-  return this.attributeAliases?.[name] ?? name;
-}
+  /** Mirrors: ClassMethods#attribute_method_suffix (attribute_methods.rb:140-143). */
+  attributeMethodSuffix(
+    this: ClassMethodsHost,
+    ...suffixes: Array<string | { parameters?: string | null | false }>
+  ): void {
+    const parameters = extractParameters(suffixes);
+    this.attributeMethodPatterns = [
+      ...this.attributeMethodPatterns,
+      ...(suffixes as string[]).map((suffix) => new AttributeMethodPattern({ suffix, parameters })),
+    ];
+    this.undefineAttributeMethods();
+  },
 
-/**
- * @internal Rails-private helper. Mirrors: ClassMethods#generated_attribute_methods
- *
- *   def generated_attribute_methods
- *     @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
- *   end
- *
- * (attribute_methods.rb:400-402.) The `||=` is on a per-class ivar, so the
- * memo is checked as an *own* property: a subclass must build and include its
- * own module rather than reusing the one it inherits from its parent, which is
- * what Ruby's per-class ivar (reset in `inherited`, attribute_methods.rb:386-393)
- * gives for free.
- */
-export function generatedAttributeMethods(this: ClassMethods): Module {
-  if (!Object.hasOwn(this, "_generatedAttributeMethods")) {
-    const mod = new Module();
-    include(this as unknown as new (...args: unknown[]) => unknown, mod);
-    this._generatedAttributeMethods = mod;
-  }
-  return this._generatedAttributeMethods!;
-}
+  /** Mirrors: ClassMethods#attribute_method_affix (attribute_methods.rb:175-178). */
+  attributeMethodAffix(
+    this: ClassMethodsHost,
+    ...affixes: Array<{ prefix: string; suffix: string; parameters?: string | null | false }>
+  ): void {
+    this.attributeMethodPatterns = [
+      ...this.attributeMethodPatterns,
+      ...affixes.map((affix) => new AttributeMethodPattern(affix)),
+    ];
+    this.undefineAttributeMethods();
+  },
 
-/** @internal Rails-private helper. Mirrors: ClassMethods#instance_method_already_implemented? */
-export function isInstanceMethodAlreadyImplemented(
-  this: ClassMethods,
-  methodName: string,
-): boolean {
-  return this.generatedAttributeMethods().isMethodDefined(methodName);
-}
+  aliasAttribute(this: ClassMethodsHost, newName: string, oldName: string): void {
+    this.attributeAliases = { ...this.attributeAliases, [newName]: oldName };
+    const aliases = this.aliasesByAttributeName();
+    if (!aliases.has(oldName)) aliases.set(oldName, []);
+    aliases.get(oldName)!.push(newName);
 
-/**
- * @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_cache
- *
- * @missingRailsArgs new — PERMANENT: attribute_methods.rb:418 writes
- * `Concurrent::Map.new(initial_capacity: 4)`; a JS `Map` has no capacity hint,
- * so the kwarg has no counterpart to pass.
- */
-export function attributeMethodPatternsCache(
-  this: ClassMethods,
-): Map<string, Array<AttributeMethod>> {
-  const h = this as AttributeMethodHost & {
-    _attributeMethodPatternsCache?: Map<string, Array<AttributeMethod>>;
-  };
-  if (!Object.prototype.hasOwnProperty.call(h, "_attributeMethodPatternsCache")) {
-    h._attributeMethodPatternsCache = new Map();
-  }
-  return h._attributeMethodPatternsCache!;
-}
+    this.eagerlyGenerateAliasAttributeMethods(newName, oldName);
+  },
 
-/** @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_matching */
-export function attributeMethodPatternsMatching(
-  this: ClassMethods,
-  methodName: string,
-): Array<AttributeMethod> {
-  const cache = this.attributeMethodPatternsCache();
-  if (cache.has(methodName)) return cache.get(methodName)!;
-  const matches = this.attributeMethodPatterns.flatMap((pattern) => {
-    const m = pattern.match(methodName);
-    return m ? [m] : [];
-  });
-  cache.set(methodName, matches);
-  return matches;
-}
+  eagerlyGenerateAliasAttributeMethods(
+    this: ClassMethodsHost,
+    newName: string,
+    oldName: string,
+  ): void {
+    CodeGenerator.batch(this.generatedAttributeMethods(), __FILE__, __LINE__, (codeGenerator) => {
+      this.generateAliasAttributeMethods(codeGenerator, newName, oldName);
+    });
+  },
 
-/**
- * @internal Rails-private helper. Mirrors: ClassMethods#define_proxy_call
- *
- * Ruby's `(code_generator, name, proxy_target, parameters, *call_args,
- * namespace:, as:)` puts required keywords after a splat, which TS cannot
- * express: the kwargs travel as the last element of the rest tuple.
- *
- * Two steps of attribute_methods.rb:408-424 have no TS analogue and are
- * dropped rather than emulated: `call_args.map!(&:inspect)` quotes each
- * argument for the Ruby source string, where the port passes the values
- * themselves, and `call_args << parameters if parameters` appends the
- * forwarding signature, which `defineCall`'s rest parameter already does.
- */
-export function defineProxyCall(
-  codeGenerator: CodeGenerator,
-  name: string,
-  proxyTarget: string,
-  parameters: string | null | false,
-  ...rest: [...callArgs: string[], options: { namespace: string; as?: string }]
-): void {
-  const options = rest[rest.length - 1] as { namespace: string; as?: string };
-  const callArgs = rest.slice(0, -1) as string[];
-  const mangledName = buildMangledName(name);
+  generateAliasAttributeMethods(
+    this: ClassMethodsHost,
+    codeGenerator: CodeGenerator,
+    newName: string,
+    oldName: string,
+  ): void {
+    CodeGenerator.batch(codeGenerator, __FILE__, __LINE__, () => {
+      for (const pattern of this.attributeMethodPatterns) {
+        this.aliasAttributeMethodDefinition(codeGenerator, pattern, newName, oldName);
+      }
+      this.attributeMethodPatternsCache().clear();
+    });
+  },
 
-  const namespace = `${options.namespace}_${proxyTarget}`;
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::ClassMethods#alias_attribute_method_definition
+   * (activerecord/attribute_methods.rb:87-96) — the alias is generated by the
+   * same pattern path as a regular attribute method, under the alias' name and
+   * with the override arm on.
+   */
+  aliasAttributeMethodDefinition(
+    this: ClassMethodsHost,
+    codeGenerator: CodeGenerator,
+    pattern: AttributeMethodPattern,
+    newName: string,
+    oldName: string,
+  ): void {
+    this.defineAttributeMethodPattern(pattern, oldName, {
+      owner: codeGenerator,
+      as: newName,
+      override: true,
+    });
+  },
 
-  defineCall(codeGenerator, name, proxyTarget, mangledName, parameters, callArgs, {
-    namespace,
-    as: options.as ?? name,
-  });
-}
+  isAttributeAlias(this: ClassMethodsHost, name: string): boolean {
+    return Object.prototype.hasOwnProperty.call(this.attributeAliases, name);
+  },
 
-/**
- * @internal Rails-private helper. Mirrors: ClassMethods#build_mangled_name
- * Returns a compilable temp name for attributes with non-identifier characters.
- */
-export function buildMangledName(name: string): string {
-  if (NAME_COMPILABLE_REGEXP.test(name)) return name;
-  const hex = Array.from(name)
-    .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
-    .join("");
-  return `__temp__${hex}`;
-}
+  attributeAlias(this: ClassMethodsHost, name: string): string | undefined {
+    return this.attributeAliases[name];
+  },
 
-/**
- * @internal Rails-private helper. Mirrors: ClassMethods#define_call
- *
- * Rails compiles `def mangled_name(params); self.target_name(call_args); end`
- * into the generator's batch. A TS "source" is the definition itself, so the
- * emitted body is the equivalent closure over `callArgs`; a rest parameter
- * forwards what Ruby's `params` names, so `parameters` only matters when it is
- * `false` — `def #{mangled_name}(#{parameters || ''})` (attribute_methods.rb:465)
- * is then a zero-arg reader, which is an accessor property in TS (CLAUDE.md,
- * "Generated attribute readers are properties"). A `parameters: false` pattern
- * (before_type_cast.rb:32, query.rb:10) is NOT nil, so it survives as `false`.
- * `CALL_COMPILABLE_REGEXP` has no analogue either: a JS property lookup needs
- * no name to be compilable, so the `send(...)` arm it guards never applies.
- * `name` is unused here exactly as it is in Ruby.
- */
-export function defineCall(
-  codeGenerator: CodeGenerator,
-  _name: string,
-  targetName: string,
-  mangledName: string,
-  parameters: string | null | false,
-  callArgs: string[],
-  { namespace, as }: { namespace: string; as: string },
-): void {
-  codeGenerator.defineCachedMethod(mangledName, { namespace, as }, (batch) => {
-    batch.push((mod) => {
-      if (parameters === false) {
+  defineAttributeMethods(this: ClassMethodsHost, ...attrNames: string[]): void {
+    CodeGenerator.batch(this.generatedAttributeMethods(), __FILE__, __LINE__, (owner) => {
+      for (const attrName of attrNames) {
+        this.defineAttributeMethod(attrName, { _owner: owner });
+        const aliases = this.aliasesByAttributeName();
+        const attrAliases = aliases.get(attrName);
+        if (attrAliases) {
+          for (const aliasedName of attrAliases) {
+            this.generateAliasAttributeMethods(owner, aliasedName, attrName);
+          }
+        }
+      }
+    });
+  },
+
+  /**
+   * Ruby defaults the `_owner:` kwarg to `generated_attribute_methods`
+   * (attribute_methods.rb:311), a self-send. A `this`-typed default in the
+   * parameter list makes the module object's own type circular through
+   * {@link ClassMethodsHost}, which TS cannot infer, so the default is
+   * spelled where TS can see it — same value, same self-send, one line later.
+   */
+  defineAttributeMethod(
+    this: ClassMethodsHost,
+    attrName: string,
+    options: { _owner?: Module | CodeGenerator; as?: string } = {},
+  ): void {
+    const { _owner = this.generatedAttributeMethods(), as = attrName } = options;
+    CodeGenerator.batch(_owner, __FILE__, __LINE__, (owner) => {
+      for (const pattern of this.attributeMethodPatterns) {
+        this.defineAttributeMethodPattern(pattern, attrName, { owner, as });
+      }
+      this.attributeMethodPatternsCache().clear();
+    });
+    if (!Object.prototype.hasOwnProperty.call(this, "_patternsGeneratedFor")) {
+      this._patternsGeneratedFor = new Map(this._patternsGeneratedFor ?? []);
+    }
+    this._patternsGeneratedFor!.set(as, this.attributeMethodPatterns);
+  },
+
+  /**
+   * Mirrors: ClassMethods#define_attribute_method_pattern
+   *
+   * Rails' only `override: true` caller is `alias_attribute_method_definition`
+   * (activerecord/attribute_methods.rb:94), and so is trails'.
+   *
+   * `"define_method_#{pattern.proxy_target}"` (attribute_methods.rb:333) is
+   * spelled out rather than interpolated: a proxy target ending in `=` names a
+   * Ruby writer, whose bare camel spelling belongs to the reader hook of the same
+   * name, so it takes the `set*` fallback docs/ruby-ts-conventions.md gives a
+   * `name=` writer.
+   */
+  defineAttributeMethodPattern(
+    this: ClassMethodsHost,
+    pattern: AttributeMethodPattern,
+    attrName: string,
+    { owner, as, override = false }: { owner: CodeGenerator; as: string; override?: boolean },
+  ): void {
+    const canonicalMethodName = pattern.methodName(attrName);
+    const publicMethodName = pattern.methodName(as);
+
+    // If defining a regular attribute method, we don't override methods that are
+    // explicitly defined in parent classes (attribute_methods.rb:326). The
+    // predicate is a template method: Ruby dispatches it through the class, and
+    // ActiveRecord overrides it to raise DangerousAttributeError for a name
+    // Active Record itself defines and to consult the class's own methods
+    // (activerecord/attribute_methods.rb:165-179).
+    if (this.isInstanceMethodAlreadyImplemented(publicMethodName)) {
+      if (!override) return;
+    }
+
+    // A `parameters: false` pattern emits an accessor property, and a property
+    // cannot shadow an inherited method without breaking every caller that
+    // invokes it — the third consequence in CLAUDE.md, "Generated attribute
+    // readers are properties". Rails needs no such check: `id_in_database` stays
+    // a method whether it comes from PrimaryKey or from the `_in_database`
+    // suffix, so a pk-less model (a PostgreSQL foreign table) generating over it
+    // is harmless there and is not there.
+    if (pattern.parameters === false && !override && answersWithAMethod(this, publicMethodName)) {
+      return;
+    }
+
+    const generateMethod = pattern.proxyTarget.endsWith("=")
+      ? camelize(`set_define_method_${pattern.proxyTarget.slice(0, -1)}`, false)
+      : camelize(`define_method_${pattern.proxyTarget}`, false);
+
+    const generator = (this as unknown as Record<string, unknown>)[generateMethod];
+    if (typeof generator === "function") {
+      (generator as (attrName: string, options: { owner: CodeGenerator; as: string }) => void).call(
+        this,
+        attrName,
+        { owner, as },
+      );
+    } else {
+      this.defineProxyCall(
+        owner,
+        canonicalMethodName,
+        pattern.proxyTarget,
+        pattern.parameters,
+        attrName,
+        {
+          namespace: "active_model_proxy",
+          as: publicMethodName,
+        },
+      );
+    }
+  },
+
+  undefineAttributeMethods(this: ClassMethodsHost): void {
+    const mod = this.generatedAttributeMethods();
+    mod.undefMethod(...mod.instanceMethods());
+    // Clear the pattern-match cache so stale entries don't survive after patterns change.
+    // Mirrors: Rails attribute_method_patterns_cache.clear in undefine_attribute_methods.
+    // Only clear an own-property cache; don't reach up and clear a parent's cache
+    // via inherited prototype-chain lookup.
+    if (Object.hasOwn(this, "_attributeMethodPatternsCache")) {
+      (
+        this as ClassMethodsHost & { _attributeMethodPatternsCache: Map<unknown, unknown> }
+      )._attributeMethodPatternsCache.clear();
+    }
+  },
+
+  /**
+   * Mirrors: ClassMethods#aliases_by_attribute_name
+   * (`activemodel/lib/active_model/attribute_methods.rb:382-384`), a plain
+   * per-class ivar. Rails' `inherited` hook resets it on every subclass
+   * (`:387-394`), so a subclass starts empty; JS has no such hook (CLAUDE.md,
+   * "Module mixins"), and the own-property check is the port of that reset.
+   */
+  aliasesByAttributeName(this: ClassMethodsHost): Map<string, string[]> {
+    if (!Object.prototype.hasOwnProperty.call(this, "_aliasesByAttributeName")) {
+      this._aliasesByAttributeName = new Map<string, string[]>();
+    }
+    return this._aliasesByAttributeName;
+  },
+
+  /** @internal Rails-private helper. Mirrors: ClassMethods#resolve_attribute_name */
+  resolveAttributeName(this: ClassMethodsHost, name: string): string {
+    return this.attributeAliases?.[name] ?? name;
+  },
+
+  /**
+   * @internal Rails-private helper. Mirrors: ClassMethods#generated_attribute_methods
+   *
+   *   def generated_attribute_methods
+   *     @generated_attribute_methods ||= Module.new.tap { |mod| include mod }
+   *   end
+   *
+   * (attribute_methods.rb:400-402.) The `||=` is on a per-class ivar, so the
+   * memo is checked as an *own* property: a subclass must build and include its
+   * own module rather than reusing the one it inherits from its parent, which is
+   * what Ruby's per-class ivar (reset in `inherited`, attribute_methods.rb:386-393)
+   * gives for free.
+   */
+  generatedAttributeMethods(this: ClassMethodsHost): Module {
+    if (!Object.hasOwn(this, "_generatedAttributeMethods")) {
+      const mod = new Module();
+      include(this as unknown as new (...args: unknown[]) => unknown, mod);
+      this._generatedAttributeMethods = mod;
+    }
+    return this._generatedAttributeMethods!;
+  },
+
+  /** @internal Rails-private helper. Mirrors: ClassMethods#instance_method_already_implemented? */
+  isInstanceMethodAlreadyImplemented(this: ClassMethodsHost, methodName: string): boolean {
+    return this.generatedAttributeMethods().isMethodDefined(methodName);
+  },
+
+  /**
+   * @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_cache
+   *
+   * @missingRailsArgs new — PERMANENT: attribute_methods.rb:418 writes
+   * `Concurrent::Map.new(initial_capacity: 4)`; a JS `Map` has no capacity hint,
+   * so the kwarg has no counterpart to pass.
+   */
+  attributeMethodPatternsCache(this: ClassMethodsHost): Map<string, Array<AttributeMethod>> {
+    const h = this as AttributeMethodHost & {
+      _attributeMethodPatternsCache?: Map<string, Array<AttributeMethod>>;
+    };
+    if (!Object.prototype.hasOwnProperty.call(h, "_attributeMethodPatternsCache")) {
+      h._attributeMethodPatternsCache = new Map();
+    }
+    return h._attributeMethodPatternsCache!;
+  },
+
+  /** @internal Rails-private helper. Mirrors: ClassMethods#attribute_method_patterns_matching */
+  attributeMethodPatternsMatching(
+    this: ClassMethodsHost,
+    methodName: string,
+  ): Array<AttributeMethod> {
+    const cache = this.attributeMethodPatternsCache();
+    if (cache.has(methodName)) return cache.get(methodName)!;
+    const matches = this.attributeMethodPatterns.flatMap((pattern) => {
+      const m = pattern.match(methodName);
+      return m ? [m] : [];
+    });
+    cache.set(methodName, matches);
+    return matches;
+  },
+
+  /**
+   * @internal Rails-private helper. Mirrors: ClassMethods#define_proxy_call
+   *
+   * Ruby's `(code_generator, name, proxy_target, parameters, *call_args,
+   * namespace:, as:)` puts required keywords after a splat, which TS cannot
+   * express: the kwargs travel as the last element of the rest tuple.
+   *
+   * Two steps of attribute_methods.rb:408-424 have no TS analogue and are
+   * dropped rather than emulated: `call_args.map!(&:inspect)` quotes each
+   * argument for the Ruby source string, where the port passes the values
+   * themselves, and `call_args << parameters if parameters` appends the
+   * forwarding signature, which `defineCall`'s rest parameter already does.
+   */
+  defineProxyCall(
+    this: ClassMethodsHost,
+    codeGenerator: CodeGenerator,
+    name: string,
+    proxyTarget: string,
+    parameters: string | null | false,
+    ...rest: [...callArgs: string[], options: { namespace: string; as?: string }]
+  ): void {
+    const options = rest[rest.length - 1] as { namespace: string; as?: string };
+    const callArgs = rest.slice(0, -1) as string[];
+    const mangledName = this.buildMangledName(name);
+
+    const namespace = `${options.namespace}_${proxyTarget}`;
+
+    this.defineCall(codeGenerator, name, proxyTarget, mangledName, parameters, callArgs, {
+      namespace,
+      as: options.as ?? name,
+    });
+  },
+
+  /**
+   * @internal Rails-private helper. Mirrors: ClassMethods#build_mangled_name
+   * Returns a compilable temp name for attributes with non-identifier characters.
+   */
+  buildMangledName(name: string): string {
+    if (NAME_COMPILABLE_REGEXP.test(name)) return name;
+    const hex = Array.from(name)
+      .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
+      .join("");
+    return `__temp__${hex}`;
+  },
+
+  /**
+   * @internal Rails-private helper. Mirrors: ClassMethods#define_call
+   *
+   * Rails compiles `def mangled_name(params); self.target_name(call_args); end`
+   * into the generator's batch. A TS "source" is the definition itself, so the
+   * emitted body is the equivalent closure over `callArgs`; a rest parameter
+   * forwards what Ruby's `params` names, so `parameters` only matters when it is
+   * `false` — `def #{mangled_name}(#{parameters || ''})` (attribute_methods.rb:465)
+   * is then a zero-arg reader, which is an accessor property in TS (CLAUDE.md,
+   * "Generated attribute readers are properties"). A `parameters: false` pattern
+   * (before_type_cast.rb:32, query.rb:10) is NOT nil, so it survives as `false`.
+   * `CALL_COMPILABLE_REGEXP` has no analogue either: a JS property lookup needs
+   * no name to be compilable, so the `send(...)` arm it guards never applies.
+   * `name` is unused here exactly as it is in Ruby.
+   */
+  defineCall(
+    codeGenerator: CodeGenerator,
+    _name: string,
+    targetName: string,
+    mangledName: string,
+    parameters: string | null | false,
+    callArgs: string[],
+    { namespace, as }: { namespace: string; as: string },
+  ): void {
+    codeGenerator.defineCachedMethod(mangledName, { namespace, as }, (batch) => {
+      batch.push((mod) => {
+        if (parameters === false) {
+          Object.defineProperty(mod, mangledName, {
+            get(this: ReadWriteHost) {
+              return sendProxyTarget(this, targetName, callArgs);
+            },
+            configurable: true,
+          });
+          return;
+        }
         Object.defineProperty(mod, mangledName, {
-          get(this: ReadWriteHost) {
-            return sendProxyTarget(this, targetName, callArgs);
+          value: function (this: ReadWriteHost, ...args: unknown[]) {
+            return sendProxyTarget(this, targetName, [...callArgs, ...args]);
           },
+          writable: true,
           configurable: true,
         });
-        return;
-      }
-      Object.defineProperty(mod, mangledName, {
-        value: function (this: ReadWriteHost, ...args: unknown[]) {
-          return sendProxyTarget(this, targetName, [...callArgs, ...args]);
-        },
-        writable: true,
-        configurable: true,
       });
     });
-  });
-}
-
-// ---------------------------------------------------------------------------
-// Instance-level Rails privates (attribute_methods.rb)
-// ---------------------------------------------------------------------------
-
-export type InstanceHost = {
-  _attributes?: { isKey(name: string): boolean };
-  attributes: Record<string, unknown>;
-  isRespondToWithoutAttributes(method: string): boolean;
-  attributeMethodPatterns?: AttributeMethodPattern[];
-  constructor: AttributeMethodHost;
+  },
 };
 
 /**
- * A record with the module's own instance methods included — the
- * `include(Model, …)` at the bottom of model.ts.
- */
-type InstanceMethods = InstanceHost & {
-  isAttributeMethod(attrName: string): boolean;
-  constructor: ClassMethods;
-};
-
-/** The receiver `respond_to?` (attribute_methods.rb:528-539) self-sends to. */
-type RespondToHost = {
-  isRespondToWithoutAttributes(method: string): boolean;
-  matchedAttributeMethod(methodName: string): AttributeMethod | null;
-};
-
-/**
- * Mirrors: attribute_methods.rb:528-539
+ * The instance half of `ActiveModel::AttributeMethods`
+ * (attribute_methods.rb:504-590), plus the module's `included do` block
+ * (attribute_methods.rb:70-73):
  *
- *   def respond_to?(method, include_private_methods = false)
- *     if super
- *       true
- *     elsif !include_private_methods && super(method, true)
- *       false
- *     else
- *       !matched_attribute_method(method.to_s).nil?
- *     end
+ *   included do
+ *     class_attribute :attribute_aliases, instance_writer: false, default: {}
+ *     class_attribute :attribute_method_patterns, instance_writer: false,
+ *       default: [ ClassMethods::AttributeMethodPattern.new ]
  *   end
- *
- * Ruby's `super` here is the aliased original, which trails names
- * {@link isRespondToWithoutAttributes} — TS has no `super` for a module
- * outside the prototype chain, so the `super` send is spelled as a send to
- * that alias, in the same position.
- *
- * @missingRailsCall super — PERMANENT: the middle arm (`elsif !include_private_methods
- * && super(method, true)`, attribute_methods.rb:531-535) is omitted. It answers
- * `false` for a name that exists ONLY as a Ruby-private method; a JS receiver
- * has no string-named private methods, so `super(method, true)` and `super`
- * always agree and the arm can never be taken. Porting it means porting a
- * branch that reads as live and cannot run. `includePrivateMethods` stays in
- * the signature — it is what Rails' callers pass — but no longer selects
- * anything.
  */
-export function respondTo(
-  this: RespondToHost,
-  method: string,
-  includePrivateMethods: boolean = false,
-): boolean {
-  void includePrivateMethods;
-  if (this.isRespondToWithoutAttributes(method)) {
-    return true;
-  } else {
-    return this.matchedAttributeMethod(String(method)) !== null;
-  }
-}
+export const InstanceMethods = {
+  [included](base: object): void {
+    classAttribute.call(base, "attributeAliases", { instanceWriter: false, default: {} });
+    classAttribute.call(base, "attributeMethodPatterns", {
+      instanceWriter: false,
+      default: [new AttributeMethodPattern()],
+    });
+  },
+
+  /**
+   * attribute_missing — generic dispatch for an attribute method recognized
+   * through Rails' method_missing path (`matched_attribute_method`), as opposed
+   * to one `define_attribute_method_pattern` has already generated: a generated
+   * method sends its proxy target directly.
+   *
+   * Mirrors: attribute_methods.rb:520-522
+   *   def attribute_missing(match, ...)
+   *     __send__(match.proxy_target, match.attr_name, ...)
+   *   end
+   */
+  attributeMissing(
+    this: Record<string, unknown>,
+    match: AttributeMethod,
+    ...args: unknown[]
+  ): unknown {
+    const target = (this as Record<string, (...a: unknown[]) => unknown>)[match.proxyTarget];
+    if (typeof target !== "function") {
+      throw new MissingAttributeError(
+        `attribute_missing dispatch failed: ${match.proxyTarget} not defined`,
+      );
+    }
+    return target.call(this, match.attrName, ...args);
+  },
+
+  /**
+   * Mirrors: #respond_to_without_attributes? — the alias Rails captures for the
+   * original `respond_to?` before overriding it (attribute_methods.rb:527-528,
+   * `alias :respond_to_without_attributes? :respond_to?`). It keeps the
+   * `respond_to?(method, include_private_methods = false)` signature and answers
+   * whether the receiver responds to `method` at all — including attribute
+   * accessors exposed as getter/setter properties, not just plain functions. The
+   * `in` check mirrors Ruby `respond_to?` across the prototype chain.
+   *
+   * Rails' `include_private_methods` parameter is dropped: a JS receiver has no
+   * string-named private methods for it to reveal, so it could never change the
+   * answer. See {@link respondTo} for the branch that drops with it.
+   */
+  isRespondToWithoutAttributes(this: object, method: string): boolean {
+    return method in (this as Record<string, unknown>);
+  },
+
+  /**
+   * Mirrors: attribute_methods.rb:528-539
+   *
+   *   def respond_to?(method, include_private_methods = false)
+   *     if super
+   *       true
+   *     elsif !include_private_methods && super(method, true)
+   *       false
+   *     else
+   *       !matched_attribute_method(method.to_s).nil?
+   *     end
+   *   end
+   *
+   * Ruby's `super` here is the aliased original, which trails names
+   * {@link isRespondToWithoutAttributes} — TS has no `super` for a module
+   * outside the prototype chain, so the `super` send is spelled as a send to
+   * that alias, in the same position.
+   *
+   * @missingRailsCall super — PERMANENT: the middle arm (`elsif !include_private_methods
+   * && super(method, true)`, attribute_methods.rb:531-535) is omitted. It answers
+   * `false` for a name that exists ONLY as a Ruby-private method; a JS receiver
+   * has no string-named private methods, so `super(method, true)` and `super`
+   * always agree and the arm can never be taken. Porting it means porting a
+   * branch that reads as live and cannot run. `includePrivateMethods` stays in
+   * the signature — it is what Rails' callers pass — but no longer selects
+   * anything.
+   */
+  respondTo(
+    this: InstanceMethodsHost,
+    method: string,
+    includePrivateMethods: boolean = false,
+  ): boolean {
+    void includePrivateMethods;
+    if (this.isRespondToWithoutAttributes(method)) {
+      return true;
+    } else {
+      return this.matchedAttributeMethod(String(method)) !== null;
+    }
+  },
+
+  /**
+   * @internal Rails-private helper. Mirrors: #attribute_method?
+   * (attribute_methods.rb:541-543) —
+   * `respond_to_without_attributes?(:attributes) && attributes.include?(attr_name)`.
+   * Ruby `Hash#include?` is key existence, so the second call is `Object.hasOwn`
+   * over the hash `attributes` returns.
+   */
+  isAttributeMethod(this: InstanceMethodsHost, attrName: string): boolean {
+    return (
+      this.isRespondToWithoutAttributes("attributes") && Object.hasOwn(this.attributes, attrName)
+    );
+  },
+
+  /** @internal Rails-private helper. Mirrors: #matched_attribute_method */
+  matchedAttributeMethod(this: InstanceMethodsHost, methodName: string): AttributeMethod | null {
+    const matches = this.constructor.attributeMethodPatternsMatching(methodName);
+    return matches.find((m) => this.isAttributeMethod(m.attrName)) ?? null;
+  },
+
+  /**
+   * @internal Rails-private helper. Mirrors: #missing_attribute
+   * Rails passes `stack` (a `caller` backtrace) so `raise` reports the call site
+   * rather than this helper; JS `Error` captures its own stack, so when a `stack`
+   * string is supplied we overwrite the error's stack to match Rails' intent.
+   */
+  missingAttribute(this: InstanceHost, attrName: string, stack?: string): never {
+    const err = new MissingAttributeError(
+      `missing attribute '${attrName}' for ${(this.constructor as { name?: string }).name ?? "unknown"}`,
+    );
+    if (stack !== undefined) err.stack = stack;
+    throw err;
+  },
+
+  /**
+   * Mirrors: attribute_methods.rb:555-558
+   *   private
+   *     def _read_attribute(attr)
+   *       __send__(attr)
+   *     end
+   *
+   * ActiveModel dispatches through the reader method; only ActiveRecord's
+   * override goes to the attribute set (activerecord/attribute_methods/read.rb:
+   * 35-37). A generated reader is an accessor property in trails (CLAUDE.md
+   * § "Generated attribute readers are properties"), so `__send__(attr)` is a
+   * property read rather than a call.
+   *
+   * A name the receiver does not answer is where Ruby's `__send__` raises
+   * `NoMethodError` and `method_missing` (attribute_methods.rb:507-514) takes
+   * over: a `matched_attribute_method` goes to `attribute_missing`, and anything
+   * else falls to `super` and propagates. JS has no `method_missing`, so a bare
+   * property read would answer `undefined` there instead — the cascade is spelled
+   * out here.
+   *
+   * @internal Rails-private helper.
+   */
+  _readAttribute(this: InstanceMethodsHost, attr: string): unknown {
+    if (!this.isRespondToWithoutAttributes(attr)) {
+      const match = this.matchedAttributeMethod(attr);
+      if (match) return this.attributeMissing(match);
+      throw new NoMethodError(
+        `undefined method '${attr}' for an instance of ${(this.constructor as { name?: string }).name ?? "unknown"}`,
+      );
+    }
+    return (this as unknown as Record<string, unknown>)[attr];
+  },
+};
 
 /**
  * The `send(proxy_target, *call_args)` the generated body performs
@@ -884,7 +892,7 @@ export function defineMethodAttribute(
 ): void {
   if (as === canonicalName && isDefinedByAClassBody(this, as)) return;
   const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName);
-  const mangledName = buildMangledName(methodName);
+  const mangledName = ClassMethods.buildMangledName(methodName);
   owner.defineCachedMethod(mangledName, { namespace: "active_model", as }, (sources) => {
     sources.push((mod) => {
       Object.defineProperty(mod, mangledName, {
@@ -925,7 +933,7 @@ export function defineMethodAttribute(
  * `undefine_attribute_methods` leaves the patterns alone and stays undone, and
  * a class that has generated nothing keeps its own first-generation seat.
  */
-export function _resurrectAttributeMethods(klass: ClassMethods): void {
+export function _resurrectAttributeMethods(klass: ClassMethodsHost): void {
   const patterns = klass.attributeMethodPatterns;
   if (klass._patternsAtLastResurrection === patterns) return;
   klass._patternsAtLastResurrection = patterns;
@@ -934,30 +942,3 @@ export function _resurrectAttributeMethods(klass: ClassMethods): void {
     .map(([attrName]) => attrName);
   if (stale.length > 0) klass.defineAttributeMethods(...stale);
 }
-
-/**
- * The instance half of `ActiveModel::AttributeMethods`, plus the module's
- * `included do` block (attribute_methods.rb:70-73):
- *
- *   included do
- *     class_attribute :attribute_aliases, instance_writer: false, default: {}
- *     class_attribute :attribute_method_patterns, instance_writer: false,
- *       default: [ ClassMethods::AttributeMethodPattern.new ]
- *   end
- */
-export const InstanceMethods = {
-  [included](base: object): void {
-    classAttribute.call(base, "attributeAliases", { instanceWriter: false, default: {} });
-    classAttribute.call(base, "attributeMethodPatterns", {
-      instanceWriter: false,
-      default: [new AttributeMethodPattern()],
-    });
-  },
-  respondTo,
-  attributeMissing,
-  isAttributeMethod,
-  matchedAttributeMethod,
-  missingAttribute,
-  isRespondToWithoutAttributes,
-  _readAttribute,
-};

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -3,10 +3,10 @@ import { Type } from "./type/value.js";
 import { AttributeSet } from "./attribute-set.js";
 import {
   AttrNames,
-  attributeMissing,
+  ClassMethods as AttributeMethodsClassMethods,
+  InstanceMethods as AttributeMethodsInstanceMethods,
   type AttributeMethodHost,
   type AttributeMethod,
-  buildMangledName,
 } from "./attribute-methods.js";
 import {
   attribute as registrationAttribute,
@@ -129,7 +129,7 @@ export function setDefineMethodAttribute(
   const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName, {
     writer: true,
   });
-  const tempMethodName = buildMangledName(methodName);
+  const tempMethodName = AttributeMethodsClassMethods.buildMangledName(methodName);
   owner.defineCachedMethod(tempMethodName, { namespace: "active_model", as: `${as}=` }, (batch) => {
     batch.push((mod) => {
       Object.defineProperty(mod, tempMethodName, {
@@ -276,4 +276,4 @@ export class Attributes {
 // Ruby `include ActiveModel::AttributeMethods` (attributes.rb:8) — the module
 // brings `attribute_missing` with it; the interface merge above is its type
 // side.
-include(Attributes, { attributeMissing });
+include(Attributes, { attributeMissing: AttributeMethodsInstanceMethods.attributeMissing });

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -164,21 +164,7 @@ interface DirtyModel extends Dirty {
 
 // `include ActiveModel::AttributeMethods`, which `define_attribute_methods`
 // and every `*_will_change!` come from (attribute_methods.rb:73).
-extend(DirtyModel, {
-  attributeMethodPrefix: AttributeMethods.attributeMethodPrefix,
-  attributeMethodSuffix: AttributeMethods.attributeMethodSuffix,
-  attributeMethodAffix: AttributeMethods.attributeMethodAffix,
-  aliasAttribute: AttributeMethods.aliasAttribute,
-  defineAttributeMethods: AttributeMethods.defineAttributeMethods,
-  defineAttributeMethod: AttributeMethods.defineAttributeMethod,
-  defineAttributeMethodPattern: AttributeMethods.defineAttributeMethodPattern,
-  undefineAttributeMethods: AttributeMethods.undefineAttributeMethods,
-  resolveAttributeName: AttributeMethods.resolveAttributeName,
-  generatedAttributeMethods: AttributeMethods.generatedAttributeMethods,
-  isInstanceMethodAlreadyImplemented: AttributeMethods.isInstanceMethodAlreadyImplemented,
-  attributeMethodPatternsCache: AttributeMethods.attributeMethodPatternsCache,
-  attributeMethodPatternsMatching: AttributeMethods.attributeMethodPatternsMatching,
-});
+extend(DirtyModel, AttributeMethods.ClassMethods);
 include(DirtyModel, AttributeMethods.InstanceMethods);
 
 // `include ActiveModel::Dirty` (dirty_test.rb:8) and its `included do` block

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -6,18 +6,8 @@ export { NestedError } from "./nested-error.js";
 export { ValidationError, ValidationContext } from "./validations.js";
 export type { ModelWithErrors } from "./validations.js";
 export { Validator, EachValidator, BlockValidator } from "./validator.js";
-export {
-  MissingAttributeError,
-  missingAttribute,
-  aliasAttribute,
-  aliasesByAttributeName,
-  AttributeMethodPattern,
-  AttrNames,
-  buildMangledName,
-  defineAttributeMethods,
-  undefineAttributeMethods,
-  isInstanceMethodAlreadyImplemented,
-} from "./attribute-methods.js";
+export { MissingAttributeError, AttributeMethodPattern, AttrNames } from "./attribute-methods.js";
+export * as AttributeMethods from "./attribute-methods.js";
 export type { InstanceHost } from "./attribute-methods.js";
 export {
   ForbiddenAttributesError,

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -50,9 +50,6 @@ import {
   defineMethodAttribute,
   _resurrectAttributeMethods,
 } from "./attribute-methods.js";
-
-/** The class half of `include ActiveModel::AttributeMethods` (attribute_methods.rb:75-501). */
-type AttributeMethodsClassMethods = Extended<typeof AttributeMethods.ClassMethods>;
 import * as AttributeAssignment from "./attribute-assignment.js";
 import {
   ClassMethods as ValidationsCallbacksClassMethods,
@@ -92,6 +89,9 @@ import { Naming } from "./naming.js";
  * by the `extend()` at the bottom of this file.
  *
  */
+/** The class half of `include ActiveModel::AttributeMethods` (attribute_methods.rb:75-501). */
+type AttributeMethodsClassMethods = Extended<typeof AttributeMethods.ClassMethods>;
+
 const AttributesClassMethods = { attribute, setDefineMethodAttribute, attributeNames };
 
 /**
@@ -102,6 +102,11 @@ const AttributesClassMethods = { attribute, setDefineMethodAttribute, attributeN
  */
 type ValidatorLike = ValidatorBase | EachValidator | { validate(record: ValidatableRecord): void };
 
+/**
+ * The instance side of every module `Model` includes, including the instance
+ * half of Ruby `include ActiveModel::AttributeMethods` (attribute_methods.rb:73)
+ * that the `include(Model, …)` at the bottom of this file installs.
+ */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
 export interface Model
   extends
@@ -111,9 +116,6 @@ export interface Model
     Serialization,
     Naming,
     SerializersJSON,
-    // The instance half of Ruby `include ActiveModel::AttributeMethods`
-    // (attribute_methods.rb:73), installed by the `include(Model, …)` at the
-    // bottom of this file.
     Included<typeof AttributeMethods.InstanceMethods> {
   /**
    * Redeclared as a method, not the property `Included<>` derives, so a

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -27,8 +27,6 @@ import {
   ToJsonWithActiveSupportEncoder,
   type Included,
   type Extended,
-  type CodeGenerator,
-  Module,
 } from "@blazetrails/activesupport";
 import { humanAttributeName as translationHumanAttributeName } from "./translation.js";
 import { AttributeSet } from "./attribute-set.js";
@@ -52,6 +50,9 @@ import {
   defineMethodAttribute,
   _resurrectAttributeMethods,
 } from "./attribute-methods.js";
+
+/** The class half of `include ActiveModel::AttributeMethods` (attribute_methods.rb:75-501). */
+type AttributeMethodsClassMethods = Extended<typeof AttributeMethods.ClassMethods>;
 import * as AttributeAssignment from "./attribute-assignment.js";
 import {
   ClassMethods as ValidationsCallbacksClassMethods,
@@ -102,7 +103,24 @@ const AttributesClassMethods = { attribute, setDefineMethodAttribute, attributeN
 type ValidatorLike = ValidatorBase | EachValidator | { validate(record: ValidatableRecord): void };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
-export interface Model extends Dirty, Access, Conversion, Serialization, Naming, SerializersJSON {
+export interface Model
+  extends
+    Dirty,
+    Access,
+    Conversion,
+    Serialization,
+    Naming,
+    SerializersJSON,
+    // The instance half of Ruby `include ActiveModel::AttributeMethods`
+    // (attribute_methods.rb:73), installed by the `include(Model, …)` at the
+    // bottom of this file.
+    Included<typeof AttributeMethods.InstanceMethods> {
+  /**
+   * Redeclared as a method, not the property `Included<>` derives, so a
+   * subclass may override `attribute_missing` the way Rails' cascade expects.
+   */
+  attributeMissing(match: AttributeMethod, ...args: unknown[]): unknown;
+
   /**
    * `ActiveModel::Validations#validates_with` (validations/with.rb:144-151),
    * mixed on by the `include(Model, …)` at the bottom of this file.
@@ -111,21 +129,6 @@ export interface Model extends Dirty, Access, Conversion, Serialization, Naming,
 
   /** `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43). */
   toJSON: Included<typeof ToJsonWithActiveSupportEncoder>["toJSON"];
-
-  /**
-   * The instance half of Ruby `include ActiveModel::AttributeMethods`
-   * (attribute_methods.rb:73), installed by the `include(Model, …)` at the
-   * bottom of this file. Declared as methods, not properties, so a subclass
-   * may override `attribute_missing` the way Rails' cascade expects.
-   */
-  attributeMissing(match: AttributeMethod, ...args: unknown[]): unknown;
-  isAttributeMethod(attrName: string): boolean;
-  matchedAttributeMethod(methodName: string): AttributeMethod | null;
-  missingAttribute(attrName: string, stack?: string): never;
-  isRespondToWithoutAttributes(method: string): boolean;
-  respondTo(method: string, includePrivateMethods?: boolean): boolean;
-  /** @internal */
-  _readAttribute(attr: string): unknown;
 
   /**
    * The private instance reader `ActiveModel::Attributes` defines
@@ -467,33 +470,29 @@ export class Model {
 
   // Ruby `include ActiveModel::AttributeMethods` (attribute_methods.rb:73)
   // brings the whole ClassMethods surface along; the `extend(Model, …)` at the
-  // bottom of this file installs it, and these declarations are its type side.
-  declare static attributeMethodPrefix: (
-    ...prefixes: Array<string | { parameters?: string | null | false }>
-  ) => void;
-  declare static attributeMethodSuffix: (
-    ...suffixes: Array<string | { parameters?: string | null | false }>
-  ) => void;
-  declare static attributeMethodAffix: (
-    ...affixes: Array<{ prefix: string; suffix: string; parameters?: string | null | false }>
-  ) => void;
-  declare static aliasAttribute: (newName: string, oldName: string) => void;
-  declare static eagerlyGenerateAliasAttributeMethods: (newName: string, oldName: string) => void;
-  declare static defineAttributeMethods: (...attrNames: string[]) => void;
-  declare static defineAttributeMethod: (
-    attrName: string,
-    options?: { _owner?: Module | CodeGenerator; as?: string },
-  ) => void;
-  declare static defineAttributeMethodPattern: (
-    pattern: AttributeMethodPattern,
-    attrName: string,
-    options: { owner: CodeGenerator; as: string; override?: boolean },
-  ) => void;
-  declare static undefineAttributeMethods: () => void;
-  declare static generatedAttributeMethods: () => Module;
-  declare static isInstanceMethodAlreadyImplemented: (methodName: string) => boolean;
-  declare static attributeMethodPatternsCache: () => Map<string, Array<AttributeMethod>>;
-  declare static attributeMethodPatternsMatching: (methodName: string) => Array<AttributeMethod>;
+  // bottom of this file installs it, and these declarations are its type side,
+  // read off the module object rather than restated here.
+  declare static attributeMethodPrefix: AttributeMethodsClassMethods["attributeMethodPrefix"];
+  declare static attributeMethodSuffix: AttributeMethodsClassMethods["attributeMethodSuffix"];
+  declare static attributeMethodAffix: AttributeMethodsClassMethods["attributeMethodAffix"];
+  declare static aliasAttribute: AttributeMethodsClassMethods["aliasAttribute"];
+  declare static eagerlyGenerateAliasAttributeMethods: AttributeMethodsClassMethods["eagerlyGenerateAliasAttributeMethods"];
+  declare static generateAliasAttributeMethods: AttributeMethodsClassMethods["generateAliasAttributeMethods"];
+  declare static aliasAttributeMethodDefinition: AttributeMethodsClassMethods["aliasAttributeMethodDefinition"];
+  declare static isAttributeAlias: AttributeMethodsClassMethods["isAttributeAlias"];
+  declare static attributeAlias: AttributeMethodsClassMethods["attributeAlias"];
+  declare static defineAttributeMethods: AttributeMethodsClassMethods["defineAttributeMethods"];
+  declare static defineAttributeMethod: AttributeMethodsClassMethods["defineAttributeMethod"];
+  declare static defineAttributeMethodPattern: AttributeMethodsClassMethods["defineAttributeMethodPattern"];
+  declare static undefineAttributeMethods: AttributeMethodsClassMethods["undefineAttributeMethods"];
+  declare static aliasesByAttributeName: AttributeMethodsClassMethods["aliasesByAttributeName"];
+  declare static generatedAttributeMethods: AttributeMethodsClassMethods["generatedAttributeMethods"];
+  declare static isInstanceMethodAlreadyImplemented: AttributeMethodsClassMethods["isInstanceMethodAlreadyImplemented"];
+  declare static attributeMethodPatternsCache: AttributeMethodsClassMethods["attributeMethodPatternsCache"];
+  declare static attributeMethodPatternsMatching: AttributeMethodsClassMethods["attributeMethodPatternsMatching"];
+  declare static defineProxyCall: AttributeMethodsClassMethods["defineProxyCall"];
+  declare static buildMangledName: AttributeMethodsClassMethods["buildMangledName"];
+  declare static defineCall: AttributeMethodsClassMethods["defineCall"];
 
   declare static lookupAncestors: () => Array<{
     new (...args: never[]): unknown;
@@ -681,22 +680,7 @@ extend(Model, {
 // (attribute_methods.rb:396-398) wins over the registration one. The module's
 // ClassMethods land on the class and its instance methods on instances, which
 // is what lets every ported body self-send them.
-extend(Model, {
-  attributeMethodPrefix: AttributeMethods.attributeMethodPrefix,
-  attributeMethodSuffix: AttributeMethods.attributeMethodSuffix,
-  attributeMethodAffix: AttributeMethods.attributeMethodAffix,
-  aliasAttribute: AttributeMethods.aliasAttribute,
-  eagerlyGenerateAliasAttributeMethods: AttributeMethods.eagerlyGenerateAliasAttributeMethods,
-  defineAttributeMethods: AttributeMethods.defineAttributeMethods,
-  defineAttributeMethod: AttributeMethods.defineAttributeMethod,
-  defineAttributeMethodPattern: AttributeMethods.defineAttributeMethodPattern,
-  undefineAttributeMethods: AttributeMethods.undefineAttributeMethods,
-  resolveAttributeName: AttributeMethods.resolveAttributeName,
-  generatedAttributeMethods: AttributeMethods.generatedAttributeMethods,
-  isInstanceMethodAlreadyImplemented: AttributeMethods.isInstanceMethodAlreadyImplemented,
-  attributeMethodPatternsCache: AttributeMethods.attributeMethodPatternsCache,
-  attributeMethodPatternsMatching: AttributeMethods.attributeMethodPatternsMatching,
-});
+extend(Model, AttributeMethods.ClassMethods);
 // Its `included do` block (attribute_methods.rb:70-73) rides along, issued from
 // the module's own `[included]` hook.
 include(Model, AttributeMethods.InstanceMethods);

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -6,13 +6,8 @@
 import { CodeGenerator, include, Module } from "@blazetrails/activesupport";
 import { isEmpty } from "@blazetrails/activesupport/ruby-empty";
 import {
-  aliasesByAttributeName,
-  missingAttribute,
+  AttributeMethods,
   type AttributeMethodPattern,
-  isInstanceMethodAlreadyImplemented as _amInstanceMethodAlreadyImplemented,
-  aliasAttribute as amAliasAttribute,
-  defineAttributeMethods as amDefineAttributeMethods,
-  undefineAttributeMethods as amUndefineAttributeMethods,
   type InstanceHost as AttributeMethodsInstanceHost,
   type DirtyOptions,
 } from "@blazetrails/activemodel";
@@ -347,7 +342,7 @@ export function aliasAttribute(this: AttributeMethodsHost, newName: string, oldN
   if (!Object.prototype.hasOwnProperty.call(this, "_generatedAttributeMethods")) {
     initializeGeneratedModules.call(this);
   }
-  amAliasAttribute.call(this as never, newName, oldName);
+  AttributeMethods.ClassMethods.aliasAttribute.call(this as never, newName, oldName);
 
   if (
     Object.prototype.hasOwnProperty.call(this, "_aliasAttributesMassGenerated") &&
@@ -500,7 +495,10 @@ export function defineAttributeMethods(this: AttributeMethodsHost): boolean {
       Object.prototype.hasOwnProperty.call(this, "_attributeMethodsGenerated") &&
       this._attributeMethodsGenerated;
     if (!generatedByNestedLoad) {
-      amDefineAttributeMethods.call(this as never, ...this.attributeNames());
+      AttributeMethods.ClassMethods.defineAttributeMethods.call(
+        this as never,
+        ...this.attributeNames(),
+      );
       if (this._hasAttribute("id")) this.aliasAttribute("id_value", "id");
     }
   }
@@ -540,7 +538,9 @@ export function generateAliasAttributes(this: AttributeMethodsHost): void {
     return;
   }
   CodeGenerator.batch(this.generatedAttributeMethods(), __FILE__, __LINE__, (codeGenerator) => {
-    for (const [oldName, newNames] of aliasesByAttributeName(this as never)) {
+    for (const [oldName, newNames] of AttributeMethods.ClassMethods.aliasesByAttributeName.call(
+      this as never,
+    )) {
       for (const newName of newNames) {
         generateAliasAttributeMethods.call(this, codeGenerator, newName, oldName);
       }
@@ -564,7 +564,7 @@ export function undefineAttributeMethods(this: AttributeMethodsHost): void {
     Object.prototype.hasOwnProperty.call(this, "_attributeMethodsGenerated") &&
     this._attributeMethodsGenerated
   ) {
-    amUndefineAttributeMethods.call(this as never);
+    AttributeMethods.ClassMethods.undefineAttributeMethods.call(this as never);
   }
   this._attributeMethodsGenerated = false;
   this._aliasAttributesMassGenerated = false;
@@ -636,14 +636,20 @@ export function isInstanceMethodAlreadyImplemented(
 
   const superclass = Object.getPrototypeOf(this);
   if (Object.prototype.hasOwnProperty.call(superclass ?? {}, "_isActiveRecordBase")) {
-    return _amInstanceMethodAlreadyImplemented.call(this as any, methodName);
+    return AttributeMethods.ClassMethods.isInstanceMethodAlreadyImplemented.call(
+      this as any,
+      methodName,
+    );
   } else {
     const base = frameworkBase(this);
     const defined =
       base != null &&
       isMethodDefinedWithin.call(this, methodName, superclass, base) &&
       !isOwnedByGeneratedAttributeMethods(superclass, methodName);
-    return defined || _amInstanceMethodAlreadyImplemented.call(this as any, methodName);
+    return (
+      defined ||
+      AttributeMethods.ClassMethods.isInstanceMethodAlreadyImplemented.call(this as any, methodName)
+    );
   }
 }
 
@@ -883,7 +889,10 @@ export function attributeForInspect(this: InstanceMethodHost, attr: string): str
  */
 export function get(this: InstanceMethodHost, attrName: string): unknown {
   return this.readAttribute(attrName, (n) =>
-    missingAttribute.call(this as unknown as AttributeMethodsInstanceHost, n),
+    AttributeMethods.InstanceMethods.missingAttribute.call(
+      this as unknown as AttributeMethodsInstanceHost,
+      n,
+    ),
   );
 }
 

--- a/packages/activerecord/src/attribute-methods/read.test.ts
+++ b/packages/activerecord/src/attribute-methods/read.test.ts
@@ -41,6 +41,11 @@ describe("ReadTest", () => {
       static generatedAttributeMethods = Base.generatedAttributeMethods;
       static isInstanceMethodAlreadyImplemented = Base.isInstanceMethodAlreadyImplemented;
       static attributeMethodPatternsCache = Base.attributeMethodPatternsCache;
+      static aliasesByAttributeName = Base.aliasesByAttributeName;
+      static generateAliasAttributeMethods = Base.generateAliasAttributeMethods;
+      static defineProxyCall = Base.defineProxyCall;
+      static buildMangledName = Base.buildMangledName;
+      static defineCall = Base.defineCall;
     }
     return Klass;
   }

--- a/packages/activerecord/src/attribute-methods/read.ts
+++ b/packages/activerecord/src/attribute-methods/read.ts
@@ -5,7 +5,7 @@
  */
 
 import type { AttributeSet } from "@blazetrails/activemodel";
-import { AttrNames, buildMangledName } from "@blazetrails/activemodel";
+import { AttrNames, AttributeMethods } from "@blazetrails/activemodel";
 import type { CodeGenerator } from "@blazetrails/activesupport";
 
 /**
@@ -98,7 +98,7 @@ export function defineMethodAttribute(
   { owner, as = canonicalName }: { owner: CodeGenerator; as?: string },
 ): void {
   const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName);
-  const tempMethodName = buildMangledName(methodName);
+  const tempMethodName = AttributeMethods.ClassMethods.buildMangledName(methodName);
   completeHalfAccessor(this, as, "get", function (this: ReadRecord) {
     return readGeneratedAttribute(this, canonicalName);
   });

--- a/packages/activerecord/src/attribute-methods/write.ts
+++ b/packages/activerecord/src/attribute-methods/write.ts
@@ -12,7 +12,7 @@ import {
   Model,
   MissingAttributeError,
   AttrNames,
-  buildMangledName,
+  AttributeMethods,
 } from "@blazetrails/activemodel";
 import type { CodeGenerator } from "@blazetrails/activesupport";
 import { completeHalfAccessor } from "./read.js";
@@ -112,7 +112,7 @@ export function setDefineMethodAttribute(
   const { methodName } = AttrNames.defineAttributeAccessorMethod(owner, canonicalName, {
     writer: true,
   });
-  const tempMethodName = buildMangledName(methodName);
+  const tempMethodName = AttributeMethods.ClassMethods.buildMangledName(methodName);
   completeHalfAccessor(this, as, "set", function (this: Model, value: unknown) {
     this._writeAttribute(canonicalName, value);
   });

--- a/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
+++ b/scripts/api-compare/call-mismatches-exclude/activemodel/attribute-methods.json
@@ -2,6 +2,13 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_method?",
+    "call": "include?",
+    "reason": "attribute_methods.rb:542 is `attributes.include?(attr_name)` over a Ruby Hash; trails' `attributes` returns a plain object, so key existence is `Object.hasOwn` and there is no `include?` to send. Surfaced by grouping the file into module objects, which restored the pairing this method had lost."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
     "rubyName": "define_call",
     "call": "match?",
     "reason": "attribute_methods.rb:457 guards the `send(...)` arm with `CALL_COMPILABLE_REGEXP.match?(target_name)`; trails emits a JS property descriptor rather than compiled source, and a property lookup needs no name to be compilable, so the arm the regexp selects has no counterpart to guard (see the JSDoc on defineCall)."


### PR DESCRIPTION
Rails' `ActiveModel::AttributeMethods` is a module with a nested `module ClassMethods` (attribute_methods.rb:75-501) plus the module's own instance methods (:504-590). trails had every member as a bare top-level `export function`, with the two module identities existing only as local host types and inline object literals in `model.ts` — so a reader could not tell which half a member belonged to, and every new host re-listed all 15 names by hand.

## What changed

- `attribute-methods.ts` exports `ClassMethods` and `InstanceMethods` module objects **holding the bodies** (not references), so the object literal IS the module and api-compare still measures every body for call parity.
- `model.ts` wires them with one `extend(Model, AttributeMethods.ClassMethods)` and one `include(Model, AttributeMethods.InstanceMethods)`; its per-name `declare static` block now reads each type off the module object, and the instance half comes from `Included<typeof AttributeMethods.InstanceMethods>` on the `Model` interface.
- The host types derive via `Extended<>` / `Included<>` — no hand-maintained parallel list of signatures.
- Four self-sends converge from a host-first-argument spelling to real `this` sends: `generate_alias_attribute_methods`, `alias_attribute_method_definition`, `aliases_by_attribute_name`, `attribute_alias?` / `attribute_alias`.

## The pairing trap #6798 hit

An exported declaration carrying Rails method names but no bodies outranks the file's real bodies when api-compare pairs a Ruby method against the file (RFC 0025, `api-compare-bodyless-declaration-outranks-real-body`) — and `export interface Host extends Extended<typeof ClassMethods>` is exactly such a declaration. Measured: with the derived host interfaces exported, all 22 ClassMethods bodies dropped out of the compared population and both baselined call rows went stale.

The fix here keeps the derived host interfaces (`ClassMethodsHost`, `InstanceMethodsHost`) **unexported**, exporting only the ivar-carrying state interfaces (`AttributeMethodHost`, `InstanceHost`) that consumers actually need — which also keeps the `class_attribute` readers' matches (exporting nothing cost 14 matched methods).

Net: matched call pairs 7123 → 7127, `Overall` unchanged at 13535/15423.

## Baseline

Restoring the pairing surfaced one omission that had been hidden behind a bodyless declaration: `attribute_method?` → `include?` (attribute_methods.rb:542 sends `include?` to a Ruby Hash; trails' `attributes` is a plain object, so key existence is `Object.hasOwn`). Baselined with that reason. The two pre-existing rows (`resolve_attribute_name`/`fetch`, `define_call`/`match?`) are still reported.

## Not in this PR

The remaining inline literals in `model.ts` (AttributeRegistration, Validations, ForbiddenAttributesProtection) get the same treatment under a new story, `group-model-ts-remaining-inline-mixin-literals-into-module-objects`, rather than doubling this diff.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm parity:api:calls`, `pnpm parity:api:calls:args` green; `parity:api` / `parity:test` deltas non-negative; `parity:api:extra --package activemodel` novel count unchanged. Suites: all of `packages/activemodel/src`, the AR attribute-methods / dirty / base / core / persistence files, and `scripts/`.

Closes-story: group-attribute-methods-into-classmethods-instancemethods-modules