### PR TITLE
refactor(arel): define eql?/hash per node class where Rails does, and drop the trails-only #join

### DIFF
--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -30,7 +30,7 @@ import { JoinDependency } from "../associations/join-dependency.js";
 import type { AliasTracker } from "../associations/alias-tracker.js";
 import { threadedConnectionFor } from "../connection-handling.js";
 import { wrapWithScopeProxy } from "./delegation.js";
-import { any, compactBlank, foreignKey, wrap } from "@blazetrails/activesupport";
+import { any, compactBlank, foreignKey, rbEqual, rbHash, wrap } from "@blazetrails/activesupport";
 
 /**
  * Provides chainable where.not(), where.associated(), where.missing().
@@ -602,13 +602,13 @@ function _selectBang(this: QueryMethodsHost, ...columns: any[]): any {
   const seenStrings = new Set<string>();
   const seenNodeHashes = new Map<number, Nodes.Node[]>();
   const nodeIsDuplicate = (node: Nodes.Node): boolean => {
-    const h = node.hash();
+    const h = rbHash(node);
     const bucket = seenNodeHashes.get(h);
     if (!bucket) return false;
-    return bucket.some((n) => n.eql(node));
+    return bucket.some((n) => rbEqual(n, node));
   };
   const addNodeToSeen = (node: Nodes.Node): void => {
-    const h = node.hash();
+    const h = rbHash(node);
     const bucket = seenNodeHashes.get(h);
     if (bucket) bucket.push(node);
     else seenNodeHashes.set(h, [node]);

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -1,3 +1,4 @@
+import { rbEqual } from "@blazetrails/activesupport";
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
@@ -172,7 +173,7 @@ describe("ActiveRecord::Relation", () => {
       const predicates = [t.get("id").in([1, 2, 3]), t.get("name").eq(bindParam(null))];
       const whereClause = new WhereClause(predicates);
       const expected = new Nodes.And(predicates);
-      expect(whereClause.ast.eql(expected)).toBe(true);
+      expect(rbEqual(whereClause.ast, expected)).toBe(true);
     });
 
     it("ast wraps any SQL literals in parenthesis", () => {
@@ -191,7 +192,7 @@ describe("ActiveRecord::Relation", () => {
       const t = table();
       const whereClause = new WhereClause([t.get("id").in([1, 2, 3])]);
       const whereClauseWithEmpty = new WhereClause([t.get("id").in([1, 2, 3]), ""]);
-      expect(whereClause.ast.eql(whereClauseWithEmpty.ast)).toBe(true);
+      expect(rbEqual(whereClause.ast, whereClauseWithEmpty.ast)).toBe(true);
     });
 
     it("or joins the two clauses using OR", () => {

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -210,7 +210,7 @@ export class WhereClause {
         if (left !== null && exprNodes.some((e) => rbEqual(e, left))) return false;
         return true;
       }
-      if (attrNodes.some((a) => a.eql(attr))) return false;
+      if (attrNodes.some((a) => rbEqual(a, attr))) return false;
       if (colStrings.has(String(attr.name))) return false;
       const qualified = `${String(attr.relation.name)}.${attr.name}`;
       if (colStrings.has(qualified)) return false;
@@ -378,7 +378,7 @@ function extractAttribute(node: Nodes.Node | string): Nodes.Attribute | null {
   let attrNode: Nodes.Attribute | null = null;
   fetchAttribute(node, (attr: Nodes.Node) => {
     if (!(attr instanceof Nodes.Attribute)) return true;
-    if (attrNode !== null && !attrNode.eql(attr)) {
+    if (attrNode !== null && !rbEqual(attrNode, attr)) {
       attrNode = null;
       return false;
     }

--- a/packages/activerecord/src/relation/where-clause.ts
+++ b/packages/activerecord/src/relation/where-clause.ts
@@ -1,3 +1,4 @@
+import { rbEqual } from "@blazetrails/activesupport";
 /**
  * WhereClause — manages WHERE predicates on a Relation.
  *
@@ -139,7 +140,7 @@ export class WhereClause {
       // `String#==` in Ruby; a JS primitive has no method to dispatch, so it is
       // seated in the SqlLiteral whose `eql` is that same `String#==`.
       this.predicates.every((predicate, i) =>
-        (typeof predicate === "string" ? sql(predicate) : predicate).eql(other.predicates[i]),
+        rbEqual(typeof predicate === "string" ? sql(predicate) : predicate, other.predicates[i]),
       )
     );
   }
@@ -206,7 +207,7 @@ export class WhereClause {
         // Mirrors Rails' `non_attrs.include?(node.left)` branch: drop a predicate
         // whose left expression matches one being merged in (last equality wins).
         const left = predicationLeft(node);
-        if (left !== null && exprNodes.some((e) => e.eql(left))) return false;
+        if (left !== null && exprNodes.some((e) => rbEqual(e, left))) return false;
         return true;
       }
       if (attrNodes.some((a) => a.eql(attr))) return false;
@@ -285,7 +286,7 @@ function subtractNodes(
 ): (Nodes.Node | string)[] {
   const result: (Nodes.Node | string)[] = [];
   for (const node of a) {
-    if (!b.some((other) => (typeof node === "string" ? sql(node) : node).eql(other))) {
+    if (!b.some((other) => rbEqual(typeof node === "string" ? sql(node) : node, other))) {
       result.push(node);
     }
   }
@@ -350,7 +351,7 @@ function unionNodes(
   for (const node of b) {
     if (
       !result.some((existing) =>
-        (typeof existing === "string" ? sql(existing) : existing).eql(node),
+        rbEqual(typeof existing === "string" ? sql(existing) : existing, node),
       )
     ) {
       result.push(node);

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -680,6 +680,7 @@ export { currentTimeInstant } from "./time-travel.js";
 
 export { Range } from "./range-ext.js";
 export { rbEqual } from "./rb-equal.js";
+export { rbHash } from "./rb-hash.js";
 export { caseEquals, isInclude } from "./core-ext/range/compare-range.js";
 export { overlap, overlaps } from "./core-ext/range/overlap.js";
 // Note: core-ext/range's conversions and each are intentionally kept as subpath

--- a/packages/activesupport/src/rb-equal.ts
+++ b/packages/activesupport/src/rb-equal.ts
@@ -22,5 +22,30 @@ export function rbEqual(a: unknown, b: unknown): boolean {
   if (typeof (a as { eql?: unknown }).eql === "function") {
     return (a as { eql(other: unknown): boolean }).eql(b);
   }
+  // Ruby's `Array#==` compares elementwise with `==`, and `Date#==` /
+  // `Time#==` compare by value — both are `rb_equal` sends of their own, and a
+  // JS `===` on either is reference equality.
+  if (Array.isArray(a)) {
+    return (
+      Array.isArray(b) && a.length === b.length && a.every((element, i) => rbEqual(element, b[i]))
+    );
+  }
+  // boundary: a JS Date is one of the values a ported `==` is handed, and
+  // Ruby's `Date#==` / `Time#==` compare by value where JS `===` does not.
+  if (a instanceof Date) return b instanceof Date && a.getTime() === b.getTime();
+  // A plain object stands in for a Ruby Hash, whose `==` compares keys and
+  // values rather than identity.
+  if (isPlainObject(a)) {
+    if (!isPlainObject(b)) return false;
+    const keys = Object.keys(a);
+    return (
+      keys.length === Object.keys(b).length &&
+      keys.every((key) => key in b && rbEqual(a[key], b[key]))
+    );
+  }
   return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && value.constructor === Object;
 }

--- a/packages/activesupport/src/rb-hash.ts
+++ b/packages/activesupport/src/rb-hash.ts
@@ -1,0 +1,82 @@
+/**
+ * Ruby's `Object#hash` — the value every `eql?`-pairing `hash` body composes
+ * with. Ported node bodies spell `[self.class, @left, @right].hash`, and JS has
+ * no `hash` on Object, Array, String or Class at all, so one copy serves every
+ * ported `hash`.
+ *
+ * Like Ruby, it is consistent with `rbEqual`: two objects that are `==` hash
+ * alike, and an object whose class defines no `hash` falls back to identity.
+ *
+ * @noRailsEquivalent PERMANENT — `Object#hash` / `Array#hash` are C primitives
+ *   (object.c, array.c), not Ruby methods, so they have no counterpart file.
+ */
+export function rbHash(value: unknown): number {
+  if (value === null || value === undefined) return 0x9e3779b9;
+  switch (typeof value) {
+    case "string":
+      return stringHash(value);
+    case "number":
+    case "bigint":
+      return stringHash(String(value));
+    case "boolean":
+      return value ? 0x5bf03635 : 0x27d4eb2f;
+    case "symbol":
+      return stringHash(String(value));
+    case "function":
+      // A class object — Ruby's `self.class.hash`.
+      return stringHash(`class:${value.name}`);
+  }
+  if (Array.isArray(value)) {
+    let h = 0x811c9dc5;
+    for (const element of value) {
+      h ^= rbHash(element);
+      h = Math.imul(h, 0x01000193);
+    }
+    return h >>> 0;
+  }
+  const object = value as { hash?: unknown };
+  if (typeof object.hash === "function") {
+    return (object as { hash(): number }).hash();
+  }
+  // A value object whose Ruby `==` is `equals` (Temporal, Duration) has to hash
+  // by that same value, or two `==` objects land in different buckets.
+  if (typeof (value as { equals?: unknown }).equals === "function") {
+    return stringHash(`${(value as object).constructor.name}(${String(value)})`);
+  }
+  // boundary: a JS Date reaches a ported `hash` the same way it reaches
+  // `rbEqual`, and Ruby hashes it by value.
+  if (value instanceof Date) return stringHash(`Date(${value.toISOString()})`);
+  // A plain object stands in for a Ruby Hash, whose `hash` folds every key and
+  // value; the sort keeps it insertion-order independent, as Ruby's is.
+  if ((value as object).constructor === Object) {
+    const plain = value as Record<string, unknown>;
+    let h = 0x811c9dc5;
+    for (const key of Object.keys(plain).sort()) {
+      h ^= stringHash(key) ^ rbHash(plain[key]);
+      h = Math.imul(h, 0x01000193);
+    }
+    return h >>> 0;
+  }
+  return identityHash(value as object);
+}
+
+function stringHash(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+const identityHashes = new WeakMap<object, number>();
+let nextIdentityHash = 1;
+
+function identityHash(object: object): number {
+  let h = identityHashes.get(object);
+  if (h === undefined) {
+    h = Math.imul(nextIdentityHash++, 0x01000193) >>> 0;
+    identityHashes.set(object, h);
+  }
+  return h;
+}

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -1,4 +1,4 @@
-import { include, type Included } from "@blazetrails/activesupport";
+import { include, rbEqual, rbHash, type Included } from "@blazetrails/activesupport";
 import { _setAttribute } from "../node-slots.js";
 import { Node } from "../nodes/node.js";
 import { As } from "../nodes/binary.js";
@@ -77,6 +77,28 @@ export class Attribute extends Node {
 
   isAbleToTypeCast(): boolean {
     return this.relation.isAbleToTypeCast();
+  }
+
+  /**
+   * `Arel::Attributes::Attribute < Struct.new :relation, :name`
+   * (attribute.rb:5), so `==` / `eql?` / `hash` are `Struct`'s, over the two
+   * members in order.
+   *
+   * @noRailsEquivalent PERMANENT: inherited from `Struct`, so no
+   * `attribute.rb` method declares either; TypeScript has no `Struct` to
+   * subclass, so the inherited pair has to be written out.
+   */
+  hash(): number {
+    return rbHash([this.constructor, this.relation, this.name]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Attribute &&
+      this.constructor === other.constructor &&
+      rbEqual(this.relation, other.relation) &&
+      rbEqual(this.name, other.name)
+    );
   }
 
   /**

--- a/packages/arel/src/nodes.test.ts
+++ b/packages/arel/src/nodes.test.ts
@@ -34,7 +34,10 @@ describe("TestNodes", () => {
     const badNodeDescendants = nodeDescendants.filter((subnode) => {
       const eqlOwner = owner(subnode, "eql");
       const hashOwner = owner(subnode, "hash");
-      return eqlOwner !== hashOwner;
+      // Ruby's `eqeq_method.super_method` arm — a node still on the default
+      // `Object#==` is bad. In JS the default lives on no prototype at all, so
+      // "not using it" reads as: some class in the chain owns the pair.
+      return eqlOwner === null || eqlOwner !== hashOwner;
     });
 
     const problemMsg =

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -1,6 +1,6 @@
 import type { Attribute as ModelAttribute } from "@blazetrails/activemodel";
 import type { Temporal } from "@blazetrails/date";
-import { include } from "@blazetrails/activesupport";
+import { include, rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { _Attribute, _Equality, _In } from "../node-slots.js";
 import { Node } from "./node.js";
@@ -113,6 +113,20 @@ export class Binary extends NodeExpression {
     super();
     this.left = left;
     this.right = right;
+  }
+
+  // Mirrors Arel::Nodes::Binary#hash / #eql? / #== (binary.rb:19-29).
+  hash(): number {
+    return rbHash([this.constructor, this.left, this.right]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Binary &&
+      this.constructor === other.constructor &&
+      rbEqual(this.left, other.left) &&
+      rbEqual(this.right, other.right)
+    );
   }
 
   // Mirrors Arel::Nodes::Binary#initialize_copy (binary.rb:14-18), which Ruby

--- a/packages/arel/src/nodes/bind-param.ts
+++ b/packages/arel/src/nodes/bind-param.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 
 /**
@@ -20,6 +21,16 @@ export class BindParam extends Node {
   constructor(value?: unknown) {
     super();
     this.value = value;
+  }
+
+  // Mirrors Arel::Nodes::BindParam#hash / #eql? / #== (bind_param.rb:12-21) —
+  // the `eql?` arm is `is_a?`, not a class comparison, so a subclass matches.
+  hash(): number {
+    return rbHash([this.constructor, this.value]);
+  }
+
+  eql(other: unknown): boolean {
+    return other instanceof BindParam && rbEqual(this.value, other.value);
   }
 
   /**

--- a/packages/arel/src/nodes/bound-sql-literal.ts
+++ b/packages/arel/src/nodes/bound-sql-literal.ts
@@ -1,4 +1,4 @@
-import { ArgumentError } from "@blazetrails/activesupport";
+import { ArgumentError, rbEqual, rbHash } from "@blazetrails/activesupport";
 import { arelNode } from "../arel.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
@@ -71,6 +71,26 @@ export class BoundSqlLiteral extends NodeExpression {
       this.positionalBinds = null;
       this.namedBinds = namedBinds;
     }
+  }
+
+  // Mirrors Arel::Nodes::BoundSqlLiteral#hash / #eql? / #== (bound_sql_literal.rb:41-52).
+  hash(): number {
+    return rbHash([
+      this.constructor,
+      this.sqlWithPlaceholders,
+      this.positionalBinds,
+      this.namedBinds,
+    ]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof BoundSqlLiteral &&
+      this.constructor === other.constructor &&
+      rbEqual(this.sqlWithPlaceholders, other.sqlWithPlaceholders) &&
+      rbEqual(this.positionalBinds, other.positionalBinds) &&
+      rbEqual(this.namedBinds, other.namedBinds)
+    );
   }
 
   // Mirrors Arel::Nodes::BoundSqlLiteral#+ — concatenates with another

--- a/packages/arel/src/nodes/case.ts
+++ b/packages/arel/src/nodes/case.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
@@ -42,6 +43,21 @@ export class Case extends NodeExpression {
     this.default = new Else(buildQuoted(result === undefined ? null : result));
     return this;
   }
+  // Mirrors Arel::Nodes::Case#hash / #eql? / #== (case.rb:35-46).
+  hash(): number {
+    return rbHash([this.case, this.conditions, this.default]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Case &&
+      this.constructor === other.constructor &&
+      rbEqual(this.case, other.case) &&
+      rbEqual(this.conditions, other.conditions) &&
+      rbEqual(this.default, other.default)
+    );
+  }
+
   // Mirrors Arel::Nodes::Case#then — sets the right side of the most
   // recent When clause. Rails: `@conditions.last.right = build_quoted(expression)`.
   // Rails raises NoMethodError on `nil.right=` if no #when has been called;

--- a/packages/arel/src/nodes/casted.ts
+++ b/packages/arel/src/nodes/casted.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
 import { _Attribute, _Table, _setBuildQuoted } from "../node-slots.js";
@@ -77,6 +78,20 @@ export class Casted extends NodeExpression {
       return this.attribute.typeCastForDatabase(this.value);
     }
     return this.value;
+  }
+
+  // Mirrors Arel::Nodes::Casted#hash / #eql? / #== (casted.rb:24-34).
+  hash(): number {
+    return rbHash([this.constructor, this.value, this.attribute]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Casted &&
+      this.constructor === other.constructor &&
+      rbEqual(this.value, other.value) &&
+      rbEqual(this.attribute, other.attribute)
+    );
   }
 }
 

--- a/packages/arel/src/nodes/comment.ts
+++ b/packages/arel/src/nodes/comment.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 
 /**
@@ -11,5 +12,18 @@ export class Comment extends Node {
   constructor(values: string[]) {
     super();
     this.values = values;
+  }
+
+  // Mirrors Arel::Nodes::Comment#hash / #eql? / #== (comment.rb:17-26).
+  hash(): number {
+    return rbHash([this.values]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Comment &&
+      this.constructor === other.constructor &&
+      rbEqual(this.values, other.values)
+    );
   }
 }

--- a/packages/arel/src/nodes/cte.ts
+++ b/packages/arel/src/nodes/cte.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 import { Binary } from "./binary.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -48,6 +49,21 @@ export class Cte extends Binary {
   ) {
     super(name, relation);
     this.materialized = materialized;
+  }
+
+  // Mirrors Arel::Nodes::Cte#hash / #eql? / #== (cte.rb:14-25).
+  override hash(): number {
+    return rbHash([this.name, this.relation, this.materialized]);
+  }
+
+  override eql(other: unknown): boolean {
+    return (
+      other instanceof Cte &&
+      this.constructor === other.constructor &&
+      rbEqual(this.name, other.name) &&
+      rbEqual(this.relation, other.relation) &&
+      rbEqual(this.materialized, other.materialized)
+    );
   }
 
   toCte(): Cte {

--- a/packages/arel/src/nodes/delete-statement.ts
+++ b/packages/arel/src/nodes/delete-statement.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 
@@ -26,6 +27,34 @@ export class DeleteStatement extends Node {
     this.limit = null;
     this.offset = null;
     this.key = null;
+  }
+
+  // Mirrors Arel::Nodes::DeleteStatement#hash / #eql? / #== (delete_statement.rb:25-41).
+  hash(): number {
+    return rbHash([
+      this.constructor,
+      this.relation,
+      this.wheres,
+      this.orders,
+      this.limit,
+      this.offset,
+      this.key,
+    ]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof DeleteStatement &&
+      this.constructor === other.constructor &&
+      rbEqual(this.relation, other.relation) &&
+      rbEqual(this.wheres, other.wheres) &&
+      rbEqual(this.orders, other.orders) &&
+      rbEqual(this.groups, other.groups) &&
+      rbEqual(this.havings, other.havings) &&
+      rbEqual(this.limit, other.limit) &&
+      rbEqual(this.offset, other.offset) &&
+      rbEqual(this.key, other.key)
+    );
   }
 
   // Mirrors Arel::Nodes::DeleteStatement#initialize_copy

--- a/packages/arel/src/nodes/extract.ts
+++ b/packages/arel/src/nodes/extract.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 import { Unary } from "./unary.js";
 import { As } from "./binary.js";
@@ -14,6 +15,15 @@ export class Extract extends Unary {
   constructor(expr: Node | Node[], field: string) {
     super(expr);
     this.field = field;
+  }
+
+  // Mirrors Arel::Nodes::Extract#hash / #eql? / #== (extract.rb:12-21).
+  override hash(): number {
+    return (super.hash() ^ rbHash(this.field)) >>> 0;
+  }
+
+  override eql(other: unknown): boolean {
+    return super.eql(other) && rbEqual(this.field, (other as Extract).field);
   }
 
   as(aliasName: string): As {

--- a/packages/arel/src/nodes/false.ts
+++ b/packages/arel/src/nodes/false.ts
@@ -1,3 +1,13 @@
+import { rbHash } from "@blazetrails/activesupport";
 import { NodeExpression } from "./node-expression.js";
 
-export class False extends NodeExpression {}
+export class False extends NodeExpression {
+  // Mirrors Arel::Nodes::False#hash / #eql? / #== (false.rb:5-13).
+  hash(): number {
+    return rbHash(this.constructor);
+  }
+
+  eql(other: unknown): boolean {
+    return other instanceof False && this.constructor === other.constructor;
+  }
+}

--- a/packages/arel/src/nodes/fragments.ts
+++ b/packages/arel/src/nodes/fragments.ts
@@ -1,4 +1,4 @@
-import { ArgumentError } from "@blazetrails/activesupport";
+import { ArgumentError, rbEqual, rbHash } from "@blazetrails/activesupport";
 import { arelNode } from "../arel.js";
 import { objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
@@ -16,31 +16,17 @@ export class Fragments extends Node {
     this.values = values;
   }
 
-  // Mirrors Arel::Nodes::Fragments#hash (fragments.rb:17-19) — `[@values].hash`,
-  // so `values` alone keys it, not every field the way Node#hash does.
-  override hash(): number {
-    let h = 0x811c9dc5;
-    for (const value of this.values) {
-      const valueHash =
-        value instanceof Node
-          ? value.hash()
-          : typeof value === "string"
-            ? stringHash(value)
-            : stringHash(String(value));
-      h ^= valueHash;
-      h = Math.imul(h, 0x01000193);
-    }
-    return h >>> 0;
+  // Mirrors Arel::Nodes::Fragments#hash (fragments.rb:17-19) — `[@values].hash`.
+  hash(): number {
+    return rbHash([this.values]);
   }
 
-  // Mirrors Arel::Nodes::Fragments#eql? / #== (fragments.rb:28-32) — the class
-  // and `values` alone, not Node#eql's serialization of every field.
-  override eql(other: unknown): boolean {
+  // Mirrors Arel::Nodes::Fragments#eql? / #== (fragments.rb:28-32).
+  eql(other: unknown): boolean {
     return (
       other instanceof Fragments &&
       this.constructor === other.constructor &&
-      this.values.length === other.values.length &&
-      this.values.every((value, i) => valueEql(value, other.values[i]))
+      rbEqual(this.values, other.values)
     );
   }
 
@@ -53,10 +39,6 @@ export class Fragments extends Node {
     return copy;
   }
 
-  join(node: Node): Fragments {
-    return new Fragments([...this.values, node]);
-  }
-
   // Mirrors Arel::Nodes::Fragments#+ (fragments.rb:22-26). Method-renamed to
   // `plus` because TS classes can't define an arithmetic operator, and the
   // param is `unknown` so the Rails guard stays reachable from typed callers
@@ -67,20 +49,4 @@ export class Fragments extends Node {
     }
     return new Fragments([...this.values, other as Node]);
   }
-}
-
-// Ruby `Array#==` compares elements with `==`, which on an arel node is its
-// own `eql?` (node.rb aliases the two).
-function valueEql(left: unknown, right: unknown): boolean {
-  if (left instanceof Node) return left.eql(right);
-  return left === right;
-}
-
-function stringHash(input: string): number {
-  let h = 0x811c9dc5;
-  for (let i = 0; i < input.length; i++) {
-    h ^= input.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  return h >>> 0;
 }

--- a/packages/arel/src/nodes/function.ts
+++ b/packages/arel/src/nodes/function.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 import type { NodeOrValue } from "./binary.js";
 import { NodeExpression } from "./node-expression.js";
@@ -35,6 +36,21 @@ export class Function extends NodeExpression {
   as(aliaz: string): this {
     this.alias = aliaz;
     return this;
+  }
+
+  // Mirrors Arel::Nodes::Function#hash / #eql? / #== (function.rb:21-32).
+  hash(): number {
+    return rbHash([this.expressions, this.alias, this.distinct]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Function &&
+      this.constructor === other.constructor &&
+      rbEqual(this.expressions, other.expressions) &&
+      rbEqual(this.alias, other.alias) &&
+      rbEqual(this.distinct, other.distinct)
+    );
   }
 }
 

--- a/packages/arel/src/nodes/homogeneous-in.ts
+++ b/packages/arel/src/nodes/homogeneous-in.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 import { buildQuoted } from "./casted.js";
 import { Attribute as AMAttribute, defaultValue } from "@blazetrails/activemodel";
@@ -12,6 +13,21 @@ export class HomogeneousIn extends Node {
     this.values = values;
     this.attribute = attribute;
     this.type = type;
+  }
+
+  // Mirrors Arel::Nodes::HomogeneousIn#hash / #eql? / #== (homogeneous_in.rb:13-21).
+  // `super` there is `Object#eql?` — identity — since Node defines none.
+  hash(): number {
+    return rbHash(this.ivars());
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      this === other ||
+      (other instanceof HomogeneousIn &&
+        this.constructor === other.constructor &&
+        rbEqual(this.ivars(), other.ivars()))
+    );
   }
 
   isEquality(): boolean {
@@ -89,9 +105,7 @@ export class HomogeneousIn extends Node {
 
   // Mirrors Arel::Nodes::HomogeneousIn#ivars — protected helper Rails
   // uses to fold this node's identity into hash/eql? comparisons.
-  // Trails' `eql()` / `hash()` from Node already walk every own
-  // property so this isn't called internally; kept for Rails-fidelity
-  // / parity:api privates coverage.
+  // `hash` / `eql?` above both fold through it, as Rails does.
   protected ivars(): [Node, unknown[], HomogeneousIn["type"]] {
     return [this.attribute, this.values, this.type];
   }

--- a/packages/arel/src/nodes/insert-statement.ts
+++ b/packages/arel/src/nodes/insert-statement.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 
@@ -25,6 +26,22 @@ export class InsertStatement extends Node {
     this.columns = [];
     this.values = null;
     this.select = null;
+  }
+
+  // Mirrors Arel::Nodes::InsertStatement#hash / #eql? / #== (insert_statement.rb:22-34).
+  hash(): number {
+    return rbHash([this.relation, this.columns, this.values, this.select]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof InsertStatement &&
+      this.constructor === other.constructor &&
+      rbEqual(this.relation, other.relation) &&
+      rbEqual(this.columns, other.columns) &&
+      rbEqual(this.select, other.select) &&
+      rbEqual(this.values, other.values)
+    );
   }
 
   // Mirrors Arel::Nodes::InsertStatement#initialize_copy

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import type { NodeOrValue } from "./binary.js";
 import { Function } from "./function.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -16,6 +17,15 @@ export class NamedFunction extends Function {
     super(expressions, aliasName ?? null);
     this.name = name;
     this.distinct = distinct;
+  }
+
+  // Mirrors Arel::Nodes::NamedFunction#hash / #eql? / #== (named_function.rb:12-20).
+  override hash(): number {
+    return (super.hash() ^ rbHash(this.name)) >>> 0;
+  }
+
+  override eql(other: unknown): boolean {
+    return super.eql(other) && rbEqual(this.name, (other as NamedFunction).name);
   }
 
   /**

--- a/packages/arel/src/nodes/nary.ts
+++ b/packages/arel/src/nodes/nary.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { _setAnd, _setOr } from "../node-slots.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
@@ -28,6 +29,19 @@ export class Nary extends NodeExpression {
       }
       return false;
     });
+  }
+
+  // Mirrors Arel::Nodes::Nary#hash / #eql? / #== (nary.rb:24-33).
+  hash(): number {
+    return rbHash([this.constructor, this.children]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Nary &&
+      this.constructor === other.constructor &&
+      rbEqual(this.children, other.children)
+    );
   }
 }
 

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -71,31 +71,6 @@ export class Node {
   isEquality(): boolean {
     return false;
   }
-
-  /**
-   * Ruby-ish equality helper.
-   *
-   * Mirrors: `eql?` / `==` semantics used throughout the Arel test suite.
-   */
-  eql(other: unknown): boolean {
-    if (other === this) return true;
-    if (!other || typeof other !== "object") return false;
-    if (
-      (other as { constructor: unknown }).constructor !==
-      (this as { constructor: unknown }).constructor
-    )
-      return false;
-    return stableSerialize(this) === stableSerialize(other);
-  }
-
-  /**
-   * Stable hash for use in tests / maps.
-   *
-   * Mirrors: `hash` in Ruby Arel nodes.
-   */
-  hash(): number {
-    return fnv1a32(stableSerialize(this));
-  }
 }
 
 function assertRegistered<T>(ctor: T | undefined, name: string): T {
@@ -105,55 +80,6 @@ function assertRegistered<T>(ctor: T | undefined, name: string): T {
     );
   }
   return ctor;
-}
-
-function fnv1a32(input: string): number {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < input.length; i++) {
-    hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return hash >>> 0;
-}
-
-function stableSerialize(value: unknown, seen: WeakSet<object> = new WeakSet()): string {
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
-  const t = typeof value;
-  if (t === "string") return JSON.stringify(value);
-  if (t === "number" || t === "boolean" || t === "bigint") return String(value);
-  if (t === "symbol") return "symbol";
-  if (t === "function") return "function";
-
-  // boundary: Arel inspect output recognizes legacy Date values.
-  if (value instanceof Date) return `Date(${value.toISOString()})`;
-
-  if (typeof value === "object") {
-    if (seen.has(value)) return "[Circular]";
-    seen.add(value);
-
-    if (Array.isArray(value)) {
-      try {
-        return `[${value.map((v) => stableSerialize(v, seen)).join(",")}]`;
-      } finally {
-        seen.delete(value);
-      }
-    }
-
-    const obj = value as Record<string, unknown>;
-    const ctorName = (value as { constructor?: { name?: string } }).constructor?.name ?? "Object";
-    const keys = Object.keys(obj).sort();
-    try {
-      const body = keys
-        .map((k) => `${JSON.stringify(k)}:${stableSerialize(obj[k], seen)}`)
-        .join(",");
-      return `${ctorName}{${body}}`;
-    } finally {
-      seen.delete(value);
-    }
-  }
-
-  return String(value);
 }
 
 /**

--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 import { JoinSource } from "./join-source.js";
@@ -51,6 +52,37 @@ export class SelectCore extends Node {
   /** Mirrors: `alias :froms= :from=` (select_core.rb:32). */
   set froms(value: Node | null) {
     this.from = value;
+  }
+
+  // Mirrors Arel::Nodes::SelectCore#hash / #eql? / #== (select_core.rb:44-64).
+  hash(): number {
+    return rbHash([
+      this.source,
+      this.setQuantifier,
+      this.projections,
+      this.optimizerHints,
+      this.wheres,
+      this.groups,
+      this.havings,
+      this.windows,
+      this.comment,
+    ]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof SelectCore &&
+      this.constructor === other.constructor &&
+      rbEqual(this.source, other.source) &&
+      rbEqual(this.setQuantifier, other.setQuantifier) &&
+      rbEqual(this.optimizerHints, other.optimizerHints) &&
+      rbEqual(this.projections, other.projections) &&
+      rbEqual(this.wheres, other.wheres) &&
+      rbEqual(this.groups, other.groups) &&
+      rbEqual(this.havings, other.havings) &&
+      rbEqual(this.windows, other.windows) &&
+      rbEqual(this.comment, other.comment)
+    );
   }
 
   // Mirrors Arel::Nodes::SelectCore#initialize_copy (select_core.rb:35-43),

--- a/packages/arel/src/nodes/select-statement.ts
+++ b/packages/arel/src/nodes/select-statement.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
@@ -28,6 +29,24 @@ export class SelectStatement extends NodeExpression {
     this.offset = null;
     this.lock = null;
     this.with = null;
+  }
+
+  // Mirrors Arel::Nodes::SelectStatement#hash / #eql? / #== (select_statement.rb:24-38).
+  hash(): number {
+    return rbHash([this.cores, this.orders, this.limit, this.lock, this.offset, this.with]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof SelectStatement &&
+      this.constructor === other.constructor &&
+      rbEqual(this.cores, other.cores) &&
+      rbEqual(this.orders, other.orders) &&
+      rbEqual(this.limit, other.limit) &&
+      rbEqual(this.lock, other.lock) &&
+      rbEqual(this.offset, other.offset) &&
+      rbEqual(this.with, other.with)
+    );
   }
 
   // Mirrors Arel::Nodes::SelectStatement#initialize_copy

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -1,4 +1,4 @@
-import { ArgumentError, isBlank, type Included } from "@blazetrails/activesupport";
+import { ArgumentError, isBlank, rbHash, type Included } from "@blazetrails/activesupport";
 import { arelNode } from "../arel.js";
 import { Node } from "./node.js";
 import { Fragments } from "./fragments.js";
@@ -44,9 +44,21 @@ export class SqlLiteral extends Node {
    * method declares them, and TypeScript cannot subclass the string primitive.
    * No amount of porting removes this name.
    */
-  override eql(other: unknown): boolean {
+  eql(other: unknown): boolean {
     if (typeof other === "string") return this.value === other;
     return other instanceof SqlLiteral && this.value === other.value;
+  }
+
+  /**
+   * The `hash` half of the pair above, and inherited from String for the same
+   * reason: `String#hash` is over the text alone.
+   *
+   * @noRailsEquivalent PERMANENT: `SqlLiteral < String` (sql_literal.rb:5), so
+   * `hash` arrives by inheritance and no `sql_literal.rb` method declares it;
+   * TypeScript cannot subclass the string primitive.
+   */
+  hash(): number {
+    return rbHash(this.value);
   }
 
   /** Mirrors: `encode_with(coder)` (sql_literal.rb:18-20). */
@@ -81,10 +93,6 @@ export class SqlLiteral extends Node {
   /** @internal */
   quotedNode(other: unknown): Node {
     return other instanceof Node ? other : buildQuoted(other, this);
-  }
-
-  join(other: Node): Fragments {
-    return new Fragments([this, other]);
   }
 
   // Mirrors Arel::Nodes::SqlLiteral#+ (sql_literal.rb:25-29), including the

--- a/packages/arel/src/nodes/terminal.ts
+++ b/packages/arel/src/nodes/terminal.ts
@@ -1,3 +1,13 @@
+import { rbHash } from "@blazetrails/activesupport";
 import { NodeExpression } from "./node-expression.js";
 
-export class Distinct extends NodeExpression {}
+export class Distinct extends NodeExpression {
+  // Mirrors Arel::Nodes::Distinct#hash / #eql? / #== (terminal.rb:5-13).
+  hash(): number {
+    return rbHash(this.constructor);
+  }
+
+  eql(other: unknown): boolean {
+    return other instanceof Distinct && this.constructor === other.constructor;
+  }
+}

--- a/packages/arel/src/nodes/true.ts
+++ b/packages/arel/src/nodes/true.ts
@@ -1,3 +1,13 @@
+import { rbHash } from "@blazetrails/activesupport";
 import { NodeExpression } from "./node-expression.js";
 
-export class True extends NodeExpression {}
+export class True extends NodeExpression {
+  // Mirrors Arel::Nodes::True#hash / #eql? / #== (true.rb:5-13).
+  hash(): number {
+    return rbHash(this.constructor);
+  }
+
+  eql(other: unknown): boolean {
+    return other instanceof True && this.constructor === other.constructor;
+  }
+}

--- a/packages/arel/src/nodes/unary.ts
+++ b/packages/arel/src/nodes/unary.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { _setNot } from "../node-slots.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
@@ -13,6 +14,19 @@ export class Unary extends NodeExpression {
   constructor(expr: unknown) {
     super();
     this.expr = expr;
+  }
+
+  // Mirrors Arel::Nodes::Unary#hash / #eql? / #== (unary.rb:13-22).
+  hash(): number {
+    return rbHash(this.expr);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Unary &&
+      this.constructor === other.constructor &&
+      rbEqual(this.expr, other.expr)
+    );
   }
 }
 

--- a/packages/arel/src/nodes/update-statement.ts
+++ b/packages/arel/src/nodes/update-statement.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 
@@ -28,6 +29,35 @@ export class UpdateStatement extends Node {
     this.limit = null;
     this.offset = null;
     this.key = null;
+  }
+
+  // Mirrors Arel::Nodes::UpdateStatement#hash / #eql? / #== (update_statement.rb:26-43).
+  hash(): number {
+    return rbHash([
+      this.relation,
+      this.wheres,
+      this.values,
+      this.orders,
+      this.limit,
+      this.offset,
+      this.key,
+    ]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof UpdateStatement &&
+      this.constructor === other.constructor &&
+      rbEqual(this.relation, other.relation) &&
+      rbEqual(this.wheres, other.wheres) &&
+      rbEqual(this.values, other.values) &&
+      rbEqual(this.groups, other.groups) &&
+      rbEqual(this.havings, other.havings) &&
+      rbEqual(this.orders, other.orders) &&
+      rbEqual(this.limit, other.limit) &&
+      rbEqual(this.offset, other.offset) &&
+      rbEqual(this.key, other.key)
+    );
   }
 
   // Mirrors Arel::Nodes::UpdateStatement#initialize_copy

--- a/packages/arel/src/nodes/window.ts
+++ b/packages/arel/src/nodes/window.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 import { Unary } from "./unary.js";
 import { SqlLiteral } from "./sql-literal.js";
@@ -53,6 +54,21 @@ export class Window extends Node {
       return this.frame(new Range(expr));
     }
   }
+
+  // Mirrors Arel::Nodes::Window#hash / #eql? / #== (window.rb:54-65).
+  hash(): number {
+    return rbHash([this.orders, this.framing]);
+  }
+
+  eql(other: unknown): boolean {
+    return (
+      other instanceof Window &&
+      this.constructor === other.constructor &&
+      rbEqual(this.orders, other.orders) &&
+      rbEqual(this.framing, other.framing) &&
+      rbEqual(this.partitions, other.partitions)
+    );
+  }
 }
 
 /**
@@ -64,6 +80,15 @@ export class NamedWindow extends Window {
   constructor(name: string) {
     super();
     this.name = name;
+  }
+
+  // Mirrors Arel::Nodes::NamedWindow#hash / #eql? / #== (window.rb:80-88).
+  override hash(): number {
+    return (super.hash() ^ rbHash(this.name)) >>> 0;
+  }
+
+  override eql(other: unknown): boolean {
+    return super.eql(other) && rbEqual(this.name, (other as NamedWindow).name);
   }
 }
 
@@ -90,7 +115,16 @@ export class Following extends Unary {
   }
 }
 
-export class CurrentRow extends Node {}
+export class CurrentRow extends Node {
+  // Mirrors Arel::Nodes::CurrentRow#hash / #eql? / #== (window.rb:103-111).
+  hash(): number {
+    return rbHash(this.constructor);
+  }
+
+  eql(other: unknown): boolean {
+    return other instanceof CurrentRow && this.constructor === other.constructor;
+  }
+}
 
 export class Rows extends Unary {
   declare expr: Node | null;

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -1,3 +1,4 @@
+import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Attribute } from "./attributes/attribute.js";
 import { EmptyJoinError } from "./errors.js";
 import { _engine, ArelEngine, Node } from "./nodes/node.js";
@@ -192,32 +193,20 @@ export class Table extends Node {
     return new Attribute(table ?? this, resolved);
   }
 
-  /**
-   * Mirrors: Arel::Table#hash — only name (Rails excludes aliases to avoid loops).
-   */
-  override hash(): number {
-    // Rails hashes `@name` whatever it is (table.rb:88-93); a node name hashes
-    // by its own `hash`.
-    if (typeof this.name !== "string") return this.name.hash();
-    let h = 0x811c9dc5;
-    for (let i = 0; i < this.name.length; i++) {
-      h ^= this.name.charCodeAt(i);
-      h = Math.imul(h, 0x01000193);
-    }
-    return h >>> 0;
+  // Mirrors Arel::Table#hash / #eql? / #== (table.rb:88-100). The perf note
+  // there is why `aliases` and `table_alias` stay out of the hash: an alias can
+  // loop back to this table.
+  hash(): number {
+    return rbHash(this.name);
   }
 
-  /**
-   * Mirrors: Arel::Table#eql? — compares name and tableAlias (not klass).
-   * Rails excludes aliases array and engine from the hash to avoid loops.
-   */
   eql(other: unknown): boolean {
-    if (!(other instanceof Table)) return false;
-    // Ruby's `self.name == other.name` is value equality, so a SqlLiteral or
-    // node name compares by content, not identity.
-    const sameName =
-      this.name instanceof Node ? this.name.eql(other.name) : this.name === other.name;
-    return sameName && this.tableAlias === other.tableAlias;
+    return (
+      other instanceof Table &&
+      this.constructor === other.constructor &&
+      rbEqual(this.name, other.name) &&
+      rbEqual(this.tableAlias, other.tableAlias)
+    );
   }
 
   typeCastForDatabase(attrName: string | Node | null, value: unknown): unknown {

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -308,7 +308,7 @@ describe("the to_sql visitor", () => {
   describe("Nodes::Fragments", () => {
     it("can be built by adding SQL fragments one at a time", () => {
       let fragments = sql("SELECT foo, bar").plus(sql("FROM customers"));
-      fragments = fragments.join(sql("GROUP BY foo"));
+      fragments = fragments.plus(sql("GROUP BY foo"));
       expect(mustBeLike(compile(fragments))).toBe(
         mustBeLike("SELECT foo, bar FROM customers GROUP BY foo"),
       );

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -5,6 +5,6 @@
   },
   "arel": {
     "novel": 0,
-    "total": 62
+    "total": 59
   }
 }


### PR DESCRIPTION
Two RFC 0124 arel deviation-convergence stories.

## `Node#eql` / `Node#hash` → per-class, where Rails defines them

Rails defines no `eql?`/`hash` on `Arel::Nodes::Node`
(`activerecord/lib/arel/nodes/node.rb`). Each node class defines its own over
its OWN fields and aliases `==` to it. trails had one generic method on the
base that compared a whole-object structural digest (`stableSerialize`) — too
wide (it compared fields Rails omits) and too narrow (a field whose value
equality is not structural compared by its serialization rather than by its
own `==`).

Deleted the base pair and the serializer, and defined the pair on each of the
26 classes that has one upstream — `Binary` (binary.rb:19-29), `Unary`
(unary.rb:13-22), `Casted` (casted.rb:24-34), `Nary`, `Extract`, `False`,
`True`, `Distinct`, `Comment`, `BindParam`, `Cte`, `NamedFunction`,
`Function`, `HomogeneousIn`, `Case`, `Window`, `NamedWindow`, `CurrentRow`,
`SelectCore`, `SelectStatement`, `Insert`/`Update`/`DeleteStatement`,
`BoundSqlLiteral`, `Fragments`, `Table` (table.rb:88-100) — each over the same
fields in the same order, each comparing with `rbEqual` so a nested node
compares by ITS class's `eql?` and a `Date`/`Attribute` field by its own `==`,
as Ruby's recursion does.

`Attribute` and `SqlLiteral` carry `@noRailsEquivalent PERMANENT` receipts:
both inherit the pair upstream (from `Struct` and `String` respectively), and
TypeScript can subclass neither.

`nodes.test.ts`'s `every_arel_nodes_have_hash_eql_eqeq_from_same_class` was
vacuous while everything inherited the base pair; it now gains Ruby's
`eqeq_method.super_method` arm (`test/cases/arel/nodes_test.rb:19-25`) and is a
real check.

Two supporting primitives in activesupport, alongside the existing `rbEqual`:
`rbHash` (Ruby `Object#hash` / `Array#hash`, both C primitives with no
counterpart file), and `Array` / `Date` / Hash arms on `rbEqual` — Ruby's
`Array#==` and `Hash#==` are value comparisons where JS `===` is reference
equality. AR's `where-clause.ts`, `query-methods.ts` and their tests, which
spelled Ruby `==` as `.eql()` on a `Node`-typed value, now go through
`rbEqual` / `rbHash`.

## `SqlLiteral#join` / `Fragments#join` deleted

`sql_literal.rb:25-29` and `fragments.rb:22-26` each define exactly one
concatenation method, `+`, ported as `plus`. `join` was a second trails-only
spelling that predates it, and since #7079 it was the unguarded one. Deleted
both; the sole caller moves to `plus`. `parity:api:extra` scored them as
*moved* (matching `SelectManager#join` in a different file), so the ratchet
never saw them.

`parity:api:extra:gate` narrows arel's total mark 62 → 59.

Closes-story: node-eql-is-a-generic-serializer-not-per-class-eql
Closes-story: sql-literal-and-fragments-join-have-no-ruby-counterpart
