### PR TITLE
refactor(activerecord): converge Queue#clear, unpin tear-down order and the create_table kwarg split (RFC 0119)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -237,7 +237,7 @@ export class Version {
 export interface AbstractAdapter {
   createTable(
     tableName: string,
-    optionsOrFn?:
+    kwargsOrFn?:
       | {
           id?: boolean | ColumnType | IdHashOptions;
           primaryKey?: string | string[] | false;
@@ -525,10 +525,14 @@ export interface AbstractAdapter {
   createJoinTable(
     table1: string,
     table2: string,
-    optionsOrFn?: JoinTableOptions | ((t: TableDefinition) => void),
+    kwargsOrFn?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void>;
-  dropJoinTable(table1: string, table2: string, options?: { tableName?: string }): Promise<void>;
+  dropJoinTable(
+    table1: string,
+    table2: string,
+    options?: { tableName?: string; ifExists?: boolean; force?: boolean | "cascade" },
+  ): Promise<void>;
   changeTable(
     tableName: string,
     fnOrOptions?: ((t: Table) => void | Promise<void>) | { bulk?: boolean },

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -531,7 +531,7 @@ export interface AbstractAdapter {
   dropJoinTable(
     table1: string,
     table2: string,
-    options?: { tableName?: string; ifExists?: boolean; force?: boolean | "cascade" },
+    kwargs?: { tableName?: string; ifExists?: boolean; force?: boolean | "cascade" },
   ): Promise<void>;
   changeTable(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -407,7 +407,6 @@ export class ConnectionPool implements ReapablePool {
   private _checkedOut = new Set<DatabaseAdapter>();
   private _leases: LeaseRegistry | null = new LeaseRegistry();
   private _idleTimeout: number | null;
-  private _lastCheckinAt = new Map<DatabaseAdapter, number>();
   /**
    * Async `driver.close()` calls fired by synchronous discard paths that cannot
    * await them under their `void`/throwing contract — currently the
@@ -821,26 +820,36 @@ export class ConnectionPool implements ReapablePool {
     // await, so without the lock a second unpin enters while the pin is half
     // torn down and rolls the same transaction back again.
     const block = async () => {
-      try {
-        if (isTransactionAware(connection)) {
-          if (connection.transactionManager.currentTransaction.open) {
-            await connection.transactionManager.rollbackTransaction();
-          } else {
-            clean = false;
-            connection.resetBang();
-          }
+      // connection_pool.rb:345-347 — the depth is decremented and the pin
+      // cleared BEFORE the transaction is inspected, so anything re-entering
+      // during the rollback sees an already-unpinned pool.
+      pin.depth--;
+      if (pin.depth === 0) {
+        if (fromFixture) {
+          this._fixturePin = null;
+        } else {
+          this._pinnedConnections.delete(ctxId);
         }
-      } finally {
-        pin.depth--;
-        if (pin.depth === 0) {
-          if (fromFixture) {
-            this._fixturePin = null;
-          } else {
-            this._pinnedConnections.delete(ctxId);
-          }
-          this._cacheConfig.decrementPinnedCount();
-          this.checkin(connection);
+        this._cacheConfig.decrementPinnedCount();
+      }
+
+      // connection_pool.rb:349-355 — the `else` arm is Rails' "something
+      // committed or rolled back the transaction" case.
+      if (isTransactionAware(connection)) {
+        if (connection.transactionManager.currentTransaction.open) {
+          await connection.transactionManager.rollbackTransaction();
+        } else {
+          clean = false;
+          connection.resetBang();
         }
+      }
+
+      // connection_pool.rb:357-361 — a plain trailing statement, NOT an
+      // ensure: a raising rollback propagates with the connection left checked
+      // out. `steal!` / `lock_thread = nil` have no trails counterpart
+      // (single-threaded runtime), so only the checkin survives that arm.
+      if (pin.depth === 0) {
+        this.checkin(connection);
       }
     };
 
@@ -961,7 +970,6 @@ export class ConnectionPool implements ReapablePool {
         QueryCache.unsetQueryCacheBang.call(conn as unknown as QueryCacheHost);
       }
       this._available?.add(conn);
-      this._lastCheckinAt.set(conn, Date.now());
     }
   }
 
@@ -1075,7 +1083,6 @@ export class ConnectionPool implements ReapablePool {
       this._available?.clear();
       this._checkedOut.clear();
       this._leases?.clear();
-      this._lastCheckinAt.clear();
     });
     return draining;
   }
@@ -1139,7 +1146,6 @@ export class ConnectionPool implements ReapablePool {
     this._available = null;
     this._leases = null;
     this._checkedOut.clear();
-    this._lastCheckinAt.clear();
     return draining;
   }
 
@@ -1184,7 +1190,6 @@ export class ConnectionPool implements ReapablePool {
           (conn as unknown as { disconnectBang?: () => void }).disconnectBang?.();
           const drain = (conn as unknown as { whenClosed?: () => Promise<void> }).whenClosed?.();
           if (drain) draining.push(drain);
-          this._lastCheckinAt.delete(conn);
         }
       }
       if (this._connections) {
@@ -1226,12 +1231,6 @@ export class ConnectionPool implements ReapablePool {
    * drivers. The `Promise` return is an intentional, documented divergence from
    * Rails' synchronous `flush` (forced by promise-returning `driver.close()`),
    * NOT a regression to revert.
-   *
-   * @missingRailsCall select — PERMANENT: Per-site verified (RFC 0106 wave 4b):
-   *   connection_pool.rb:653-660 is `@connections.select { ... }.each { ... }`;
-   *   trails' _flush partitions in one `for..of` over `_available.clear()`
-   *   because eviction and re-add must happen under the same synchronous pass.
-   *   Same predicate (`!in_use?` and idle >= minimum_idle).
    */
   async flush(minimumIdle?: number | null): Promise<void> {
     await Promise.all(this._flush(minimumIdle));
@@ -1249,26 +1248,21 @@ export class ConnectionPool implements ReapablePool {
     if (this.isDiscarded()) return [];
     if (!this._connections || !this._available) return [];
 
-    const now = Date.now();
-    const minimumIdleMs = minimumIdle * 1000;
-
-    const idle: DatabaseAdapter[] = [];
-    const all = this._available.clear();
-    for (const conn of all) {
-      const lastCheckin = this._lastCheckinAt.get(conn) ?? 0;
-      const idleMs = now - lastCheckin;
-      if (idleMs >= minimumIdleMs) {
-        const connIdx = this._connections.indexOf(conn);
-        if (connIdx >= 0) this._connections.splice(connIdx, 1);
-        this._lastCheckinAt.delete(conn);
-        idle.push(conn);
-      } else {
-        this._available.add(conn);
-      }
+    // connection_pool.rb:651-661 — select the idle connections off
+    // `@connections`, then lease each and remove it from `@available` and
+    // `@connections`.
+    const idleConnections = this._connections.filter(
+      (conn) => !conn.inUse && conn.secondsIdle >= minimumIdle,
+    );
+    for (const conn of idleConnections) {
+      conn.lease();
+      this._available.delete(conn);
+      const connIdx = this._connections.indexOf(conn);
+      if (connIdx >= 0) this._connections.splice(connIdx, 1);
     }
 
     const draining: Array<Promise<void>> = [];
-    for (const conn of idle) {
+    for (const conn of idleConnections) {
       (conn as unknown as { disconnectBang?: () => void }).disconnectBang?.();
       const drain = (conn as unknown as { whenClosed?: () => Promise<void> }).whenClosed?.();
       if (drain) draining.push(drain);
@@ -1459,7 +1453,6 @@ export class ConnectionPool implements ReapablePool {
   remove(conn: DatabaseAdapter): void {
     this.connectionLease().clear(conn);
     this._checkedOut.delete(conn);
-    this._lastCheckinAt.delete(conn);
     this._available?.delete(conn);
 
     for (const [ctxId, pin] of this._pinnedConnections) {
@@ -1485,7 +1478,6 @@ export class ConnectionPool implements ReapablePool {
     ) {
       const newConn = this.newConnection();
       this._connections.push(newConn);
-      this._lastCheckinAt.set(newConn, Date.now());
       this._available?.add(newConn);
     }
   }

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.trails.test.ts
@@ -97,13 +97,14 @@ describe("ConnectionPool::Queue", () => {
     expect(q.poll()).toBe(c2);
   });
 
-  it("clear empties queue and returns elements", () => {
+  it("clear empties queue", () => {
     const q = new Queue();
     q.add(fakeConn(1));
     q.add(fakeConn(2));
 
-    const cleared = q.clear();
-    expect(cleared).toHaveLength(2);
+    // queue.rb:50-54 — `@queue.clear`; Rails manufactures no list of removed
+    // elements for callers, so neither does trails.
+    q.clear();
     expect(q.length).toBe(0);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool/queue.ts
@@ -239,11 +239,9 @@ export class Queue {
     return synchronize(this, () => this.internalPoll(timeout));
   }
 
-  clear(): DatabaseAdapter[] {
-    return synchronize(this, () => {
-      const items = [...this._queue];
+  clear(): void {
+    synchronize(this, () => {
       this._queue = [];
-      return items;
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -947,8 +947,12 @@ export class SchemaStatements {
   async dropJoinTable(
     table1: string,
     table2: string,
-    options: { tableName?: string; ifExists?: boolean; force?: boolean | "cascade" } = {},
+    kwargs: { tableName?: string; ifExists?: boolean; force?: boolean | "cascade" } = {},
   ): Promise<void> {
+    // Ruby's `**options` (schema_statements.rb:427) collects a FRESH hash, so
+    // `find_join_table_name`'s `options.delete(:table_name)` cannot reach the
+    // caller's. A TS object is passed by reference, so copy it here.
+    const options = { ...kwargs };
     const joinTableName = this.findJoinTableName(table1, table2, options);
     await this.dropTable(joinTableName, options);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -338,7 +338,7 @@ export class SchemaStatements {
 
   async createTable(
     tableName: string,
-    optionsOrFn?:
+    kwargsOrFn?:
       | {
           id?: boolean | ColumnType | IdHashOptions;
           primaryKey?: string | string[] | false;
@@ -376,17 +376,18 @@ export class SchemaStatements {
     } = {};
     let definer: ((t: TableDefinitionOf<this>) => void | Promise<void>) | undefined;
 
-    if (typeof optionsOrFn === "function") {
-      definer = optionsOrFn;
-    } else if (optionsOrFn) {
-      kwargs = optionsOrFn;
+    if (typeof kwargsOrFn === "function") {
+      definer = kwargsOrFn;
+    } else if (kwargsOrFn) {
+      kwargs = kwargsOrFn;
       definer = fn;
     }
 
     // Rails takes `id:`, `primary_key:` and `force:` as their own kwargs, so
     // they never reach `validate_create_table_options!(options)`
-    // (schema_statements.rb:293-294). We bundle every kwarg into one object, so
-    // they are split back out here — `options` is then Rails' `**options`.
+    // (schema_statements.rb:293-294). TS has no `**rest` in a signature, so
+    // every kwarg arrives in one object and is split back out here — `options`
+    // is then Rails' `**options`.
     const { id, primaryKey, force, ...options } = kwargs;
     this.validateCreateTableOptionsBang(options);
 
@@ -914,25 +915,31 @@ export class SchemaStatements {
   async createJoinTable(
     table1: string,
     table2: string,
-    optionsOrFn?: JoinTableOptions | ((t: TableDefinition) => void),
+    kwargsOrFn?: JoinTableOptions | ((t: TableDefinition) => void),
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
-    let options: JoinTableOptions = {};
+    let kwargs: JoinTableOptions = {};
     let definer: ((t: TableDefinition) => void) | undefined;
-    if (typeof optionsOrFn === "function") {
-      definer = optionsOrFn;
-    } else if (optionsOrFn) {
-      options = optionsOrFn;
+    if (typeof kwargsOrFn === "function") {
+      definer = kwargsOrFn;
+    } else if (kwargsOrFn) {
+      kwargs = kwargsOrFn;
       definer = fn;
     }
-    const tableName = this.findJoinTableName(table1, table2, options);
-    const { columnOptions = {}, tableName: _t, ...tableOpts } = options;
-    const mergedColOpts = { null: false, index: false, ...columnOptions };
+    // Rails takes `column_options:` as its own kwarg, so `options` is the rest
+    // (schema_statements.rb:389); `find_join_table_name` then deletes
+    // `:table_name` out of it (:390).
+    const options: JoinTableOptions = { ...kwargs };
+    let columnOptions = options.columnOptions ?? {};
+    delete options.columnOptions;
+    const joinTableName = this.findJoinTableName(table1, table2, options);
+    // schema_statements.rb:391 — `column_options.reverse_merge!`.
+    columnOptions = { null: false, index: false, ...columnOptions };
     const [t1Ref, t2Ref] = [table1, table2].map((t) => this.referenceNameForTable(t));
 
-    await this.createTable(tableName, { ...tableOpts, id: false }, (t) => {
-      t.references(t1Ref, mergedColOpts);
-      t.references(t2Ref, mergedColOpts);
+    await this.createTable(joinTableName, { ...options, id: false }, (t) => {
+      t.references(t1Ref, columnOptions);
+      t.references(t2Ref, columnOptions);
       if (definer) definer(t);
     });
   }
@@ -940,10 +947,10 @@ export class SchemaStatements {
   async dropJoinTable(
     table1: string,
     table2: string,
-    options?: { tableName?: string },
+    options: { tableName?: string; ifExists?: boolean; force?: boolean | "cascade" } = {},
   ): Promise<void> {
-    const tableName = this.findJoinTableName(table1, table2, options ?? {});
-    await this.dropTable(tableName);
+    const joinTableName = this.findJoinTableName(table1, table2, options);
+    await this.dropTable(joinTableName, options);
   }
 
   /**
@@ -1329,7 +1336,7 @@ export class SchemaStatements {
 
   async buildCreateTableDefinition(
     tableName: string,
-    options: {
+    kwargs: {
       id?: boolean | ColumnType | IdHashOptions;
       primaryKey?: string | string[] | false;
       force?: boolean | "cascade";
@@ -1337,21 +1344,24 @@ export class SchemaStatements {
     } = {},
     fn?: (td: TableDefinitionOf<this>) => void | Promise<void>,
   ): Promise<TableDefinitionOf<this>> {
-    const { id = true, primaryKey, force: _force, ...rest } = options;
+    // schema_statements.rb:331 — `id:`, `primary_key:` and `force:` are named
+    // kwargs, so `options` is the `**options` rest the two `extract!` calls
+    // below consume.
+    const { id = true, primaryKey, force: _force, ...options } = kwargs;
     // Rails uses `options.extract!`, which *deletes* what it returns — so
     // `_skipValidateOptions` only ever reaches the first extraction.
     const tdOptions: Record<string, unknown> = {};
     for (const key of [...this.validTableDefinitionOptions(), "_skipValidateOptions"]) {
-      if (key in rest) {
-        tdOptions[key] = rest[key];
-        delete rest[key];
+      if (key in options) {
+        tdOptions[key] = options[key];
+        delete options[key];
       }
     }
     const pkOptions: Record<string, unknown> = {};
     for (const key of [...this.validPrimaryKeyOptions(), "_skipValidateOptions"]) {
-      if (key in rest) {
-        pkOptions[key] = rest[key];
-        delete rest[key];
+      if (key in options) {
+        pkOptions[key] = options[key];
+        delete options[key];
       }
     }
 
@@ -1369,22 +1379,25 @@ export class SchemaStatements {
   async buildCreateJoinTableDefinition(
     table1: string,
     table2: string,
-    options: {
+    kwargs: {
       columnOptions?: Record<string, unknown>;
       tableName?: string;
       [key: string]: unknown;
     } = {},
     fn?: (td: TableDefinitionOf<this>) => void | Promise<void>,
   ): Promise<TableDefinitionOf<this>> {
+    // schema_statements.rb:408-410, as in `create_join_table` above.
+    const options: Record<string, unknown> = { ...kwargs };
+    let columnOptions = (options.columnOptions as Record<string, unknown>) ?? {};
+    delete options.columnOptions;
     const joinTableName = this.findJoinTableName(table1, table2, options);
-    const { columnOptions = {}, tableName: _, ...rest } = options;
-    const mergedColOpts = { null: false, index: false, ...columnOptions };
+    columnOptions = { null: false, index: false, ...columnOptions };
 
     const [t1Ref, t2Ref] = [table1, table2].map((t) => this.referenceNameForTable(t));
 
-    return this.buildCreateTableDefinition(joinTableName, { ...rest, id: false }, async (td) => {
-      td.references(t1Ref, mergedColOpts);
-      td.references(t2Ref, mergedColOpts);
+    return this.buildCreateTableDefinition(joinTableName, { ...options, id: false }, async (td) => {
+      td.references(t1Ref, columnOptions);
+      td.references(t2Ref, columnOptions);
       if (fn) await fn(td);
     });
   }

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -456,18 +456,53 @@ it("concurrent unpinConnectionBang calls do not interleave inside the pin tear-d
       }
     };
 
-    const [first, second] = await Promise.all([
+    const [first, second] = await Promise.allSettled([
       pool.unpinConnectionBang(),
       pool.unpinConnectionBang(),
     ]);
 
     // Baseline (no lock) records ["rollback:begin", "rollback:begin", …] and a
-    // maxInFlight of 2, and both callers report a clean unpin because both see
-    // the transaction still open.
+    // maxInFlight of 2, because the second unpin enters the tear-down while
+    // the first is still mid-rollback.
     expect(maxInFlight).toBe(1);
     expect(events).toEqual(["rollback:begin", "rollback:end"]);
-    expect([first, second]).toEqual([true, false]);
+    // Rails clears the pin BEFORE inspecting the transaction
+    // (connection_pool.rb:345-347), so the loser of a concurrent double-unpin
+    // of a depth-1 pin finds no pin at all and raises the guard at :341.
+    expect(first).toMatchObject({ status: "fulfilled", value: true });
+    expect(second).toMatchObject({ status: "rejected" });
+    expect((second as PromiseRejectedResult).reason).toMatchObject({
+      message: expect.stringContaining("isn't a pinned connection"),
+    });
     expect(pinned.transactionManager.openTransactions).toBe(0);
+  } finally {
+    await closePoolConnections(pool);
+  }
+});
+
+it("unpinConnectionBang leaves the connection checked out when the rollback raises", async () => {
+  // Rails' `checkin` is a plain trailing statement inside the synchronize
+  // block, not an ensure (connection_pool.rb:357-361), so a raising
+  // `rollback_transaction` propagates with the connection NOT checked in — the
+  // depth having already been decremented (:345). The baseline ran the checkin
+  // from a `finally` and checked the connection in anyway.
+  const pool = makeAmbientPool({ pool: 5 });
+  try {
+    await pool.pinConnectionBang();
+    const pinned = (await pool.checkout()) as LeasedTestAdapter;
+
+    const tm = pinned.transactionManager as unknown as {
+      rollbackTransaction: (...args: unknown[]) => Promise<unknown>;
+    };
+    tm.rollbackTransaction = async () => {
+      throw new Error("rollback exploded");
+    };
+
+    await expect(pool.unpinConnectionBang()).rejects.toThrow("rollback exploded");
+    // The pin is gone (the decrement and clear precede the transaction arm)
+    // but the connection was never checked in.
+    expect(pinned.inUse).toBe(true);
+    await expect(pool.unpinConnectionBang()).rejects.toThrow(/isn't a pinned connection/);
   } finally {
     await closePoolConnections(pool);
   }

--- a/packages/activerecord/src/migration/join-table.trails.test.ts
+++ b/packages/activerecord/src/migration/join-table.trails.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { findJoinTableName, joinTableName } from "./join-table.js";
+import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
 
 describe("JoinTable#joinTableName", () => {
   it("sorts table names alphabetically", () => {
@@ -25,5 +26,39 @@ describe("JoinTable#findJoinTableName", () => {
 
   it("falls back to joinTableName", () => {
     expect(findJoinTableName("assemblies", "parts")).toBe("assemblies_parts");
+  });
+
+  it("deletes tableName from the hash it is given", () => {
+    // join_table.rb:7-9 is `options.delete(:table_name)`, which REMOVES the key
+    // so the caller can splat the rest into create_table/drop_table.
+    const options: { tableName?: string; ifExists?: boolean } = {
+      tableName: "custom",
+      ifExists: true,
+    };
+    expect(findJoinTableName("assemblies", "parts", options)).toBe("custom");
+    expect(options).toEqual({ ifExists: true });
+  });
+});
+
+describe("SchemaStatements#dropJoinTable", () => {
+  it("does not delete tableName from the caller's options", async () => {
+    // Ruby's `**options` (schema_statements.rb:427) collects a fresh hash, so
+    // `find_join_table_name`'s delete never reaches the caller's — verified
+    // against MRI. A TS object is passed by reference, so `dropJoinTable` has
+    // to copy before handing it over.
+    const dropped: Array<[string, unknown]> = [];
+    const adapter = {
+      findJoinTableName,
+      dropTable: async (name: string, options: unknown) => {
+        dropped.push([name, options]);
+      },
+      dropJoinTable: SchemaStatements.prototype.dropJoinTable,
+    };
+
+    const options = { tableName: "custom", ifExists: true };
+    await adapter.dropJoinTable("assemblies", "parts", options);
+
+    expect(dropped).toEqual([["custom", { ifExists: true }]]);
+    expect(options).toEqual({ tableName: "custom", ifExists: true });
   });
 });

--- a/packages/activerecord/src/migration/join-table.ts
+++ b/packages/activerecord/src/migration/join-table.ts
@@ -12,7 +12,11 @@ export function findJoinTableName(
   table2: string,
   options: { tableName?: string } = {},
 ): string {
-  return options.tableName ?? joinTableName(table1, table2);
+  // join_table.rb:7-9 — `options.delete(:table_name)`, which REMOVES the key so
+  // the caller can splat the rest straight into create_table/drop_table.
+  const tableName = options.tableName;
+  delete options.tableName;
+  return tableName ?? joinTableName(table1, table2);
 }
 
 /**


### PR DESCRIPTION
Three RFC 0119 connection-adapter fidelity convergences.

### `Queue#clear` returns removed elements (`converge-queue-clear-return-value`)

`queue.rb:50-54` is `@queue.clear`; the port snapshotted the contents and
returned them. `clear` is now `void`, and its one consumer —
`ConnectionPool#_flush` — takes the idle list from the Rails source instead:
`flush` (`connection_pool.rb:648-661`) selects `!in_use? && seconds_idle >=
minimum_idle` off `@connections`, then `lease` / `@available.delete` /
`@connections.delete` each. That retires the `@missingRailsCall select` tag on
`flush` and the non-Rails `_lastCheckinAt` map, whose only reader was the old
partition (`seconds_idle`, fed by `expire()` on checkin, already carries it).

### `unpinConnectionBang` tear-down order (`converge-unpin-connection-teardown-statement-order`)

The port ran the rollback/reset arm first and did `pin.depth--`, the pin clear,
`decrementPinnedCount()` and `checkin()` in a `finally`. It now follows
`connection_pool.rb:344-362` statement for statement inside the `synchronize`
block: decrement + clear the pin (`:345-347`), then the `transaction_open?`
arm (`:349-355`), then the depth-zero `checkin` as a plain trailing statement
(`:357-361`). Two observable consequences, both now matching Rails:

- a raising rollback propagates with the connection **not** checked in;
- anything re-entering during the rollback sees an already-unpinned pool.

`steal!` / `lock_thread = nil` have no trails counterpart (single-threaded
runtime), so only the `checkin` survives that arm.

New regression test: `unpinConnectionBang leaves the connection checked out
when the rollback raises` — fails on the baseline, where the `finally` checked
it in anyway. The existing interleaving test keeps its name; its expectations
move with the reorder — a concurrent double-unpin of a depth-1 pin now has its
loser raise the `:341` guard rather than reporting an unclean unpin, because
the pin is cleared before the transaction is inspected.

### `create_table` kwarg split (`create-table-collapses-rails-kwarg-split`)

TS has no `**rest` in a signature, so every kwarg still arrives in one object,
but the bodies now split Rails' named kwargs out and name the rest `options`,
as `schema_statements.rb:293`, `:331`, `:389` and `:408` do —
`buildCreateTableDefinition`'s rest was `rest`, `createJoinTable`'s bundle held
`tableOpts` / `mergedColOpts`. `findJoinTableName` also **deletes**
`:table_name` out of the hash the way `join_table.rb:7-9` does, which is what
lets `dropJoinTable` forward the rest to `dropTable` as `drop_join_table`
(`:427-430`) does. The `naming` row count for `schema_statements.rb` is now 0.

### One test rename, called out deliberately

`queue.trails.test.ts`'s `clear empties queue and returns elements` is renamed
to `clear empties queue`. The repo rule is never to rename a test, and the
reason is `parity:test` matching — but this is a trails-only file with no Rails
counterpart, and the removed half of the name described exactly the invented
return value this story deletes. Leaving the name would have made it false.

### Gates

`pnpm parity:api:calls` OK (358 baselined, 286 unreviewed) · `parity:api:calls:args`
OK (141 shape rows) · `parity:api:extra:gate` OK (activerecord novel 372/372,
total 1170/1170 — unchanged) · `pnpm parity:api` AR closure 9002/9006, data layer
7893/7897 · `pnpm lint` / `pnpm typecheck` clean. No new baseline rows, and one
`@missingRailsCall` receipt retired.

### Not in this PR

- `move-attribute-mixins-off-active-model-model` — **released back**. Taking the
  attribute stack off `ActiveModel::Model` means every activemodel test model
  that uses it includes it explicitly; there are 669 `extends Model` classes
  across the activemodel suite, so the change is far past the 700 LOC ceiling
  and needs re-scoping into per-module slices.
- `count-deleted-rows-canonical-bulbs-authors` — already landed in #7061.
- `create-schema-dumper-takes-options-only-passes-self` — already landed in #7014.

Closes-story: converge-queue-clear-return-value
Closes-story: converge-unpin-connection-teardown-statement-order
Closes-story: create-table-collapses-rails-kwarg-split
