### PR TITLE
fix(activerecord): stop the uniqueness trails test leaking a unique index onto topics

### DIFF
--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -9,11 +9,11 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { StrictValidationFailed } from "@blazetrails/activemodel";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-fixtures.js";
+import { Subscriber } from "../test-helpers/models/subscriber.js";
 import { Topic } from "../test-helpers/models/topic.js";
 import { checkoutRawTestAdapter } from "../test-adapter.js";
 import type { TestDatabaseAdapter } from "../test-adapter.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
-import { rebuildCanonicalTables } from "../support/canonical-table-rebuild.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
 describe("UniquenessValidationContextTest", () => {
@@ -90,38 +90,40 @@ describe("UniquenessCoveredByUniqueIndexAdapterResolutionTest", () => {
   let adapter: TestDatabaseAdapter;
   let pool: ConnectionPool;
 
-  class DirectTopic extends Topic {
-    static _tableName = "topics";
+  class DirectSubscriber extends Subscriber {
+    static _tableName = "subscribers";
   }
 
   beforeAll(async () => {
     ({ adapter, pool } = await checkoutRawTestAdapter());
-    await rebuildCanonicalTables(adapter, ["topics"]);
-    await adapter.addIndex("topics", "title", { unique: true, name: "topics_direct_index" });
-    (DirectTopic as unknown as { _adapter: TestDatabaseAdapter })._adapter = adapter;
+    (DirectSubscriber as unknown as { _adapter: TestDatabaseAdapter })._adapter = adapter;
   });
 
   afterAll(async () => {
+    // This describe writes through the raw pool, outside any fixtures
+    // transaction, so its row would otherwise outlive the file and be visible
+    // to every later test sharing the worker database.
+    await DirectSubscriber.where({ nick: "direct-abc" }).deleteAll();
     pool.releaseConnection();
     await pool.disconnectBang();
   });
 
   it("skips the existence check for a directly assigned adapter", async () => {
-    DirectTopic.clearValidatorsBang();
-    DirectTopic.validatesUniquenessOf("title");
+    DirectSubscriber.clearValidatorsBang();
+    DirectSubscriber.validatesUniquenessOf("nick");
 
-    const t = await DirectTopic.createBang({ title: "direct-abc" });
-    t.writeAttribute("author_name", "John");
+    const s = await DirectSubscriber.createBang({ nick: "direct-abc" });
+    s.writeAttribute("name", "John");
 
-    // title is unchanged and covered by a unique index, so no SELECT is issued.
+    // nick is unchanged and covered by a unique index, so no SELECT is issued.
     await assertNoQueries(false, async () => {
-      await t.isValid();
+      await s.isValid();
     });
 
-    // A changed title still consults the database.
-    t.writeAttribute("title", "direct-abc v2");
+    // A changed nick still consults the database.
+    s.writeAttribute("nick", "direct-abc v2");
     await assertQueriesCount(1, false, async () => {
-      await t.isValid();
+      await s.isValid();
     });
   });
 });

--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -100,9 +100,8 @@ describe("UniquenessCoveredByUniqueIndexAdapterResolutionTest", () => {
   });
 
   afterAll(async () => {
-    // This describe writes through the raw pool, outside any fixtures
-    // transaction, so its row would otherwise outlive the file and be visible
-    // to every later test sharing the worker database.
+    // Written through the raw pool, outside any fixtures transaction, so it
+    // outlives the file unless deleted here.
     await DirectSubscriber.where({ nick: "direct-abc" }).deleteAll();
     pool.releaseConnection();
     await pool.disconnectBang();


### PR DESCRIPTION
## Root cause

`Active Record SQLite Tests` went red on `main` at 691f6a0c with

```
FAIL packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
  > leading-colon string writes > create and insert_all store a leading colon verbatim
TypeError: Cannot read properties of null (reading 'title')
```

The failing test is not the buggy one. `uniqueness-validation.trails.test.ts`'s
`UniquenessCoveredByUniqueIndexAdapterResolutionTest` describe checked out a **raw,
unpinned** adapter, called `rebuildCanonicalTables(adapter, ["topics"])`, and then
`addIndex("topics", "title", { unique: true, name: "topics_direct_index" })`. Neither
mutation was ever undone. Because that adapter is outside any fixtures transaction,
both the rebuilt table (with its reset `AUTOINCREMENT` sequence) and the stray unique
index survive the file and are visible to every later test that shares the worker
database.

In `leading-colon-string-writes`, the loop writes four titles — `::Alpha`, `:Alpha`,
`:::Alpha`, `Alpha::Beta` — through `create` and then `insert_all`. With a unique index
on `topics.title` in place, `insertAll` no longer lands the row it is supposed to, so
the following `Topic.where({ author_name: "colon" }).first()` returns `null` and
`inserted!.title` throws.

That is why it only ever reddened the SQLite lane: `ci.yml:1118` and `ci.yml:1270` run
the PG and MariaDB lanes with `--shard=N/2`, while the SQLite job runs
`packages/activerecord/` **unsharded**. SQLite is the only lane where these two files
can land in the same fork, and therefore the same worker database.

## Reproduction

Deterministic, and it pins the two files to one worker:

```
pnpm vitest run --no-file-parallelism \
  packages/activerecord/src/validations/uniqueness-validation.trails.test.ts \
  packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
```

Before this change that fails with the CI error verbatim (inserted id 5, same
connection). After it, both files pass.

## The fix

No patching-up of the DDL — the DDL is removed. `subscribers.nick` already carries a
single-column, non-partial unique index in the canonical schema
(`test-schema.ts:1553`, mirroring `vendor/rails/activerecord/test/schema/schema.rb:1175`),
which is exactly what `covered_by_unique_index?` looks for
(`validations/uniqueness.ts:409`). Pointing the directly-assigned model at
`subscribers` covers the same adapter-resolution path with no schema mutation at all,
so there is nothing left to leak.

The one row the describe writes still lands outside the fixtures transaction, so
`afterAll` deletes it before releasing the pool.

`rebuildCanonicalTables` and `addIndex` are gone from the file.

## Notes

- Test-only change; no ported method body, no public surface, so `parity:api` /
  `parity:test` are unmoved. The test names are unchanged.
- The describe keeps its name and its assertions; it is not weakened — it still
  asserts the zero-query and one-query arms via `assertNoQueries` /
  `assertQueriesCount`.

Closes-story: red-691f6a0c