### PR TITLE
test(activerecord): report why insert_all's row is missing in the leading-colon flake

### DIFF
--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -22,6 +22,47 @@ const CASES: [string, string][] = [
   ["Alpha::Beta", "Alpha::Beta"],
 ];
 
+/**
+ * Diagnostics for the intermittent failure tracked by
+ * `leading-colon-insert-all-first-returns-null-flake` (RFC 0061): the row
+ * `insert_all` just wrote is occasionally not found by the very next read, seen
+ * on SQLite and MariaDB and only ever inside a full-suite run. The cheap
+ * explanations are eliminated (a stale query cache — the cache is never enabled
+ * in the AR lanes; a silently skipped `ON CONFLICT DO NOTHING` — the only unique
+ * constraint is the PK and the id counters self-adjust), so the next sighting
+ * has to bring data out of the failing process itself.
+ *
+ * This runs ONLY once the read has already come back empty, and reports rather
+ * than repairs — it exists to turn a bare "Cannot read properties of null" into
+ * an error that says which of the remaining hypotheses is true:
+ *
+ *   - `returning` empty        → the INSERT itself wrote no row.
+ *   - `returning` non-empty but the row is absent from `topics` → something
+ *     removed it between the two statements.
+ *   - the row present in `topics` but not returned by the read → the read is at
+ *     fault (wrong connection, or an uncommitted transaction on another one).
+ */
+async function missingRowDiagnostics(
+  iteration: number,
+  sent: string,
+  returning: unknown,
+): Promise<string> {
+  const connection = (await Topic.leaseConnection()) as unknown as {
+    execQuery(sql: string): Promise<{ rows: unknown[][] }>;
+    openTransactions: number;
+  };
+  const all = await connection.execQuery(
+    'SELECT "id", "title", "author_name" FROM "topics" ORDER BY "id"',
+  );
+  return [
+    `insert_all wrote a row that the next read did not find.`,
+    `  iteration:        ${iteration} (sent ${JSON.stringify(sent)})`,
+    `  returning:        ${JSON.stringify(returning)}`,
+    `  openTransactions: ${connection.openTransactions}`,
+    `  topics rows:      ${JSON.stringify(all.rows)}`,
+  ].join("\n");
+}
+
 describe("leading-colon string writes", () => {
   fixtures({ topics: [Topic, {}] });
 
@@ -47,13 +88,16 @@ describe("leading-colon string writes", () => {
 
   it("create and insert_all store a leading colon verbatim", async () => {
     await Topic.create({ title: "seed" });
-    for (const [sent, stored] of CASES) {
+    for (const [iteration, [sent, stored]] of CASES.entries()) {
       const created = await Topic.create({ title: sent });
       expect((await Topic.find(created.id)).title).toBe(stored);
 
-      await Topic.insertAll([{ title: sent, author_name: "colon" }]);
+      const returning = await Topic.insertAll([{ title: sent, author_name: "colon" }]);
       const inserted = await Topic.where({ author_name: "colon" }).first();
-      expect(inserted!.title).toBe(stored);
+      if (inserted == null) {
+        throw new Error(await missingRowDiagnostics(iteration, sent, returning.rows));
+      }
+      expect(inserted.title).toBe(stored);
       await Topic.where({ author_name: "colon" }).deleteAll();
     }
   });

--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -23,34 +23,20 @@ const CASES: [string, string][] = [
 ];
 
 /**
- * Diagnostics for the intermittent failure tracked by
- * `leading-colon-insert-all-first-returns-null-flake` (RFC 0061): the row
- * `insert_all` just wrote is occasionally not found by the very next read, seen
- * on SQLite and MariaDB and only ever inside a full-suite run. The cheap
- * explanations are eliminated (a stale query cache — the cache is never enabled
- * in the AR lanes; a silently skipped `ON CONFLICT DO NOTHING` — the only unique
- * constraint is the PK and the id counters self-adjust), so the next sighting
- * has to bring data out of the failing process itself.
- *
- * This runs ONLY once the read has already come back empty, and reports rather
- * than repairs — it exists to turn a bare "Cannot read properties of null" into
- * an error that says which of the remaining hypotheses is true:
- *
- *   - `returning` empty        → the INSERT itself wrote no row.
- *   - `returning` non-empty but the row is absent from `topics` → something
- *     removed it between the two statements.
- *   - the row present in `topics` but not returned by the read → the read is at
- *     fault (wrong connection, or an uncommitted transaction on another one).
+ * Reports why the row `insert_all` just wrote was not found by the next read —
+ * the intermittent failure tracked by
+ * `leading-colon-insert-all-first-returns-null-flake` (RFC 0061), which has only
+ * ever reproduced inside a full-suite run. Runs on the already-failing path
+ * only. An empty `returning` means the INSERT wrote no row; a non-empty one with
+ * the row absent from `topics` means something removed it in between; the row
+ * present but unread means the read is at fault.
  */
 async function missingRowDiagnostics(
   iteration: number,
   sent: string,
   returning: unknown,
 ): Promise<string> {
-  const connection = (await Topic.leaseConnection()) as unknown as {
-    execQuery(sql: string): Promise<{ rows: unknown[][] }>;
-    openTransactions: number;
-  };
+  const connection = await Topic.leaseConnection();
   const all = await connection.execQuery(
     'SELECT "id", "title", "author_name" FROM "topics" ORDER BY "id"',
   );

--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-fixtures.js";
+import { withConnection } from "../connection-handling.js";
 import { Topic } from "../test-helpers/models/topic.js";
 
 const CASES: [string, string][] = [
@@ -41,6 +42,7 @@ async function missingRowDiagnostics(
   iteration: number,
   sent: string,
   returning: unknown,
+  writeConnection: unknown,
 ): Promise<string> {
   const connection = await Topic.leaseConnection();
   const id = connection.quoteColumnName("id");
@@ -59,6 +61,15 @@ async function missingRowDiagnostics(
   } catch (error) {
     probe = `raised ${error instanceof Error ? error.message : String(error)}`;
   }
+  const sameConnection = writeConnection === connection;
+  const rowsViaWriteLease = await withConnection.call(Topic as never, async (c: unknown) => {
+    const conn = c as typeof connection;
+    const result = await conn.execQuery(
+      `SELECT ${id} FROM ${conn.quoteTableName("topics")} ` +
+        `WHERE ${conn.quoteColumnName("author_name")} = 'colon'`,
+    );
+    return result.rows;
+  });
   return [
     `insert_all wrote a row that the next read did not find.`,
     `  iteration:        ${iteration} (sent ${JSON.stringify(sent)})`,
@@ -66,6 +77,8 @@ async function missingRowDiagnostics(
     `  openTransactions: ${connection.openTransactions}`,
     `  topics rows:      ${JSON.stringify(all.rows)}`,
     `  next insert:      ${probe}`,
+    `  same connection:  ${String(sameConnection)}`,
+    `  colon rows via write lease: ${JSON.stringify(rowsViaWriteLease)}`,
   ].join("\n");
 }
 
@@ -98,10 +111,13 @@ describe("leading-colon string writes", () => {
       const created = await Topic.create({ title: sent });
       expect((await Topic.find(created.id)).title).toBe(stored);
 
+      const writeConnection = await withConnection.call(Topic as never, (c: unknown) => c);
       const returning = await Topic.insertAll([{ title: sent, author_name: "colon" }]);
       const inserted = await Topic.where({ author_name: "colon" }).first();
       if (inserted == null) {
-        throw new Error(await missingRowDiagnostics(iteration, sent, returning.rows));
+        throw new Error(
+          await missingRowDiagnostics(iteration, sent, returning.rows, writeConnection),
+        );
       }
       expect(inserted.title).toBe(stored);
       await Topic.where({ author_name: "colon" }).deleteAll();

--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -52,12 +52,20 @@ async function missingRowDiagnostics(
   const all = await connection.execQuery(
     `SELECT ${columns.join(", ")} FROM ${connection.quoteTableName("topics")} ORDER BY ${id}`,
   );
+  let probe: string;
+  try {
+    const row = await Topic.create({ title: "__pk probe" });
+    probe = `inserted id ${String(row.id)}`;
+  } catch (error) {
+    probe = `raised ${error instanceof Error ? error.message : String(error)}`;
+  }
   return [
     `insert_all wrote a row that the next read did not find.`,
     `  iteration:        ${iteration} (sent ${JSON.stringify(sent)})`,
     `  returning:        ${JSON.stringify(returning)}`,
     `  openTransactions: ${connection.openTransactions}`,
     `  topics rows:      ${JSON.stringify(all.rows)}`,
+    `  next insert:      ${probe}`,
   ].join("\n");
 }
 

--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -37,8 +37,14 @@ async function missingRowDiagnostics(
   returning: unknown,
 ): Promise<string> {
   const connection = await Topic.leaseConnection();
+  const id = connection.quoteColumnName("id");
+  const columns = [
+    id,
+    connection.quoteColumnName("title"),
+    connection.quoteColumnName("author_name"),
+  ];
   const all = await connection.execQuery(
-    'SELECT "id", "title", "author_name" FROM "topics" ORDER BY "id"',
+    `SELECT ${columns.join(", ")} FROM ${connection.quoteTableName("topics")} ORDER BY ${id}`,
   );
   return [
     `insert_all wrote a row that the next read did not find.`,

--- a/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
+++ b/packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
@@ -30,6 +30,12 @@ const CASES: [string, string][] = [
  * only. An empty `returning` means the INSERT wrote no row; a non-empty one with
  * the row absent from `topics` means something removed it in between; the row
  * present but unread means the read is at fault.
+ *
+ * The read runs on the test's own pinned connection, not a fresh checkout:
+ * `leaseConnection` routes through `checkout`, which resolves the pool's
+ * pool-scoped fixture pin ahead of everything else (`connection-pool.ts:883`,
+ * `:1542`). `openTransactions` is reported partly as a check on that — a `0`
+ * beside an empty table would mean this read went somewhere else.
  */
 async function missingRowDiagnostics(
   iteration: number,


### PR DESCRIPTION
`leading-colon string writes > create and insert_all store a leading colon verbatim` fails intermittently with a bare `TypeError: Cannot read properties of null (reading 'title')` — the row `insert_all` just wrote is not found by the very next read. Three sightings so far, on two adapters, each passing on a bare re-run:

- `main` @ `691f6a0c0` — Active Record SQLite Tests
- PR #7087 @ `9d848b427` — Active Record MariaDB Tests (1)
- `main` @ `a0a368888` — Active Record SQLite Tests (run 33015202121)

It only ever happens inside a full-suite run, and the current failure message carries no information at all: by the time the `TypeError` is raised the process is gone, so every sighting so far has cost an agent a full investigation cycle that ends in "cannot reproduce".

This PR does not attempt a fix — it makes the next sighting diagnosable.

### Why not a fix

The cheap hypotheses are eliminated, by reading rather than by re-running (all recorded on the story with `file:line` anchors):

- **A stale query-cache read.** trails wires all twelve methods of `query_cache.rb:12-16`, split across `abstract-adapter.ts:2863-2874` (the nine no adapter overrides, including `execInsertAll`, which `insert-all.ts:231` bottoms out in) and the per-adapter `execute` / `rollbackDbTransaction` / `rollbackToSavepoint`. A grep of the adapter files alone finds three of twelve and looks like a gap; it isn't. Independently, the query cache is never enabled in the AR lanes — only `QueryCache.run` (`query-cache.ts:73-82`) enables it, via executor hooks installed only by the trailtie (`trailtie.ts:243`), which the AR suite does not boot.
- **A silently skipped write.** `insert_all` does emit `ON CONFLICT DO NOTHING` (verified against the live SQL), so a uniqueness conflict would no-op the insert without raising — but the only unique constraint on `topics` is the PK (the `(author_name, title)` index is not unique), and the id counters self-adjust: SQLite's `topics` is `AUTOINCREMENT` and `sqlite_sequence` tracks explicit ids (verified: an explicit `id` 500 moves it to 501), which is also why the Postgres-only gate on `reset_pk_sequence!` at `fixtures.ts:710` is correctly premised.
- **Local reproduction.** 200 back-to-back insert/read/delete cycles in one process, the file alone ×5, the whole `relation/` directory (65 files), and a topics-heavy 10-file slice ×2 are all green.

What remains — a connection/visibility split, or a concurrent delete — cannot be told apart without data from the failing process.

### What this adds

`missingRowDiagnostics` runs **only** once the read has already come back empty, and reports rather than repairs. It splits the remaining hypothesis space on the first line of the failure:

- `returning` empty → the INSERT itself wrote no row.
- `returning` non-empty but the row absent from `topics` → something removed it between the two statements.
- row present in `topics` but not returned by the read → the read is at fault (wrong connection, or an uncommitted transaction on another one).

It also reports the iteration, the sent value, and `openTransactions`. Its identifiers are quoted through the adapter (`quoteTableName` / `quoteColumnName`) rather than written with `"` — the flake has been seen on MariaDB, where double-quoted identifiers are a syntax error, so a hand-quoted diagnostic would have thrown instead of reporting on one of the two affected lanes. Sample output, from forcing the empty-read path locally:

```
insert_all wrote a row that the next read did not find.
  iteration:        0 (sent "::Alpha")
  returning:        [[3]]
  openTransactions: 1
  topics rows:      [[1,"seed",null],[2,"::Alpha",null],[3,"::Alpha","colon"]]
```

### Not done

No test is renamed, skipped, reordered or weakened — the assertions are unchanged and the name is load-bearing for `parity:test`. `expect(inserted!.title)` becomes `expect(inserted.title)` only because the explicit null check above it now narrows the type. No new public surface (the helper is module-local), no ported method body touched.

Verification: `parity:api:calls`, `parity:api:calls:args`, `parity:api:extra --package activerecord` and `parity:api:extra:gate` (activerecord 372/372 novel, 1170/1170 total — unchanged) are all clean, and `parity:test` is unmoved (no test added, removed or renamed). The file passes; the diagnostic path itself was exercised by forcing the empty read, so it cannot itself throw and mask the data on CI; `pnpm typecheck` and `eslint` on the touched file are clean.

---

## Review round 1

**1. [scope] Confirming this is an instrumentation-only interim PR.** Yes — intentionally, and the root-cause work is not being dropped. What has happened to the story instead:

- Its `## Context` now carries the eliminations, with `file:line` anchors, so the next agent starts from them rather than re-deriving: the twelve-way `dirties_query_cache` split, the executor-only query-cache enablement, the `ON CONFLICT DO NOTHING` / PK-counter analysis, and the local-repro attempts that came back green (tasks `c19bf60`).
- It is raised to **priority 1** so it gets scheduled rather than sitting at the bottom of the `null` pile (tasks `e00d027`, in the markdown — the `tasks priority` verb wrote only the DB, which the next ingest would have reverted).
- It stays `draft` and unclaimed, so it remains claimable by whoever picks it up.

**On stamping this PR onto the story — deliberately not done, and I'd push back on doing it.** `tasks in-progress <id> --pr 7106` is what makes the daily merge sweep finish a story: it rescues stories that are both `in-progress` and carry a PR number. Since this PR does not meet the acceptance criteria, stamping it would let the sweep mark the flake **done** the moment this merges, silently closing an unfixed flake — the exact outcome the finding is trying to avoid. That is also why the body carries no `Closes-story:` trailer. The story is left open, prioritised, and pre-loaded with the eliminations; the fix claims it separately.

**2. [question] `Topic.leaseConnection()` does return the test's pinned connection.** Confirmed both ways, so the diagnostic cannot produce a spurious "read is at fault":

- By reading: `leaseConnection` (`connection-pool.ts:673-680`) routes through `checkout`, which resolves the pin first (`:883`) via `_resolvePinnedConnection`, and the pool-scoped `_fixturePin` takes priority over everything else (`:1542`) — it is checked ahead of the per-execution-context map precisely so it resolves the same from any context, which is what makes it correct for a helper called mid-test rather than from a `fixtures()` hook.
- Empirically: leasing mid-test returns the **identical object** (`===`) to the connection `insertAll`'s `withConnection` path uses, reports `openTransactions: 1`, and reads back a row created earlier in the same test and still uncommitted — none of which a fresh non-pinned checkout could do.

The helper's JSDoc now cites that pin priority, and notes that `openTransactions` doubles as the check on it: a `0` beside an empty table would itself be the signal that the read went somewhere else.

---

## Review round 2

**1. [scope] The linkage is now on record — in the story's prose, not its DB state.** The finding's substance was that "nothing on record shows this work is tracked against it". Fixed: the story now carries a `## Tracking` section naming trails#7106, what it instruments, and an explicit note that it is diagnostic-only and does not meet the acceptance criteria (tasks `d722b15`). Prose is markdown-owned, so it survives ingest and is visible to anyone who opens the story or runs `tasks show`.

**What I have not done is `tasks in-progress --pr 7106`, and I'd ask for a maintainer call before doing it.** The `/link` skill documents the consequence: the daily merge sweep "only rescues stories that are both `in-progress` and carry a PR number" — that pairing is precisely what lets it finish a story. Applying it to a PR that does not fix the flake means the sweep marks the story **done** when this merges, closing an unfixed flake and deleting the very landing place the finding wants to preserve. It would also leave a stale `in-progress` claim in the way of whoever comes to fix it.

So the state is deliberate: `draft`, unclaimed, priority 1, prose-linked to this PR, and pre-loaded with the eliminations. Every route to the fix stays open and nothing about this work is off the record. If the maintainer would rather have the DB stamp regardless, it is one command and I'll run it — I'm flagging the trade-off rather than quietly deciding it.

**2. [question] Confirmed fixed** — thanks for re-tracing `checkout()` / `_resolvePinnedConnection()` / `leaseConnection()` independently.

**Maintainer call on finding 1:** keep the prose link only. The story stays `draft`, unclaimed, priority 1, with the `## Tracking` section naming this PR as diagnostic-only; no `in-progress`/`pr:` stamp, so the merge sweep cannot complete an unfixed flake. Finding 1 is resolved by that decision rather than by a code change.

---

## The instrumentation fired on its first run — mechanism now proven

CI run 33026062066 failed on **PostgreSQL (1)** and **MariaDB (1)**, both shard 1/2, both at iteration 0. That is this flake, not a regression from this diff: the only pre-failure change here is capturing `insertAll`'s return value, and before this PR the same failure raised a bare `TypeError` on the same line. What changed is that it now reports itself.

PostgreSQL:

```
  iteration:        0 (sent "::Alpha")
  returning:        []
  openTransactions: 1
  topics rows:      [[1,"seed",null],[2,"::Alpha",null]]
```

`returning: []` with the row absent from the table means **the INSERT wrote nothing** — the read was never at fault, and `openTransactions: 1` confirms the diagnostic read the pinned connection. `insert_all` emits `ON CONFLICT DO NOTHING` (Rails-faithful — `insert_all` is `on_duplicate: :skip`), and the only unique index on `topics` is `topics_pkey` on `id`, so the skipped insert is a **primary-key collision: the sequence handed out an id the table already holds**.

Reproduced exactly, locally on PostgreSQL, by forcing the sequence behind (`setval('topics_id_seq', 1, false)`) after the test's two `create`s — byte-for-byte identical to the CI diagnostic, `topics rows` dump included. A healthy run traces `(1,false)` → creates take 1 and 2 → `(2,true)` → `insert_all` takes 3.

MariaDB shows the same skipped write in its own idiom: `returning: [[4]]` while `topics rows` is `[[3,"seed",null],[4,"::Alpha",null]]` — id 4 is the `create` row, i.e. `LAST_INSERT_ID()` echoing the previous insert rather than a new one.

The open question is now a single narrow one — **what leaves the PK sequence behind mid-test** — and the story carries the full write-up plus the first place to look (per-worker DB slot isolation, since a shared slot DB would produce exactly this and would explain why it never reproduces in a single file). See tasks `c62ebaa`.

**This PR is red because the bug it instruments now fires**, and it fires reliably under sharding rather than rarely. That is a merge decision for the maintainer: the diagnostic is doing its job, but the underlying fix is a separate piece of work and the flake is no longer rare enough for this to go green on its own.
