### PR TITLE
refactor(activemodel): move the serialization mixins off Model onto ActiveRecord::Base

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -376,6 +376,8 @@ export default defineConfig(
       "packages/trailties/src/**/*.ts",
       "packages/activemodel/src/**/*.ts",
       "packages/activesupport/src/**/*.ts",
+      "packages/globalid/src/**/*.ts",
+      "packages/i18n/src/**/*.ts",
     ],
     // test-helpers/ mirrors Rails' test/ code, which the Ruby extractor never
     // reads, so the manifest cannot back an `@internal` there by construction

--- a/eslint/rails-private-jsdoc.config.mjs
+++ b/eslint/rails-private-jsdoc.config.mjs
@@ -64,6 +64,8 @@ export default [
       "packages/trailties/src/**/*.ts",
       "packages/activemodel/src/**/*.ts",
       "packages/activesupport/src/**/*.ts",
+      "packages/globalid/src/**/*.ts",
+      "packages/i18n/src/**/*.ts",
     ],
     // test-helpers/ mirrors Rails' test/ code, which the Ruby extractor never
     // reads, so the manifest cannot back an `@internal` there by construction

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -37,8 +37,6 @@ import {
   initializeDup as dirtyInitializeDup,
 } from "./dirty.js";
 import { defineModelCallbacks as defineModelCallbacksImpl } from "./callbacks.js";
-import { Serialization } from "./serialization.js";
-import { JSON as SerializersJSON } from "./serializers/json.js";
 import { EachValidator, Validator as ValidatorBase } from "./validator.js";
 import type { ValidatableRecord } from "./validator.js";
 import type { ConditionalOptions } from "./validations.js";
@@ -109,14 +107,7 @@ type ValidatorLike = ValidatorBase | EachValidator | { validate(record: Validata
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (json.rb:47-49); the class/interface merge is how `include()` surfaces on the type side.
 export interface Model
-  extends
-    Dirty,
-    Access,
-    Conversion,
-    Serialization,
-    Naming,
-    SerializersJSON,
-    Included<typeof AttributeMethods.InstanceMethods> {
+  extends Dirty, Access, Conversion, Naming, Included<typeof AttributeMethods.InstanceMethods> {
   /**
    * Redeclared as a method, not the property `Included<>` derives, so a
    * subclass may override `attribute_missing` the way Rails' cascade expects.
@@ -238,7 +229,7 @@ export interface Model
 
 /**
  * Model — the base class that bundles Attributes, Validations, Callbacks,
- * Dirty tracking, Serialization, and Naming.
+ * Dirty tracking and Naming.
  *
  * Mirrors: ActiveModel::Model (with all the included modules)
  */
@@ -246,11 +237,6 @@ export interface Model
 export class Model {
   [key: string]: unknown;
 
-  /**
-   * `class_attribute :include_root_in_json, instance_writer: false,
-   * default: false` (json.rb:15), installed by `JSON.[included]`.
-   */
-  declare static includeRootInJson: boolean | string;
   /**
    * `class_attribute :param_delimiter, instance_reader: false, default: "-"`
    * (conversion.rb:32), installed by `Conversion.[included]`.
@@ -706,13 +692,6 @@ extend(Model, Naming);
 // the module's own `[included]` hook.
 include(Model, Conversion);
 extend(Model, ConversionClassMethods);
-
-// Ruby `include ActiveModel::Serialization` (serialization.rb:127), which
-// `ActiveModel::Serializers::JSON` pulls in (json.rb:11); its `included do`
-// block (json.rb:12-16) extends Naming and issues the
-// `class_attribute :include_root_in_json`.
-include(Model, Serialization);
-include(Model, SerializersJSON);
 
 // Ruby `include ActiveModel::AttributeAssignment` (api.rb:14).
 include(Model, {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -1,4 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type --
+   Each model below spells `include ActiveModel::Serialization` in its class body, the way the
+   Rails test model it mirrors does; the empty class/interface merge beside it is how
+   `include()` surfaces those members on the type side. */
 import { describe, it, expect } from "vitest";
+import { include } from "@blazetrails/activesupport";
+import { Serialization } from "./serialization.js";
 import { Model } from "./index.js";
 import { NoMethodError } from "./attribute-assignment.js";
 
@@ -19,9 +25,12 @@ describe("SerializationTest", () => {
     // is consulted by `serializable_hash` (serialization_test.rb).
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "Alice" });
     (
       p as unknown as { readAttributeForSerialization(n: string): unknown }
@@ -34,9 +43,12 @@ describe("SerializationTest", () => {
     // yields `friends: []` — the accessor exists and returns an empty array.
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "Alice" });
     setAssociationAccessors(p, { posts: [] });
     const hash = p.serializableHash({ include: "posts" });
@@ -49,9 +61,12 @@ describe("SerializationTest", () => {
     // (a non-array Enumerable). serialization maps over it element-wise.
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
       }
     }
+    interface Person extends Serialization {}
+
     const friend = { _attributes: new Map([["name", "Joe"]]) };
     const friendList: Iterable<unknown> = {
       [Symbol.iterator]: () => [friend][Symbol.iterator](),
@@ -66,10 +81,13 @@ describe("SerializationTest", () => {
   it("only include", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "Alice", age: 25 });
     const hash = p.serializableHash({ only: ["name"] });
     expect(hash["name"]).toBe("Alice");
@@ -79,10 +97,13 @@ describe("SerializationTest", () => {
   it("except include", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "Alice", age: 25 });
     const hash = p.serializableHash({ except: ["age"] });
     expect(hash["name"]).toBe("Alice");
@@ -92,9 +113,12 @@ describe("SerializationTest", () => {
   it("should raise NoMethodError for non existing method", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "test" });
     expect(() => p.serializableHash({ methods: ["nonexistent"] })).toThrow(NoMethodError);
     expect(() => p.serializableHash({ methods: ["nonexistent"] })).toThrow(
@@ -105,9 +129,12 @@ describe("SerializationTest", () => {
   it("multiple includes", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "test" });
     const hash = p.serializableHash();
     expect(hash).toHaveProperty("name", "test");
@@ -120,11 +147,14 @@ describe("SerializationTest", () => {
     // (Joe's is [David], Sue's is []).
     class User extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
         this.attribute("email", "string");
         this.attribute("gender", "string");
       }
     }
+    interface User extends Serialization {}
+
     const david = new User({ name: "David", email: "david@example.com", gender: "male" });
     const joe = new User({ name: "Joe", email: "joe@example.com", gender: "male" });
     const sue = new User({ name: "Sue", email: "sue@example.com", gender: "female" });
@@ -157,10 +187,13 @@ describe("SerializationTest", () => {
   it("multiple includes with options", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "test", age: 25 });
     const hash = p.serializableHash({ only: ["name"] });
     expect(hash).toHaveProperty("name", "test");
@@ -170,10 +203,13 @@ describe("SerializationTest", () => {
   it("all includes with options", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "test", age: 25 });
     const hash = p.serializableHash();
     expect(hash).toHaveProperty("name", "test");
@@ -182,6 +218,7 @@ describe("SerializationTest", () => {
 
   class SerPerson extends Model {
     static {
+      include(this, Serialization);
       this.attribute("name", "string");
       this.attribute("age", "integer");
       this.attribute("email", "string");
@@ -190,6 +227,8 @@ describe("SerializationTest", () => {
       return `Hi ${this._readAttribute("name")}`;
     }
   }
+
+  interface SerPerson extends Serialization {}
 
   it("method serializable hash should work", () => {
     const p = new SerPerson({ name: "Alice", age: 30, email: "a@b.com" });
@@ -235,11 +274,14 @@ describe("SerializationTest", () => {
 
   class Post extends Model {
     static {
+      include(this, Serialization);
       this.attribute("title", "string");
       this.attribute("body", "string");
       this.attribute("rating", "integer");
     }
   }
+
+  interface Post extends Serialization {}
 
   it("include option with singular association", () => {
     const p = new Post({ title: "Hello", body: "World", rating: 5 });
@@ -267,11 +309,14 @@ describe("SerializationTest", () => {
   it("method serializable hash should work with only option with order of given keys", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
         this.attribute("age", "integer");
         this.attribute("email", "string");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "Alice", age: 25, email: "a@b.com" });
     const result = p.serializableHash({ only: ["email", "name"] });
     // Rails `Array(only) & attribute_names` orders by the `only:` list, not the
@@ -283,9 +328,12 @@ describe("SerializationTest", () => {
   it("include option with plural association", () => {
     class Person extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
       }
     }
+    interface Person extends Serialization {}
+
     const p = new Person({ name: "Alice" });
     const result = p.serializableHash();
     expect(result.name).toBe("Alice");

--- a/packages/activemodel/src/serialization.trails.test.ts
+++ b/packages/activemodel/src/serialization.trails.test.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type --
+   Each model below spells `include ActiveModel::Serializers::JSON` in its class body, the way the
+   Rails test model it mirrors does; the empty class/interface merge beside it is how
+   `include()` surfaces those members on the type side. */
 /**
  * Serialization tests — TS-only coverage with no counterpart in
  * vendor/rails/activemodel/test/cases/serialization_test.rb. Relocated here
@@ -5,6 +9,8 @@
  * and a renamed or split Rails test stays visible in review.
  */
 import { describe, it, expect } from "vitest";
+import { include } from "@blazetrails/activesupport";
+import { JSON as SerializersJSON } from "./serializers/json.js";
 import { Model } from "./index.js";
 import { readAttributeForSerialization, type SerializationRecord } from "./serialization.js";
 import { NoMethodError } from "./attribute-assignment.js";
@@ -25,11 +31,13 @@ describe("Serialization — trails-only coverage", () => {
   // there use it too.
   class Post extends Model {
     static {
+      include(this, SerializersJSON);
       this.attribute("title", "string");
       this.attribute("body", "string");
       this.attribute("rating", "integer");
     }
   }
+  interface Post extends SerializersJSON {}
 
   it("read_attribute_for_serialization dispatches the accessor, not a stale attributes hash", () => {
     // Rails default `alias :read_attribute_for_serialization :send`: a host
@@ -50,12 +58,15 @@ describe("Serialization — trails-only coverage", () => {
     // attribute's getter serializes the override, not the raw store value.
     class Person extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
       get name(): string {
         return "OVERRIDE:" + (this.attribute("name") as string);
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Bob" });
     expect(p.serializableHash()).toEqual({ name: "OVERRIDE:Bob" });
   });
@@ -114,12 +125,15 @@ describe("Serialization — trails-only coverage", () => {
     // from the store.
     class Person extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
       greeting(): string {
         return "Hi " + (this._readAttribute("name") as string);
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Bob" });
     expect(readAttributeForSerialization(p as unknown as SerializationRecord, "greeting")).toBe(
       "Hi Bob",
@@ -133,9 +147,12 @@ describe("Serialization — trails-only coverage", () => {
     // (Rails' lazy `to_ary` contract) rather than building eagerly.
     class Person extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice" });
     setAssociationAccessors(p, { posts: [] });
     const hash = p.serializableHash({ include: "posts", __sync: true } as never);
@@ -148,10 +165,13 @@ describe("Serialization — trails-only coverage", () => {
     // (serialization.rb:130). trails must not substring-match a scalar string.
     class Person extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice", age: 25 });
     const hash = p.serializableHash({ only: "name" });
     expect(hash["name"]).toBe("Alice");
@@ -161,10 +181,13 @@ describe("Serialization — trails-only coverage", () => {
   it("except include with scalar coerces via Array() like an array", () => {
     class Person extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice", age: 25 });
     const hash = p.serializableHash({ except: "age" });
     expect(hash["name"]).toBe("Alice");
@@ -174,10 +197,13 @@ describe("Serialization — trails-only coverage", () => {
   it("asJson accepts a scalar only like the array form", () => {
     class Person extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice", age: 25 });
     expect(p.asJson({ only: "name" })).toEqual(p.asJson({ only: ["name"] }));
   });
@@ -238,9 +264,12 @@ describe("Serialization — trails-only coverage", () => {
     it("asJson coerces Temporal attributes to ISO 8601 strings", () => {
       class Event extends Model {
         static {
+          include(this, SerializersJSON);
           this.attribute("startsAt", "datetime");
         }
       }
+      interface Event extends SerializersJSON {}
+
       const e = new Event({ startsAt: "2026-04-24T10:00:00.123456Z" });
       const json = e.asJson();
       // `Time#as_json` renders at `ActiveSupport::JSON::Encoding.time_precision`
@@ -251,15 +280,21 @@ describe("Serialization — trails-only coverage", () => {
     it("asJson recurses into include: arrays and nested objects", () => {
       class Post extends Model {
         static {
+          include(this, SerializersJSON);
           this.attribute("id", "big_integer");
           this.attribute("title", "string");
         }
       }
+      interface Post extends SerializersJSON {}
+
       class Blog extends Model {
         static {
+          include(this, SerializersJSON);
           this.attribute("name", "string");
         }
       }
+      interface Blog extends SerializersJSON {}
+
       const b = new Blog({ name: "b" });
       setAssociationAccessors(b, {
         posts: [
@@ -276,10 +311,13 @@ describe("Serialization — trails-only coverage", () => {
     it("attribute named toJSON does not shadow Model#toJSON", () => {
       class Weird extends Model {
         static {
+          include(this, SerializersJSON);
           this.attribute("toJSON", "string");
           this.attribute("name", "string");
         }
       }
+      interface Weird extends SerializersJSON {}
+
       const w = new Weird({ toJSON: "raw-value", name: "w" });
       expect(JSON.parse(JSON.stringify(w))).toEqual({ toJSON: "raw-value", name: "w" });
       expect(w.attribute("toJSON")).toBe("raw-value");
@@ -288,10 +326,13 @@ describe("Serialization — trails-only coverage", () => {
     it("JSON.stringify(model) delegates to asJson via toJSON()", () => {
       class Row extends Model {
         static {
+          include(this, SerializersJSON);
           this.attribute("id", "big_integer");
           this.attribute("name", "string");
         }
       }
+      interface Row extends SerializersJSON {}
+
       const r = new Row({ id: "42", name: "row-1" });
       expect(JSON.stringify(r)).toBe(r.toJSON());
       const parsed = JSON.parse(JSON.stringify(r));
@@ -301,10 +342,13 @@ describe("Serialization — trails-only coverage", () => {
     it("JSON.stringify(model) with large bigint id above Number.MAX_SAFE_INTEGER", () => {
       class Row extends Model {
         static {
+          include(this, SerializersJSON);
           this.attribute("id", "big_integer");
           this.attribute("name", "string");
         }
       }
+      interface Row extends SerializersJSON {}
+
       const big = 2n ** 62n;
       const r = new Row({ id: big, name: "row-2" });
       expect(() => JSON.stringify(r)).not.toThrow();
@@ -317,10 +361,13 @@ describe("Serialization — trails-only coverage", () => {
     it("asJson is idempotent on JSON-safe values", () => {
       class Person extends Model {
         static {
+          include(this, SerializersJSON);
           this.attribute("name", "string");
           this.attribute("age", "integer");
         }
       }
+      interface Person extends SerializersJSON {}
+
       const p = new Person({ name: "Alice", age: 30 });
       expect(p.asJson()).toEqual({ name: "Alice", age: 30 });
     });
@@ -330,6 +377,7 @@ describe("Serialization — trails-only coverage", () => {
 describe("Serialization", () => {
   class Post extends Model {
     static {
+      include(this, SerializersJSON);
       this.attribute("title", "string");
       this.attribute("body", "string");
       this.attribute("rating", "integer");
@@ -339,6 +387,7 @@ describe("Serialization", () => {
       return String(this._readAttribute("title")).slice(0, 10);
     }
   }
+  interface Post extends SerializersJSON {}
 
   it("method serializable hash should work", () => {
     const p = new Post({ title: "Hello", body: "World", rating: 5 });
@@ -404,10 +453,13 @@ describe("fromJson", () => {
   it("from_json should work without a root (class attribute)", () => {
     class User extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface User extends SerializersJSON {}
+
     const u = new User({});
     u.fromJson('{"name":"Alice","age":30}');
     expect(u._readAttribute("name")).toBe("Alice");
@@ -417,9 +469,12 @@ describe("fromJson", () => {
   it("returns this for chaining", () => {
     class User extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface User extends SerializersJSON {}
+
     const u = new User({});
     const result = u.fromJson('{"name":"Bob"}');
     expect(result).toBe(u);
@@ -428,9 +483,12 @@ describe("fromJson", () => {
   it("from_json should work with a root (method parameter)", () => {
     class User extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface User extends SerializersJSON {}
+
     const u = new User({});
     u.fromJson('{"user":{"name":"Charlie"}}', true);
     expect(u._readAttribute("name")).toBe("Charlie");
@@ -439,9 +497,12 @@ describe("fromJson", () => {
   it("marks attributes as changed via dirty tracking", () => {
     class User extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface User extends SerializersJSON {}
+
     const u = new User({ name: "Original" });
     u.changesApplied();
     u.fromJson('{"name":"Updated"}');

--- a/packages/activemodel/src/serializers/json-serialization.test.ts
+++ b/packages/activemodel/src/serializers/json-serialization.test.ts
@@ -1,13 +1,24 @@
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type --
+   Each model below spells `include ActiveModel::Serializers::JSON` in its class body, the way the
+   Rails test model it mirrors does; the empty class/interface merge beside it is how
+   `include()` surfaces those members on the type side. */
 import { describe, it, expect } from "vitest";
+import { include } from "@blazetrails/activesupport";
+import { JSON as SerializersJSON } from "./json.js";
 import { Model } from "../index.js";
 
 describe("JsonSerializationTest", () => {
   it("should include root in JSON (option) even if the default is set to false", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice" });
     const json = JSON.parse(p.toJSON({ root: true }));
     expect(json["person"]).toBeDefined();
@@ -16,10 +27,15 @@ describe("JsonSerializationTest", () => {
 
   it("should include custom root in JSON", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice" });
     const json = JSON.parse(p.toJSON({ root: "human" }));
     expect(json["human"]).toBeDefined();
@@ -28,13 +44,18 @@ describe("JsonSerializationTest", () => {
 
   it("methods are called on object", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
       greeting() {
         return `Hello ${this._readAttribute("name")}`;
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice" });
     const hash = p.serializableHash({ methods: ["greeting"] });
     expect(hash["greeting"]).toBe("Hello Alice");
@@ -42,11 +63,16 @@ describe("JsonSerializationTest", () => {
 
   it("from_json should work without a root (method parameter)", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person();
     p.fromJson('{"name":"Bob","age":30}');
     expect(p._readAttribute("name")).toBe("Bob");
@@ -55,10 +81,15 @@ describe("JsonSerializationTest", () => {
 
   it("as_json should work with root option set to string", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice" });
     const json = p.asJson({ root: "custom_root" });
     expect(json["custom_root"]).toBeDefined();
@@ -66,11 +97,16 @@ describe("JsonSerializationTest", () => {
 
   it("as_json should work with include option paired with only filter", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice", age: 25 });
     const hash = p.asJson({ only: ["name"] });
     expect(hash["name"]).toBe("Alice");
@@ -79,11 +115,16 @@ describe("JsonSerializationTest", () => {
 
   it("as_json should work with include option paired with except filter", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "Alice", age: 25 });
     const hash = p.asJson({ except: ["age"] });
     expect(hash["name"]).toBe("Alice");
@@ -92,21 +133,31 @@ describe("JsonSerializationTest", () => {
 
   it("Class.model_name should be JSON encodable", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const mn = Person.modelName;
     expect(JSON.stringify(mn)).toBeDefined();
   });
 
   it("should return Hash for errors", async () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.validates("name", { presence: true });
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({});
     await p.isValid();
     const errJson = p.errors.asJson();
@@ -115,23 +166,33 @@ describe("JsonSerializationTest", () => {
 
   it("custom as_json should be honored when generating json", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
       asJson() {
         return { custom: true };
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "test" });
     expect(p.asJson()).toEqual({ custom: true });
   });
 
   it("custom as_json options should be extensible", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface Person extends SerializersJSON {}
+
     const p = new Person({ name: "test" });
     const json = p.asJson({ only: ["name"] });
     expect(json).toHaveProperty("name", "test");
@@ -139,10 +200,13 @@ describe("JsonSerializationTest", () => {
 
   class JsonPerson extends Model {
     static {
+      include(this, SerializersJSON);
       this.attribute("name", "string");
       this.attribute("age", "integer");
     }
   }
+
+  interface JsonPerson extends SerializersJSON {}
 
   it("should encode all encodable attributes", () => {
     const p = new JsonPerson({ name: "Alice", age: 30 });
@@ -195,11 +259,16 @@ describe("JsonSerializationTest", () => {
 
   it("should include root in JSON if include_root_in_json is true", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.includeRootInJson = true;
       }
     }
+    interface Person extends SerializersJSON {}
+
     try {
       const p = new Person({ name: "Alice" });
       const json = JSON.parse(p.toJSON());
@@ -211,11 +280,16 @@ describe("JsonSerializationTest", () => {
 
   it("should include custom root in JSON", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.includeRootInJson = "human";
       }
     }
+    interface Person extends SerializersJSON {}
+
     try {
       const p = new Person({ name: "Alice" });
       const json = JSON.parse(p.toJSON());
@@ -227,11 +301,16 @@ describe("JsonSerializationTest", () => {
 
   it("as_json should return a hash if include_root_in_json is true", () => {
     class Person extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.includeRootInJson = true;
       }
     }
+    interface Person extends SerializersJSON {}
+
     try {
       const p = new Person({ name: "Alice" });
       const result = p.asJson();
@@ -244,11 +323,14 @@ describe("JsonSerializationTest", () => {
   it("serializable_hash should not modify options passed in argument", () => {
     class SerPerson extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
         this.attribute("email", "string");
       }
     }
+    interface SerPerson extends SerializersJSON {}
+
     const p = new SerPerson({ name: "Alice", age: 30, email: "a@b.com" });
     const opts = { only: ["name"] };
     p.serializableHash(opts);
@@ -258,10 +340,13 @@ describe("JsonSerializationTest", () => {
   it("should not include root in JSON (class method)", () => {
     class Contact extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Contact extends SerializersJSON {}
+
     const c = new Contact({ name: "Konata", age: 16 });
     const json = c.toJSON();
     expect(json).not.toMatch(/"contact":/);
@@ -271,9 +356,12 @@ describe("JsonSerializationTest", () => {
   it("should not include root in JSON (option)", () => {
     class Contact extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface Contact extends SerializersJSON {}
+
     const c = new Contact({ name: "Konata" });
     const json = c.toJSON({ root: false });
     expect(json).not.toMatch(/"contact":/);
@@ -283,10 +371,13 @@ describe("JsonSerializationTest", () => {
   it("as_json should serialize timestamps", () => {
     class Contact extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("created_at", "string");
       }
     }
+    interface Contact extends SerializersJSON {}
+
     const c = new Contact({ name: "Konata", created_at: "2006-08-01T00:00:00.000Z" });
     const json = c.asJson();
     expect(json.created_at).toBe("2006-08-01T00:00:00.000Z");
@@ -295,10 +386,13 @@ describe("JsonSerializationTest", () => {
   it("as_json should work with root option set to true", () => {
     class Contact extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Contact extends SerializersJSON {}
+
     const c = new Contact({ name: "Konata", age: 16 });
     const json = c.asJson({ root: true });
     expect(json.contact).toBeDefined();
@@ -308,12 +402,15 @@ describe("JsonSerializationTest", () => {
   it("as_json should work with methods options", () => {
     class Contact extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
       social() {
         return "twitter";
       }
     }
+    interface Contact extends SerializersJSON {}
+
     const c = new Contact({ name: "Konata" });
     const json = c.serializableHash({ methods: ["social"] });
     expect(json.name).toBe("Konata");
@@ -322,10 +419,13 @@ describe("JsonSerializationTest", () => {
   it("as_json should work with include option", () => {
     class Contact extends Model {
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.attribute("age", "integer");
       }
     }
+    interface Contact extends SerializersJSON {}
+
     const c = new Contact({ name: "Konata", age: 16 });
     const json = c.asJson();
     expect(json.name).toBe("Konata");
@@ -336,11 +436,16 @@ describe("JsonSerializationTest", () => {
     // Rails json.rb:147 — `hash = hash.values.first if include_root`,
     // ignoring the configured root key and the wrapper's other keys.
     class Multi extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.includeRootInJson = "person";
       }
     }
+    interface Multi extends SerializersJSON {}
+
     try {
       const m = new Multi({}).fromJson('{"first":{"name":"Carol"},"person":{"name":"Dan"}}');
       expect(m._readAttribute("name")).toBe("Carol");
@@ -351,10 +456,15 @@ describe("JsonSerializationTest", () => {
 
   it("from_json rejects non-object JSON with shape-accurate diagnostics", () => {
     class P extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
       }
     }
+    interface P extends SerializersJSON {}
+
     expect(() => new P({}).fromJson("42")).toThrow(/Number passed/);
     expect(() => new P({}).fromJson("[1,2]")).toThrow(/Array passed/);
     expect(() => new P({}).fromJson("null")).toThrow(/NilClass passed/);
@@ -362,11 +472,16 @@ describe("JsonSerializationTest", () => {
 
   it("from_json rejects non-object root payload after unwrap", () => {
     class P extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.includeRootInJson = true;
       }
     }
+    interface P extends SerializersJSON {}
+
     try {
       expect(() => new P({}).fromJson('{"p":42}')).toThrow(/Number passed/);
     } finally {
@@ -379,11 +494,16 @@ describe("JsonSerializationTest", () => {
     // When the class sets includeRootInJson = true, callers can pass a wrapped
     // JSON payload without an explicit second arg.
     class Wrapped extends Model {
+      declare static includeRootInJson: boolean | string;
+
       static {
+        include(this, SerializersJSON);
         this.attribute("name", "string");
         this.includeRootInJson = true;
       }
     }
+    interface Wrapped extends SerializersJSON {}
+
     try {
       const w = new Wrapped({}).fromJson('{"wrapped":{"name":"Alice"}}');
       expect(w._readAttribute("name")).toBe("Alice");

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { JSON as JSONHost } from "./json.js";
-import { Model } from "../index.js";
 
 // Mirrors ActiveModel::Serializers::JSON (json.rb). Pinning the host
 // surface here so the mixin shape (model_name + serializable_hash +
@@ -295,9 +294,5 @@ describe("Serializers::JSON host", () => {
     // Ruby: `if root` is true for "", and `root == true` is false, so
     // Rails wraps under the empty key.
     expect(p.asJson({ root: "" })).toMatchObject({ "": { name: "Hank", age: 70 } });
-  });
-
-  it("Model already implements the same surface ergonomically", () => {
-    expect(typeof Model.prototype.asJson).toBe("function");
   });
 });

--- a/packages/activemodel/src/validations/acceptance-validation.test.ts
+++ b/packages/activemodel/src/validations/acceptance-validation.test.ts
@@ -1,4 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unsafe-declaration-merging, @typescript-eslint/no-empty-object-type --
+   Each model below spells `include ActiveModel::Serialization` in its class body, the way the
+   Rails test model it mirrors does; the empty class/interface merge beside it is how
+   `include()` surfaces those members on the type side. */
 import { describe, it, expect } from "vitest";
+import { include } from "@blazetrails/activesupport";
+import { Serialization } from "../serialization.js";
 import { Model } from "../index.js";
 
 describe("AcceptanceValidationTest", () => {
@@ -165,10 +171,13 @@ describe("AcceptanceValidationTest", () => {
   it("setup! virtual attribute excluded from attributeNames and serialization", () => {
     class Agreement extends Model {
       static {
+        include(this, Serialization);
         this.attribute("name", "string");
         this.validates("terms", { acceptance: true });
       }
     }
+    interface Agreement extends Serialization {}
+
     expect(Agreement.attributeNames()).toContain("name");
     expect(Agreement.attributeNames()).not.toContain("terms");
     const a = new Agreement({ name: "test", terms: "1" });

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -201,7 +201,7 @@ describeIfPg("PostgresqlConnectionTest", () => {
     const baseline = await adapter.execQuery("SHOW DEBUG_PRINT_PLAN");
     const a = new PostgreSQLAdapter({
       connectionString: PG_TEST_URL,
-      variables: { debug_print_plan: "default" },
+      variables: { debug_print_plan: ":default" },
     });
     try {
       const rows = await a.execQuery("SHOW DEBUG_PRINT_PLAN");

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -32,6 +32,7 @@ import type {
 import {
   ArgumentError,
   AttributeMethodPattern,
+  JSONSerializer,
   Model,
   Type,
   type AttributeOptions,
@@ -808,6 +809,15 @@ interface _ConstructorAssociationWriter {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Base extends Model {
+  /**
+   * `class_attribute :include_root_in_json, instance_writer: false,
+   * default: false` (json.rb:15), installed by `JSON.[included]` from
+   * `include ActiveModel::Serializers::JSON` (serialization.rb:6). TS
+   * static-side inheritance flows only through `extends`, so the slot the
+   * mixin installs is declared here.
+   */
+  declare static includeRootInJson: boolean | string;
+
   // --- Translation mixin (wired via extend() after class) ---
   // Normalization
   declare static normalizes: (...args: NormalizesArgs) => void;
@@ -4201,8 +4211,12 @@ export class Base extends Model {
   }
 }
 
+// `toJSON` is omitted from the merge: `Base` already inherits
+// `ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (json.rb:35-43)
+// through `Model`, and re-declaring it here would put a second copy of the
+// name on base.ts's surface.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface Base extends Included<typeof AutosaveAssociation> {
+export interface Base extends Included<typeof AutosaveAssociation>, Omit<JSONSerializer, "toJSON"> {
   /** Mirrors: ActiveRecord::Normalization#normalize_attribute (normalization.rb:26). */
   normalizeAttribute(name: string): void;
   /**
@@ -4610,6 +4624,13 @@ extend(Base, {
   resolveConfigForConnection: ConnectionHandling.resolveConfigForConnection,
   localStoredAttributes: _localStoredAttributesMethod,
 });
+
+// `include ActiveRecord::Serialization` (base.rb:325), which is
+// `include ActiveModel::Serializers::JSON` (serialization.rb:6) — the JSON
+// surface ActiveModel::Model does NOT carry (model.rb:42-45). Its `included do`
+// block sets `self.include_root_in_json = false` (serialization.rb:9-11).
+include(Base, JSONSerializer);
+Base.includeRootInJson = false;
 
 include(Base, {
   // AttributeMethods::Write

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2117,7 +2117,7 @@ export class AbstractAdapter implements Quoting {
     return {};
   }
 
-  async disableReferentialIntegrity(fn: () => Promise<void>, _tables?: string[]): Promise<void> {
+  async disableReferentialIntegrity(fn: () => Promise<void>): Promise<void> {
     await fn();
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.trails.test.ts
@@ -479,50 +479,21 @@ describe("DatabaseStatements", () => {
       expect(executed[0]).toMatch(/DELETE FROM/);
       expect(executed[1]).toMatch(/INSERT INTO/);
     });
-
-    it("scopes disableReferentialIntegrity to the fixture tables and delete targets", async () => {
-      const { insertFixturesSet } = await import("./database-statements.js");
-      let scopedTables: string[] | undefined;
-      const host: DatabaseStatementsHost &
-        Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName"> = {
-        pool,
-        typeCastedBinds,
-        execute: async () => {},
-        transaction: async <T>(fn: (tx?: unknown) => Promise<T> | T) => {
-          await fn();
-          return undefined;
-        },
-        disableReferentialIntegrity: async (fn: () => Promise<void>, tables?: string[]) => {
-          scopedTables = tables;
-          await fn();
-        },
-        quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
-        quoteTableName: (n: string) => `"${n}"`,
-        quoteColumnName: (n: string) => `"${n}"`,
-      };
-
-      await insertFixturesSet.call(host, { users: [{ name: "Alice" }], posts: [{ title: "Hi" }] }, [
-        "old_table",
-        "users",
-      ]);
-
-      expect(scopedTables && [...scopedTables].sort()).toEqual(["old_table", "posts", "users"]);
-    });
   });
 
   describe("truncateTables", () => {
-    it("scopes disableReferentialIntegrity to the tables being truncated", async () => {
+    it("truncates the filtered tables through disableReferentialIntegrity", async () => {
       const { truncateTables } = await import("./database-statements.js");
       const executed: string[] = [];
-      let scopedTables: string[] | undefined;
+      let wrapped = false;
       const host: DatabaseStatementsHost & Pick<Quoting, "quoteTableName"> = {
         pool,
         typeCastedBinds,
         execute: async (sql: string) => {
           executed.push(sql);
         },
-        disableReferentialIntegrity: async (fn: () => Promise<void>, tables?: string[]) => {
-          scopedTables = tables;
+        disableReferentialIntegrity: async (fn: () => Promise<void>) => {
+          wrapped = true;
           await fn();
         },
         quoteTableName: (n: string) => `"${n}"`,
@@ -530,7 +501,7 @@ describe("DatabaseStatements", () => {
 
       await truncateTables.call(host, "users", "posts", "schema_migrations");
 
-      expect(scopedTables).toEqual(["users", "posts"]);
+      expect(wrapped).toBe(true);
       expect(executed).toEqual(['TRUNCATE TABLE "users"', 'TRUNCATE TABLE "posts"']);
     });
   });

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -540,10 +540,12 @@ export async function truncateTables(
 
   if (filtered.length === 0) return;
 
-  const statements = (this.buildTruncateStatements ?? buildTruncateStatements).call(this, filtered);
-
   const exec = this.execute ?? execute;
   const doTruncate = async () => {
+    const statements = (this.buildTruncateStatements ?? buildTruncateStatements).call(
+      this,
+      filtered,
+    );
     if (this.executeBatch) {
       await this.executeBatch(statements, "Truncate Tables");
     } else {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -151,7 +151,7 @@ export interface DatabaseStatementsHost {
     userTransaction?: unknown;
   };
   withinNewTransaction?<T>(opts: unknown, fn: (tx?: unknown) => Promise<T> | T): Promise<T>;
-  disableReferentialIntegrity?(fn: () => Promise<void>, tables?: string[]): Promise<void>;
+  disableReferentialIntegrity?(fn: () => Promise<void>): Promise<void>;
   /** @internal */
   executeBatch?(
     statements: string[],
@@ -554,12 +554,7 @@ export async function truncateTables(
   };
 
   if (this.disableReferentialIntegrity) {
-    let executed = false;
-    await this.disableReferentialIntegrity(async () => {
-      executed = true;
-      await doTruncate();
-    }, filtered);
-    if (!executed) await doTruncate();
+    await this.disableReferentialIntegrity(doTruncate);
   } else {
     await doTruncate();
   }
@@ -990,17 +985,10 @@ export async function insertFixturesSet(
     }
   };
 
-  const affectedTables = [...new Set([...Object.keys(fixtureSet), ...tablesToDelete])];
-
   // Rails wraps fixture loading in a transaction with requires_new: true
   const doLoadInTransaction = async () => {
     if (this.disableReferentialIntegrity) {
-      let executed = false;
-      await this.disableReferentialIntegrity(async () => {
-        executed = true;
-        await doInserts();
-      }, affectedTables);
-      if (!executed) await doInserts();
+      await this.disableReferentialIntegrity(doInserts);
     } else {
       await doInserts();
     }

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -449,5 +449,5 @@ export interface PostgreSQLAdapterOptions extends TrailsAdapterOptions {
   // Mirrors: database.yml `min_messages` — SET client_min_messages on connect (default: "warning")
   minMessages?: string;
   // Mirrors: database.yml `variables:` — SET SESSION key = value on each new connection
-  variables?: Record<string, string | number | boolean | null | "default">;
+  variables?: Record<string, string | number | boolean | null | ":default">;
 }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -171,7 +171,7 @@ const OID_JSONB = 3802;
 /**
  * The `:variables` hash from `@config` (postgresql_adapter.rb:977, :1000).
  */
-type SessionVariables = Record<string, string | number | boolean | null | "default">;
+type SessionVariables = Record<string, string | number | boolean | null | ":default">;
 
 /**
  * Ruby's `Hash#fetch(key, default)` returns the STORED value whenever the key
@@ -805,10 +805,9 @@ export class PostgreSQLAdapter
     await client.query("SET intervalstyle = iso_8601");
     await client.query(`SET client_min_messages TO ${this.quoteLiteral(this._minMessages)}`);
     for (const [key, val] of Object.entries(variables)) {
-      if (val === null) continue;
-      if (val === "default") {
+      if (val === ":default") {
         await client.query(`SET SESSION ${key} TO DEFAULT`);
-      } else {
+      } else if (val != null) {
         const pgVal = val === true ? "on" : val === false ? "off" : String(val);
         await client.query(`SET SESSION ${key} TO ${this.quoteLiteral(pgVal)}`);
       }
@@ -3363,11 +3362,8 @@ export class PostgreSQLAdapter
   // Mirrors: ReferentialIntegrity#disable_referential_integrity. Extracted to
   // postgresql/referential-integrity.ts (Rails houses this in the
   // ReferentialIntegrity module, not schema_statements.rb).
-  override disableReferentialIntegrity(
-    fn: () => Promise<void>,
-    scopedTables?: string[],
-  ): Promise<void> {
-    return disableReferentialIntegrity.call(this, fn, scopedTables);
+  override disableReferentialIntegrity(fn: () => Promise<void>): Promise<void> {
+    return disableReferentialIntegrity.call(this, fn);
   }
 
   // Mirrors: ReferentialIntegrity#check_all_foreign_keys_valid!

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.trails.test.ts
@@ -1,9 +1,9 @@
 /**
  * Adapter-agnostic regression tests for disableReferentialIntegrity.
  *
- * These drive the module function against a fake host (no live PG), pinning
- * the RFC 0060 property that the catalog is enumerated exactly once and the
- * ENABLE pass re-enables the same set the DISABLE pass disabled. The live-PG
+ * These drive the module function against a fake host (no live PG), pinning the
+ * shape of referential_integrity.rb:7-38 — each ALTER pass collects `tables`
+ * itself, and the enable pass swallows an ActiveRecordError. The live-PG
  * behavior lives in adapters/postgresql/referential-integrity.test.ts.
  */
 import { describe, it, expect, vi } from "vitest";
@@ -37,13 +37,13 @@ function makeHost(tables: string[]): {
 }
 
 describe("disableReferentialIntegrity", () => {
-  it("enumerates the table list only once across both passes", async () => {
+  it("collects the table list in each pass", async () => {
     const { host, tablesCalls } = makeHost(["a", "b"]);
     await disableReferentialIntegrity.call(host, async () => {});
-    expect(tablesCalls()).toBe(1);
+    expect(tablesCalls()).toBe(2);
   });
 
-  it("re-enables exactly the set that was disabled even if the block changes the tables", async () => {
+  it("enables the tables the catalog holds once the block has run", async () => {
     let current = ["a", "b"];
     const executed: string[] = [];
     const host: FakeHost = {
@@ -65,21 +65,22 @@ describe("disableReferentialIntegrity", () => {
     expect(disableSql).toBe(
       `ALTER TABLE "a" DISABLE TRIGGER ALL;ALTER TABLE "b" DISABLE TRIGGER ALL`,
     );
-    expect(enableSql).toBe(`ALTER TABLE "a" ENABLE TRIGGER ALL;ALTER TABLE "b" ENABLE TRIGGER ALL`);
-    expect(enableSql).not.toContain(`"c"`);
+    expect(enableSql).toBe(
+      `ALTER TABLE "a" ENABLE TRIGGER ALL;ALTER TABLE "b" ENABLE TRIGGER ALL;ALTER TABLE "c" ENABLE TRIGGER ALL`,
+    );
   });
 
-  it("runs the block without any ALTER when there are no tables", async () => {
+  it("runs the block when the catalog is empty", async () => {
     const { host, executed } = makeHost([]);
     let ran = false;
     await disableReferentialIntegrity.call(host, async () => {
       ran = true;
     });
     expect(ran).toBe(true);
-    expect(executed).toHaveLength(0);
+    expect(executed).toEqual(["", ""]);
   });
 
-  it("still warns and rethrows when an empty-scope block raises InvalidForeignKey", async () => {
+  it("still warns and rethrows when the block raises InvalidForeignKey", async () => {
     const { host } = makeHost(["a", "b"]);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fkError = new InvalidForeignKey("boom", { sql: "", binds: [] });
@@ -95,12 +96,9 @@ describe("disableReferentialIntegrity", () => {
     }
   });
 
-  it("swallows an enable-pass StatementInvalid when the block dropped a snapshotted table", async () => {
+  it("swallows an enable-pass StatementInvalid raised against a missing table", async () => {
     const host: FakeHost = {
       quoteTableName: (name) => `"${name}"`,
-      // Mirrors the adapter translating undefined_table (42P01) to
-      // StatementInvalid (an ActiveRecordError) — the enable-pass catch must
-      // swallow it rather than let it escape disableReferentialIntegrity.
       execute: async (sql) => {
         if (sql.includes("ENABLE TRIGGER ALL")) {
           throw new StatementInvalid('relation "gone" does not exist', { sql, binds: [] });

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.trails.test.ts
@@ -69,27 +69,13 @@ describe("disableReferentialIntegrity", () => {
     expect(enableSql).not.toContain(`"c"`);
   });
 
-  it("toggles only the scoped tables and skips the catalog enumeration when a scope is given", async () => {
-    const { host, executed, tablesCalls } = makeHost(["a", "b", "c", "d"]);
-    await disableReferentialIntegrity.call(host, async () => {}, ["b", "c"]);
-    expect(tablesCalls()).toBe(0);
-    const disableSql = executed.find((s) => s.includes("DISABLE TRIGGER ALL"));
-    const enableSql = executed.find((s) => s.includes("ENABLE TRIGGER ALL"));
-    expect(disableSql).toBe(
-      `ALTER TABLE "b" DISABLE TRIGGER ALL;ALTER TABLE "c" DISABLE TRIGGER ALL`,
-    );
-    expect(enableSql).toBe(`ALTER TABLE "b" ENABLE TRIGGER ALL;ALTER TABLE "c" ENABLE TRIGGER ALL`);
-    expect(disableSql).not.toContain(`"a"`);
-  });
-
-  it("runs the block without any ALTER when the scope is empty", async () => {
-    const { host, executed, tablesCalls } = makeHost(["a", "b"]);
+  it("runs the block without any ALTER when there are no tables", async () => {
+    const { host, executed } = makeHost([]);
     let ran = false;
     await disableReferentialIntegrity.call(host, async () => {
       ran = true;
-    }, []);
+    });
     expect(ran).toBe(true);
-    expect(tablesCalls()).toBe(0);
     expect(executed).toHaveLength(0);
   });
 
@@ -101,7 +87,7 @@ describe("disableReferentialIntegrity", () => {
       await expect(
         disableReferentialIntegrity.call(host, async () => {
           throw fkError;
-        }, []),
+        }),
       ).rejects.toBe(fkError);
       expect(warn).toHaveBeenCalledOnce();
     } finally {

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -7,7 +7,7 @@
 import { ActiveRecordError, InvalidForeignKey } from "../../errors.js";
 
 export interface ReferentialIntegrity {
-  disableReferentialIntegrity(fn: () => Promise<void>, tables?: string[]): Promise<void>;
+  disableReferentialIntegrity(fn: () => Promise<void>): Promise<void>;
   checkAllForeignKeysValidBang(): Promise<void>;
 }
 
@@ -42,26 +42,9 @@ interface ReferentialIntegrityHost extends ReferentialIntegritySqlHost {
 // leaves any surrounding transaction usable. Only an InvalidForeignKey raised
 // by the block earns the missing-privileges warning; every other error bubbles
 // up unchanged.
-//
-// Rails toggles over the full `tables` set because its fixture load is a single
-// bulk `insert_fixtures_set` per run. trails fires this wrapper per fixture-load
-// and per truncate event (~84k times across a suite run), so an
-// ALTER over every canonical table dominates PG DDL cost. Callers that know the
-// exact tables they touch pass `scopedTables`; disabling triggers on just those
-// tables is sufficient because a table's FK-check triggers only fire when that
-// table is itself inserted/deleted/truncated — and those are the only tables the
-// wrapped block touches. Absent a scope, fall back to the whole catalog to
-// preserve the public `disable_referential_integrity` contract.
-//
-// The `scopedTables` parameter has no Rails counterpart (the method is zero-arg
-// in every adapter); it is a tracked deviation pending convergence — see RFC
-// 0023 story `converge-referential-integrity-scoped-tables-parameter` (hoist the
-// fixture-load flow to one block per set, matching Rails' insert_fixtures_set,
-// then drop the parameter).
 export async function disableReferentialIntegrity(
   this: ReferentialIntegrityHost,
   fn: () => Promise<void>,
-  scopedTables?: string[],
 ): Promise<void> {
   let originalException: Error | null = null;
 
@@ -75,9 +58,9 @@ export async function disableReferentialIntegrity(
   // translates to StatementInvalid (an ActiveRecordError), so the enable-pass
   // catch below swallows it — same as Rails silently rescues enable-pass
   // errors (referential_integrity.rb:28-34).
-  const tables = scopedTables ?? (await this.tables());
+  const tables = await this.tables();
 
-  // An empty scope has no triggers to toggle, so skip both ALTER passes — but
+  // An empty database has no triggers to toggle, so skip both ALTER passes — but
   // still route `fn()` through the shared catch below so an InvalidForeignKey it
   // raises earns the missing-privileges warning Rails always prints
   // (referential_integrity.rb:20-30), matching the non-empty path.

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -11,71 +11,35 @@ export interface ReferentialIntegrity {
   checkAllForeignKeysValidBang(): Promise<void>;
 }
 
-interface ReferentialIntegritySqlHost {
+interface ReferentialIntegrityHost {
   quoteTableName(name: string): string;
-}
-
-export function disableReferentialIntegritySql(
-  this: ReferentialIntegritySqlHost,
-  tables: string[],
-): string[] {
-  return tables.map((t) => `ALTER TABLE ${this.quoteTableName(t)} DISABLE TRIGGER ALL`);
-}
-
-export function enableReferentialIntegritySql(
-  this: ReferentialIntegritySqlHost,
-  tables: string[],
-): string[] {
-  return tables.map((t) => `ALTER TABLE ${this.quoteTableName(t)} ENABLE TRIGGER ALL`);
-}
-
-interface ReferentialIntegrityHost extends ReferentialIntegritySqlHost {
   execute(sql: string): Promise<unknown>;
   tables(): Promise<string[]>;
   transaction(fn: () => Promise<void>, options: { requiresNew: boolean }): Promise<unknown>;
 }
 
-// Mirrors: ReferentialIntegrity#disable_referential_integrity. Disables the
-// triggers (FK checks) on the affected tables inside a requires_new
-// transaction, yields, then re-enables them. Both ALTER passes are wrapped in
-// `requiresNew` so a missing-superuser failure rolls back to the savepoint and
-// leaves any surrounding transaction usable. Only an InvalidForeignKey raised
-// by the block earns the missing-privileges warning; every other error bubbles
-// up unchanged.
+// Mirrors: ReferentialIntegrity#disable_referential_integrity
+// (referential_integrity.rb:7-38).
 export async function disableReferentialIntegrity(
   this: ReferentialIntegrityHost,
   fn: () => Promise<void>,
 ): Promise<void> {
   let originalException: Error | null = null;
 
-  // Snapshot the set once and re-enable exactly what we disabled. Re-deriving
-  // the list after the block ran would risk re-enabling a different set if the
-  // block created/dropped tables.
-  //
-  // Snapshotting before `fn()` means that if the block drops a table, the
-  // ENABLE pass issues `ALTER TABLE <dropped> ENABLE TRIGGER ALL` against a
-  // gone table. Postgres raises undefined_table (42P01), which the adapter
-  // translates to StatementInvalid (an ActiveRecordError), so the enable-pass
-  // catch below swallows it — same as Rails silently rescues enable-pass
-  // errors (referential_integrity.rb:28-34).
-  const tables = await this.tables();
-
-  // An empty database has no triggers to toggle, so skip both ALTER passes — but
-  // still route `fn()` through the shared catch below so an InvalidForeignKey it
-  // raises earns the missing-privileges warning Rails always prints
-  // (referential_integrity.rb:20-30), matching the non-empty path.
-  if (tables.length > 0) {
-    try {
-      await this.transaction(
-        async () => {
-          await this.execute(disableReferentialIntegritySql.call(this, tables).join(";"));
-        },
-        { requiresNew: true },
-      );
-    } catch (e) {
-      if (e instanceof ActiveRecordError) originalException = e as Error;
-      else throw e;
-    }
+  try {
+    await this.transaction(
+      async () => {
+        await this.execute(
+          (await this.tables())
+            .map((name) => `ALTER TABLE ${this.quoteTableName(name)} DISABLE TRIGGER ALL`)
+            .join(";"),
+        );
+      },
+      { requiresNew: true },
+    );
+  } catch (e) {
+    if (e instanceof ActiveRecordError) originalException = e as Error;
+    else throw e;
   }
 
   try {
@@ -92,12 +56,14 @@ export async function disableReferentialIntegrity(
     throw e;
   }
 
-  if (tables.length === 0) return;
-
   try {
     await this.transaction(
       async () => {
-        await this.execute(enableReferentialIntegritySql.call(this, tables).join(";"));
+        await this.execute(
+          (await this.tables())
+            .map((name) => `ALTER TABLE ${this.quoteTableName(name)} ENABLE TRIGGER ALL`)
+            .join(";"),
+        );
       },
       { requiresNew: true },
     );

--- a/packages/globalid/src/global-id.ts
+++ b/packages/globalid/src/global-id.ts
@@ -8,11 +8,11 @@ import type { LocateOptions, LocatorLike, LocatorModel } from "./locator.js";
 import { constantize } from "@blazetrails/activesupport";
 
 /**
- * @internal Mirrors Ruby's `model <= GlobalID` — matches the identity
- * itself OR any subclass. Safe for non-constructor `LocatorModel`
- * values (returns false instead of throwing on missing `.prototype`).
+ * Mirrors Ruby's `model <= GlobalID` — matches the identity itself OR any
+ * subclass. Safe for non-constructor `LocatorModel` values (returns false
+ * instead of throwing on missing `.prototype`).
  */
-export function isOrExtends(klass: LocatorModel, base: { prototype: object }): boolean {
+function isOrExtends(klass: LocatorModel, base: { prototype: object }): boolean {
   if ((klass as unknown) === base) return true;
   const proto = (klass as unknown as { prototype?: unknown }).prototype;
   return typeof proto === "object" && proto !== null && proto instanceof (base as never);
@@ -146,7 +146,14 @@ export class GlobalID {
     return this.toString();
   }
 
-  /** @internal The JS serialization hook; delegates to the ported `asJson`. */
+  /**
+   * The JS serialization hook; delegates to the ported `asJson`.
+   *
+   * @internal
+   * @noRailsEquivalent PERMANENT — `JSON.stringify` dispatches on `toJSON`,
+   * which is the JS spelling of what Ruby reaches through `as_json`; without
+   * it a GlobalID serializes as a bare object rather than its URI.
+   */
   toJSON(): string {
     return this.asJson();
   }

--- a/packages/i18n/src/backend/base.ts
+++ b/packages/i18n/src/backend/base.ts
@@ -324,7 +324,14 @@ function localizable(object: unknown): unknown {
 export abstract class Base {
   /** Mirrors: `include I18n::Backend::Transliterator` (base.rb:9). */
   transliterate = transliterate;
-  /** @internal Ruby's `@transliterators` ivar, which has no public reader. */
+  /**
+   * Ruby's `@transliterators` ivar, which has no public reader.
+   *
+   * @internal
+   * @noRailsEquivalent PERMANENT — a Ruby ivar is private to the object; the
+   * TS field cannot be `private` because `Transliterator`'s `this`-typed mixin
+   * functions live in another file and read it.
+   */
   transliterators?: Record<Locale, HashTransliterator | ProcTransliterator>;
 
   private eagerLoadedFlag = false;

--- a/packages/i18n/src/backend/key-value.ts
+++ b/packages/i18n/src/backend/key-value.ts
@@ -119,7 +119,14 @@ export class KeyValue {
   store: Store | null;
   private _subtrees: boolean;
 
-  /** @internal Ruby's `@links` ivar, which `Flatten#links` memoizes into. */
+  /**
+   * Ruby's `@links` ivar, which `Flatten#links` memoizes into.
+   *
+   * @internal
+   * @noRailsEquivalent PERMANENT — a Ruby ivar is private to the object; the
+   * TS field cannot be `private` because `Flatten`'s `this`-typed mixin
+   * functions live in another file and read it.
+   */
   linksCache?: Map<string, Map<string, string>>;
 
   /** Mirrors: `include Flatten` (key_value.rb:70). */
@@ -136,7 +143,14 @@ export class KeyValue {
   /** @internal */
   escapeDefaultSeparator = escapeDefaultSeparator;
 
-  /** @internal Ruby's `@translations` ivar, which `translations` memoizes into. */
+  /**
+   * Ruby's `@translations` ivar, which `translations` memoizes into.
+   *
+   * @internal
+   * @noRailsEquivalent PERMANENT — a Ruby ivar is private to the object; the
+   * TS field cannot be `private` because the `this`-typed store functions live
+   * in another file and read it.
+   */
   translationsStore?: TranslationData;
 
   constructor(store: Store | null, subtrees = true) {

--- a/packages/i18n/src/config.ts
+++ b/packages/i18n/src/config.ts
@@ -196,7 +196,14 @@ export class Config {
   }
 }
 
-/** @internal Test seam — restores every class-level slot to its gem default. */
+/**
+ * Test seam — restores every class-level slot to its gem default.
+ *
+ * @internal
+ * @noRailsEquivalent CONVERGEABLE — Ruby's suite resets by assigning a fresh
+ * `I18n.config`; the class-level slots here are module bindings a fresh Config
+ * does not reach. Removable once the slots hang off the Config instance.
+ */
 export function resetClassConfig(): void {
   backend = undefined;
   defaultLocale = undefined;

--- a/packages/i18n/src/exceptions.ts
+++ b/packages/i18n/src/exceptions.ts
@@ -13,7 +13,14 @@
 import { EMPTY_HASH, normalizeKeys } from "./i18n.js";
 import type { Locale, TranslationKey } from "./i18n.js";
 
-/** @internal Ruby `Object#inspect`, as far as the values reaching this file go. */
+/**
+ * Ruby `Object#inspect`, as far as the values reaching this file go.
+ *
+ * @internal
+ * @noRailsEquivalent PERMANENT — Ruby gets `inspect` from `Object`, so no gem
+ * file declares it; JS has no equivalent universal method and the exception
+ * messages this file builds are defined in terms of it.
+ */
 export function inspect(value: unknown): string {
   if (value === null || value === undefined) return "nil";
   if (typeof value === "string") return inspectString(value);

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -102,7 +102,14 @@ export function setConfig(value: Config): void {
   currentConfig = value;
 }
 
-/** @internal Test seam — drops the process-wide config so a case starts clean. */
+/**
+ * Test seam — drops the process-wide config so a case starts clean.
+ *
+ * @internal
+ * @noRailsEquivalent CONVERGEABLE — Ruby's suite resets by assigning a fresh
+ * `I18n.config`; this also clears the trails-only normalized-key cache, so it
+ * folds into `setConfig` once that cache hangs off the Config instance.
+ */
 export function resetConfig(): void {
   currentConfig = undefined;
   normalizedKeyCache.clear();

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -1,7 +1,7 @@
 {
   "activerecord": {
-    "novel": 372,
-    "total": 1170
+    "novel": 370,
+    "total": 1168
   },
   "arel": {
     "novel": 0,


### PR DESCRIPTION
Bundle of four convergence stories.

## 1. Serialization off `ActiveModel::Model` (RFC 0115)

`ActiveModel::Model` is `include ActiveModel::API` + `include ActiveModel::Access`
and nothing else (`model.rb:42-45`); `API` contributes `AttributeAssignment`,
`Validations` and `Conversion` (`api.rb:60-65`). Serialization is not in that
chain — Rails' own test models spell `include ActiveModel::Serializers::JSON`
themselves (`activemodel/test/models/contact.rb`).

- `model.ts` drops `include(Model, Serialization)` / `include(Model, SerializersJSON)`,
  the two `interface Model extends` members, and the `includeRootInJson` declare.
- `ActiveRecord::Base` picks the surface up where `base.rb:325` puts it:
  `include ActiveRecord::Serialization`, which is
  `include ActiveModel::Serializers::JSON` plus
  `self.include_root_in_json = false` (`serialization.rb:6-11`).
- The activemodel test models that use it now spell the `include` in their own
  class body, the way the Rails test model they mirror does.

`model.ts` extra surface: **61 moved → 46**.

`interface Base` omits `toJSON` from the JSON merge — `Base` already inherits
`ActiveSupport::ToJsonWithActiveSupportEncoder#to_json` (`json.rb:35-43`)
through `Model`, and re-declaring it would put a second copy of the name on
base.ts's measured surface. Noted at the call site.

## 2. PG `:default` sentinel spelling (RFC 0119)

`postgresql_adapter.rb:983` is `if v == ":default" || v == :default` — the
`database.yml` spelling and the Symbol, both `":default"` under this repo's
Symbol convention. trails tested `val === "default"`, the one spelling Rails
rejects. Fixed, along with the `SessionVariables` /
`PostgreSQLAdapterOptions["variables"]` types and the one test that passed the
bare string. Branch order now mirrors the Ruby (`:default` arm first, then
`elsif !v.nil?`) rather than a leading nil-continue.

`dbconsole-option-keys.trails.test.ts` already asserted the Rails-correct
behaviour for `PGOPTIONS`, so it is unchanged.

## 3. `disableReferentialIntegrity` zero-arg shape (RFC 0119)

`disable_referential_integrity` is zero-arg in every adapter
(`postgresql/referential_integrity.rb:7`, `sqlite3_adapter.rb:255`,
`abstract_mysql_adapter.rb:212`). The trails-only `scopedTables?: string[]`
parameter, the `DatabaseStatementsHost` mirror, and the `executed` fallback
dance at both call sites are gone; `truncateTables` and `insertFixturesSet` now
read like `database_statements.rb:222-231` and `:486-496`, including building
the truncate statements inside the block the way `:228` does. The fixture-load
flow was already one block per set (`fixtures.rb:684`), so no hoist was needed.

Removing the parameter left three inventions in the body that existed only to
serve it, so the body is now `referential_integrity.rb:7-38` line for line:

- the catalog was snapshotted once for both ALTER passes; Rails collects
  `tables` inside each pass (`:12`, `:35`);
- a `tables.length > 0` guard skipped both passes on an empty catalog, with a
  matching early return before the enable pass. Rails has neither — an empty
  `collect` joins to `""` and is executed;
- `disableReferentialIntegritySql` / `enableReferentialIntegritySql` were
  extracted helpers with no Rails counterpart and no caller outside the file.
  Rails inlines the `tables.collect { ... }` expression at both sites, so they
  are inlined; the two novel names leave activerecord's extra surface and the
  marks are narrowed with `parity:api:extra:tighten` (372/1170 -> 370/1168,
  never raised).

The doc comment that cited a landed story as pending convergence is deleted.
The four renamed cases in `referential-integrity.trails.test.ts` are trails-only
names that described the snapshot property this PR removes; no Rails-derived
test name is touched anywhere in the diff.

## 4. RFC 0121 `@internal` burn-down — globalid + i18n

Both packages are now enrolled in `unbacked-internal-needs-receipt` (in
`eslint.config.mjs` and `eslint/rails-private-jsdoc.config.mjs`, kept in sync).
Eight sites decided individually:

- `globalid` `isOrExtends` — trails-local helper with one caller in its own
  file; un-exported rather than receipted, so it leaves the measured surface.
- `globalid` `GlobalID#toJSON` — `PERMANENT`, the JS dispatch hook for what Ruby
  reaches through `as_json`.
- `i18n` `Base#transliterators`, `KeyValue#linksCache`, `#translationsStore` —
  `PERMANENT`; each is a Ruby ivar, and the TS field cannot be `private`
  because the `this`-typed mixin functions that read it live in another file.
- `i18n` `exceptions.ts` `inspect` — `PERMANENT`; Ruby gets it from `Object`, so
  no gem file declares it.
- `i18n` `resetClassConfig` / `resetConfig` — `CONVERGEABLE`, with the condition
  that retires them (the slots hanging off the Config instance) stated.

`arel` and `activerecord` are untouched here, so
`pnpm parity:api:extra:gate` marks do not move.

## Verification

- `pnpm parity:api` — matched methods and files identical to `main`
  (13535/15423, 898/1050); `pnpm parity:test` identical (15735/22770, 796/1084).
- `pnpm api:extra:gate` — OK (arel 0/62, activerecord 370/1168, narrowed).
- `pnpm parity:api:calls` — OK. `pnpm parity:api:calls:args` — OK. No new
  baseline rows.
- `pnpm lint` — clean. `pnpm build` — clean.
- `--project activerecord` 12062 passed; `--project other` 18756 passed. One
  unrelated flake in `activesupport/src/time-zone.trails.test.ts` (a 5s timeout
  under load avg 16) passes in isolation.

Filed `converge-mysql-variables-default-sentinel-spelling` (RFC 0119) for the
identical bare-`"default"` sentinel in `mysql2-adapter.ts:1650`, which is out of
scope for the PG-scoped story here.

Closes-story: move-serialization-mixins-off-active-model-model
Closes-story: burn-down-internal-tags-unbacked-after-entity-keying
Closes-story: converge-pg-variables-default-sentinel-spelling
Closes-story: converge-referential-integrity-scoped-tables-parameter
