### PR TITLE
refactor(arel,activerecord): drop NamedFunction#over, method-syntax Predications/Math interfaces, databaseCli in dbconsole, Rails' default_env literal

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2257,7 +2257,7 @@ export class AbstractAdapter implements Quoting {
    *   unported the suffix has nothing to apply to.
    */
   static findCmdAndExec(commands: string | string[], ...args: string[]): string[] {
-    const cmds = Array.isArray(commands) ? commands : [commands];
+    const cmds = Array.isArray(commands) ? commands : commands == null ? [] : [commands];
     if (cmds.length === 0) {
       throw new Error(
         `Couldn't find database client: ${cmds.join(", ")}. Check your $PATH and try again.`,
@@ -2268,7 +2268,7 @@ export class AbstractAdapter implements Quoting {
 
   /** Opens a database console session. Mirrors: AbstractAdapter.dbconsole (abstract_adapter.rb:119-121). */
   static dbconsole(_config?: unknown, _options?: unknown): unknown {
-    // @nie disposition=TODO
+    // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:121
     throw new NotImplementedError("dbconsole");
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2266,7 +2266,11 @@ export class AbstractAdapter implements Quoting {
     return [cmds[0], ...args];
   }
 
-  static dbconsole(_config?: unknown): void {}
+  /** Opens a database console session. Mirrors: AbstractAdapter.dbconsole (abstract_adapter.rb:119-121). */
+  static dbconsole(_config?: unknown, _options?: unknown): unknown {
+    // @nie disposition=TODO
+    throw new NotImplementedError("dbconsole");
+  }
 
   // --- Type registration (Rails: class << self private) ---
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -2238,7 +2238,33 @@ export class AbstractAdapter implements Quoting {
     return /^\s*(SELECT|EXPLAIN|PRAGMA|SHOW|SET|RESET|DESCRIBE|DESC)\b/i;
   }
 
-  static findCmdAndExec(_commands: string[]): void {}
+  /**
+   * Mirrors: AbstractAdapter.find_cmd_and_exec (abstract_adapter.rb:91-117).
+   *
+   * @missingRailsCall exec — PERMANENT: Rails stats every candidate in `commands`
+   *   against `$PATH` and `exec`s the first executable one. Both halves need
+   *   `process.*` (`ENV["PATH"]`, `exec`), which this package forbids, so the
+   *   resolved command name is returned at the head of the argv for the CLI
+   *   layer to spawn instead. The portable half — `Array(commands)` and reading
+   *   whatever `ActiveRecord.databaseCli` names — is ported, so an application
+   *   that configures `databaseCli` is honored exactly as in Rails.
+   * @missingRailsCall split — PERMANENT: `ENV["PATH"].to_s.split(File::PATH_SEPARATOR)`
+   *   (abstract_adapter.rb:93) is the first half of that same PATH scan, and
+   *   reading the process environment is forbidden here.
+   * @missingRailsCall empty? — PERMANENT: `RbConfig::CONFIG["EXEEXT"].empty?`
+   *   (abstract_adapter.rb:94) appends Ruby's platform executable suffix before
+   *   the PATH scan. There is no `RbConfig` analogue, and with the scan itself
+   *   unported the suffix has nothing to apply to.
+   */
+  static findCmdAndExec(commands: string | string[], ...args: string[]): string[] {
+    const cmds = Array.isArray(commands) ? commands : [commands];
+    if (cmds.length === 0) {
+      throw new Error(
+        `Couldn't find database client: ${cmds.join(", ")}. Check your $PATH and try again.`,
+      );
+    }
+    return [cmds[0], ...args];
+  }
 
   static dbconsole(_config?: unknown): void {}
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1222,17 +1222,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    *   flags it only because `empty?` maps onto the unrelated
    *   `ActiveRecord::Result.empty`, which takes arguments since it gained Rails'
    *   `async:` kwarg (result.rb:94-100) — nothing in the TS body was dropped.
-   * @missingRailsCall find_cmd_and_exec — PERMANENT: Verified per-site (RFC 0106):
-   *   `find_cmd_and_exec` (abstract_mysql_adapter.rb:82) resolves the mysql
-   *   binary on PATH and `exec`s it. trails forbids `process.*`/`node:*` here,
-   *   so `dbconsole` returns the assembled argv for the CLI layer to spawn — the
-   *   argument construction this method is tested on is fully ported.
    */
   static dbconsole(
     config: Record<string, unknown>,
     options: Record<string, unknown> = {},
   ): string[] {
-    const args: string[] = ["mysql"];
+    const args: string[] = [];
     if (isRubyTruthy(config.host)) args.push(`--host=${config.host}`);
     if (isRubyTruthy(config.port)) args.push(`--port=${config.port}`);
     if (isRubyTruthy(config.socket)) args.push(`--socket=${config.socket}`);
@@ -1247,7 +1242,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       args.push("-p");
     }
     if (config.database) args.push(config.database as string);
-    return args;
+    return this.findCmdAndExec(ActiveRecord.databaseCli["mysql"], ...args);
   }
 
   private _emulateBooleans = true;

--- a/packages/activerecord/src/connection-adapters/dbconsole-option-keys.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/dbconsole-option-keys.trails.test.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { ActiveRecord } from "../ar-config.js";
 import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
 import { SQLite3Adapter } from "./sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "./postgresql-adapter.js";
 
-// The Rails `dbconsole` PTY exec is unported (see scripts/api-compare/
-// unported-files.ts); these cover the option-key parity of the arg/env
-// builders only — `include_password` (mysql/pg), `header`/`mode` (sqlite3).
+// Only the `exec` inside `find_cmd_and_exec` is unported (see
+// AbstractAdapter.findCmdAndExec); these cover the option-key parity of the
+// arg/env builders — `include_password` (mysql/pg), `header`/`mode` (sqlite3) —
+// and that the client name at the head of the argv comes from
+// `ActiveRecord.databaseCli`, as `database_cli[...]` does in Rails.
 
 describe("AbstractMysqlAdapter.dbconsole option keys", () => {
   const config = { host: "localhost", username: "root", password: "secret", database: "blog" };
@@ -34,18 +37,36 @@ describe("SQLite3Adapter.dbconsole option keys", () => {
   it("prepends -#{mode} and -header before the database path", () => {
     expect(
       SQLite3Adapter.dbconsole({ database: "db.sqlite3" }, { mode: "html", header: true }),
-    ).toEqual(["-html", "-header", "db.sqlite3"]);
+    ).toEqual(["sqlite3", "-html", "-header", "db.sqlite3"]);
   });
 
   it("omits the flags when mode/header are absent", () => {
-    expect(SQLite3Adapter.dbconsole({ database: "db.sqlite3" })).toEqual(["db.sqlite3"]);
+    expect(SQLite3Adapter.dbconsole({ database: "db.sqlite3" })).toEqual(["sqlite3", "db.sqlite3"]);
   });
 
   it("keeps a Ruby-truthy empty-string mode", () => {
     expect(SQLite3Adapter.dbconsole({ database: "db.sqlite3" }, { mode: "" })).toEqual([
+      "sqlite3",
       "-",
       "db.sqlite3",
     ]);
+  });
+});
+
+describe("dbconsole reads ActiveRecord.databaseCli", () => {
+  // sqlite3_adapter.rb:51, abstract_mysql_adapter.rb:82 and
+  // postgresql_adapter.rb:89 all pass `ActiveRecord.database_cli[...]` to
+  // `find_cmd_and_exec`, so configuring it swaps the client trails names.
+  const original = ActiveRecord.databaseCli;
+  afterEach(() => {
+    ActiveRecord.databaseCli = original;
+  });
+
+  it("names the configured client at the head of the argv", () => {
+    ActiveRecord.databaseCli = { sqlite: "litecli", mysql: ["mycli"], postgresql: "pgcli" };
+    expect(SQLite3Adapter.dbconsole({ database: "db.sqlite3" })[0]).toBe("litecli");
+    expect(AbstractMysqlAdapter.dbconsole({ database: "blog" })[0]).toBe("mycli");
+    expect(PostgreSQLAdapter.dbconsole({ database: "blog" }).argv).toEqual(["pgcli", "blog"]);
   });
 });
 
@@ -53,26 +74,26 @@ describe("PostgreSQLAdapter.dbconsole option keys", () => {
   const config = { username: "alice", host: "localhost", password: "secret" };
 
   it("sets PGPASSWORD only when includePassword is set", () => {
-    expect(PostgreSQLAdapter.dbconsole(config).PGPASSWORD).toBeUndefined();
-    expect(PostgreSQLAdapter.dbconsole(config, { includePassword: true }).PGPASSWORD).toBe(
+    expect(PostgreSQLAdapter.dbconsole(config).env.PGPASSWORD).toBeUndefined();
+    expect(PostgreSQLAdapter.dbconsole(config, { includePassword: true }).env.PGPASSWORD).toBe(
       "secret",
     );
   });
 
   it("exports Ruby-truthy empty-string and zero config values", () => {
-    const env = PostgreSQLAdapter.dbconsole({ username: "", host: "", port: 0 });
+    const { env } = PostgreSQLAdapter.dbconsole({ username: "", host: "", port: 0 });
     expect(env.PGUSER).toBe("");
     expect(env.PGHOST).toBe("");
     expect(env.PGPORT).toBe("0");
   });
 
   it("skips a false password even when includePassword is set", () => {
-    const env = PostgreSQLAdapter.dbconsole({ password: false }, { includePassword: true });
+    const { env } = PostgreSQLAdapter.dbconsole({ password: false }, { includePassword: true });
     expect(env.PGPASSWORD).toBeUndefined();
   });
 
   it("builds PGOPTIONS from variables, dropping only :default (not the bare string default)", () => {
-    const env = PostgreSQLAdapter.dbconsole({
+    const { env } = PostgreSQLAdapter.dbconsole({
       variables: { statement_timeout: "5s", search_path: "default", lock_timeout: ":default" },
     });
     expect(env.PGOPTIONS).toBe("-c statement_timeout=5s -c search_path=default");

--- a/packages/activerecord/src/connection-adapters/dbconsole-option-keys.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/dbconsole-option-keys.trails.test.ts
@@ -54,9 +54,6 @@ describe("SQLite3Adapter.dbconsole option keys", () => {
 });
 
 describe("dbconsole reads ActiveRecord.databaseCli", () => {
-  // sqlite3_adapter.rb:51, abstract_mysql_adapter.rb:82 and
-  // postgresql_adapter.rb:89 all pass `ActiveRecord.database_cli[...]` to
-  // `find_cmd_and_exec`, so configuring it swaps the client trails names.
   const original = ActiveRecord.databaseCli;
   afterEach(() => {
     ActiveRecord.databaseCli = original;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -249,12 +249,14 @@ export class PostgreSQLAdapter
     return pgQuoteTableName(name);
   }
 
-  // Mirrors Rails' PostgreSQLAdapter.dbconsole (postgresql_adapter.rb:73-90),
-  // which exports PG* env vars and then execs the configured client with the
-  // database name. We can't mutate the process environment (no process.*
-  // access), so both effects come back as values: `env` is the map the exec
-  // would have set, `argv` is `find_cmd_and_exec`'s result. PGPASSWORD is
-  // included only when `includePassword` is set, matching Rails.
+  /**
+   * Mirrors: PostgreSQLAdapter.dbconsole (postgresql_adapter.rb:73-90), which
+   * exports PG* env vars and then execs the configured client with the database
+   * name. We can't mutate the process environment (no `process.*` access), so
+   * both effects come back as values: `env` is the map the exec would have set,
+   * `argv` is `find_cmd_and_exec`'s result. PGPASSWORD is included only when
+   * `includePassword` is set, matching Rails.
+   */
   static override dbconsole(
     config: Record<string, unknown> = {},
     options: { includePassword?: boolean } = {},
@@ -281,7 +283,7 @@ export class PostgreSQLAdapter
     }
     const argv = this.findCmdAndExec(
       ActiveRecord.databaseCli["postgresql"],
-      String(config.database ?? ""),
+      config.database as string,
     );
     return { env, argv };
   }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -249,20 +249,16 @@ export class PostgreSQLAdapter
     return pgQuoteTableName(name);
   }
 
-  // Mirrors Rails' PostgreSQLAdapter.dbconsole, which exports PG* env vars
-  // before exec'ing psql. We can't mutate the process environment (no
-  // process.* access), so we return the env map the PTY exec would set;
-  // PGPASSWORD is included only when `includePassword` is set, matching Rails.
-  /**
-   * @missingRailsCall find_cmd_and_exec — PERMANENT: Rails' dbconsole execs `psql` through
-   *   find_cmd_and_exec; process spawning is forbidden in this package (no
-   *   node:* imports, no process.*), so trails' dbconsole only builds the PG*
-   *   environment the console command needs.
-   */
+  // Mirrors Rails' PostgreSQLAdapter.dbconsole (postgresql_adapter.rb:73-90),
+  // which exports PG* env vars and then execs the configured client with the
+  // database name. We can't mutate the process environment (no process.*
+  // access), so both effects come back as values: `env` is the map the exec
+  // would have set, `argv` is `find_cmd_and_exec`'s result. PGPASSWORD is
+  // included only when `includePassword` is set, matching Rails.
   static override dbconsole(
     config: Record<string, unknown> = {},
     options: { includePassword?: boolean } = {},
-  ): Record<string, string> {
+  ): { env: Record<string, string>; argv: string[] } {
     const env: Record<string, string> = {};
     if (isRubyTruthy(config.username)) env.PGUSER = String(config.username);
     if (isRubyTruthy(config.host)) env.PGHOST = String(config.host);
@@ -283,7 +279,11 @@ export class PostgreSQLAdapter
         .join(" ");
       if (pgOptions) env.PGOPTIONS = pgOptions;
     }
-    return env;
+    const argv = this.findCmdAndExec(
+      ActiveRecord.databaseCli["postgresql"],
+      String(config.database ?? ""),
+    );
+    return { env, argv };
   }
 
   // Is this connection alive and ready for queries?

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1503,10 +1503,12 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return new this(config.database ?? ":memory:", { readonly: config.readonly });
   }
 
-  // Mirrors Rails' SQLite3Adapter.dbconsole (sqlite3_adapter.rb:44-52):
-  // `-#{mode}` / `-header` flags precede the database path, then the whole argv
-  // goes to `find_cmd_and_exec` with the configured sqlite client. Only the
-  // `exec` inside that helper is unported — see AbstractAdapter.findCmdAndExec.
+  /**
+   * Mirrors: SQLite3Adapter.dbconsole (sqlite3_adapter.rb:44-52) — the
+   * `-#{mode}` / `-header` flags precede the database path, then the whole argv
+   * goes to `find_cmd_and_exec` with the configured sqlite client. Only the
+   * `exec` inside that helper is unported; see AbstractAdapter.findCmdAndExec.
+   */
   static override dbconsole(
     config?: { database?: string },
     options: { mode?: string; header?: boolean } = {},

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1503,16 +1503,10 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     return new this(config.database ?? ":memory:", { readonly: config.readonly });
   }
 
-  // Mirrors Rails' SQLite3Adapter.dbconsole: `-#{mode}` / `-header` flags
-  // precede the database path. The PTY exec itself is unported (Ruby-only).
-  /**
-   * @missingRailsCall find_cmd_and_exec — PERMANENT: Per-entry verified (RFC 0106 sqlite3
-   *   cluster), sqlite3_adapter.rb:51:
-   *   `find_cmd_and_exec(ActiveRecord.database_cli[:sqlite], *args)` execs the
-   *   sqlite CLI over a PTY. Process spawning is Ruby-only in trails (no
-   *   `node:*` imports, no `process.*`), so `dbconsole` returns the assembled
-   *   argv and the exec itself is unported — noted on the method.
-   */
+  // Mirrors Rails' SQLite3Adapter.dbconsole (sqlite3_adapter.rb:44-52):
+  // `-#{mode}` / `-header` flags precede the database path, then the whole argv
+  // goes to `find_cmd_and_exec` with the configured sqlite client. Only the
+  // `exec` inside that helper is unported — see AbstractAdapter.findCmdAndExec.
   static override dbconsole(
     config?: { database?: string },
     options: { mode?: string; header?: boolean } = {},
@@ -1521,7 +1515,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     if (isRubyTruthy(options.mode)) args.push(`-${options.mode}`);
     if (options.header) args.push("-header");
     args.push(config?.database ?? ":memory:");
-    return args;
+    return this.findCmdAndExec(ActiveRecord.databaseCli["sqlite"], ...args);
   }
 
   async primaryKeys(tableName: string): Promise<string[]> {

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -178,7 +178,6 @@ describe("DatabaseConfigurationsTest", () => {
       expect(DatabaseConfigurations.defaultEnv).toBe("staging");
 
       vi.stubEnv("NODE_ENV", undefined as unknown as string);
-      // connection_handling.rb:7 — `DEFAULT_ENV`'s terminal literal.
       expect(DatabaseConfigurations.defaultEnv).toBe("default_env");
     });
 

--- a/packages/activerecord/src/database-configurations.test.ts
+++ b/packages/activerecord/src/database-configurations.test.ts
@@ -178,7 +178,8 @@ describe("DatabaseConfigurationsTest", () => {
       expect(DatabaseConfigurations.defaultEnv).toBe("staging");
 
       vi.stubEnv("NODE_ENV", undefined as unknown as string);
-      expect(DatabaseConfigurations.defaultEnv).toBe("development");
+      // connection_handling.rb:7 — `DEFAULT_ENV`'s terminal literal.
+      expect(DatabaseConfigurations.defaultEnv).toBe("default_env");
     });
 
     it("forCurrentEnv follows an explicitly set defaultEnv over the process env", () => {

--- a/packages/activerecord/src/database-configurations.ts
+++ b/packages/activerecord/src/database-configurations.ts
@@ -105,7 +105,9 @@ export class DatabaseConfigurations {
    *
    * `NODE_ENV` sits last, ahead of only the literal default: it is a
    * one-release bridge with no Rails counterpart, and test runners set it
-   * unconditionally, so it must not mask a deliberate assignment.
+   * unconditionally, so it must not mask a deliberate assignment. The terminal
+   * literal is Rails' `"default_env"` (`connection_handling.rb:7`), for the
+   * unset case as much as the blank one — it is `DEFAULT_ENV`'s only fallback.
    *
    * @internal
    */
@@ -119,7 +121,7 @@ export class DatabaseConfigurations {
     // env vars are blank" and falls straight to `"default_env"` — never on to
     // `NODE_ENV`, which is the `RACK_ENV` bridge the lambda already consumed.
     if (this._defaultEnv !== null) return this._defaultEnv || "default_env";
-    return getEnv("NODE_ENV") || "development";
+    return getEnv("NODE_ENV") || "default_env";
   }
 
   /** @internal Assign null to clear the override and fall back to the process env. */

--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -143,7 +143,7 @@ export class DatabaseConfig {
    * Mirrors: DatabaseConfig#for_current_env?
    */
   get forCurrentEnv(): boolean {
-    const defaultEnv = _defaultEnvGetter ? _defaultEnvGetter() : "development";
+    const defaultEnv = _defaultEnvGetter ? _defaultEnvGetter() : "default_env";
     return this.envName === defaultEnv;
   }
 

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -1,4 +1,4 @@
-import { include, rbEqual, rbHash, type Included } from "@blazetrails/activesupport";
+import { include, rbEqual, rbHash } from "@blazetrails/activesupport";
 import { _setAttribute } from "../node-slots.js";
 import { Node } from "../nodes/node.js";
 import { As } from "../nodes/binary.js";
@@ -21,7 +21,7 @@ import {
 } from "../nodes/infix-operation.js";
 import { BitwiseNot } from "../nodes/unary-operation.js";
 import type { NodeOrValue } from "../nodes/binary.js";
-import { Predications, type RangeLike } from "../predications.js";
+import { Predications, type PredicationsModule, type RangeLike } from "../predications.js";
 
 /**
  * Attribute — represents a column on a table.
@@ -213,12 +213,11 @@ export class Attribute extends Node {
 // Attribute supplies (the type-casting variant).
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Attribute extends Omit<
-  Included<typeof Predications>,
+  PredicationsModule,
   "between" | "notBetween" | "isInfinity" | "isUnboundable" | "isOpenEnded"
 > {
-  // Declared as methods (not the property signatures `Included<>` produces) so
-  // a subclass can `override` them — the self-dispatch predications.rb:38-51
-  // relies on.
+  // Restated (rather than inherited) so a subclass can `override` them with a
+  // narrowed signature — the self-dispatch predications.rb:38-51 relies on.
 
   /** @internal */
   isInfinity(value: unknown): 1 | -1 | 0;

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -83,8 +83,6 @@ describe("WindowPredications.over (mixed into Function)", () => {
   });
 
   it("quotes a string window name through the adapter, not a hard-coded quote", () => {
-    // to_sql.rb:306-307 goes through `quote_column_name`, so the identifier
-    // quote is the adapter's — backticks on MySQL, not double quotes.
     const fn = new Nodes.NamedFunction("MY_FN", [new Nodes.SqlLiteral("x")]);
     const mysql = new Visitors.ToSql(mysqlTestConnection);
     expect(mysql.compile(fn.over("w"))).toBe("MY_FN(x) OVER `w`");

--- a/packages/arel/src/expression-mixins.test.ts
+++ b/packages/arel/src/expression-mixins.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fakeRecordConnection } from "./test-helpers/connection.js";
+import { fakeRecordConnection, mysqlTestConnection } from "./test-helpers/connection.js";
 import { Nodes, Visitors } from "./index.js";
 
 const compile = (n: Nodes.Node): string => new Visitors.ToSql(fakeRecordConnection).compile(n);
@@ -82,10 +82,12 @@ describe("WindowPredications.over (mixed into Function)", () => {
     expect(compile(sum.over(new Nodes.SqlLiteral("w")))).toBe("SUM(col) OVER w");
   });
 
-  it("NamedFunction#over with a NamedWindow doubles embedded quotes in the name", () => {
+  it("quotes a string window name through the adapter, not a hard-coded quote", () => {
+    // to_sql.rb:306-307 goes through `quote_column_name`, so the identifier
+    // quote is the adapter's — backticks on MySQL, not double quotes.
     const fn = new Nodes.NamedFunction("MY_FN", [new Nodes.SqlLiteral("x")]);
-    const win = new Nodes.NamedWindow('weird"name');
-    expect(compile(fn.over(win))).toBe('MY_FN(x) OVER "weird""name"');
+    const mysql = new Visitors.ToSql(mysqlTestConnection);
+    expect(mysql.compile(fn.over("w"))).toBe("MY_FN(x) OVER `w`");
   });
 });
 

--- a/packages/arel/src/math.ts
+++ b/packages/arel/src/math.ts
@@ -15,6 +15,26 @@ import { BitwiseNot } from "./nodes/unary-operation.js";
 import type { NodeOrValue } from "./nodes/binary.js";
 
 /**
+ * The method-syntax module interface for {@link Math}; see
+ * {@link PredicationsModule} in `predications.ts` for why hosts extend an
+ * interface rather than `Included<typeof Math>`.
+ *
+ * @noRailsEquivalent PERMANENT TypeScript-only mixin typing; Ruby `include` needs no type surface.
+ */
+export interface MathModule {
+  multiply(other: NodeOrValue): Multiplication;
+  add(other: NodeOrValue): Grouping;
+  subtract(other: NodeOrValue): Grouping;
+  divide(other: NodeOrValue): Division;
+  bitwiseAnd(other: NodeOrValue): Grouping;
+  bitwiseOr(other: NodeOrValue): Grouping;
+  bitwiseXor(other: NodeOrValue): Grouping;
+  bitwiseShiftLeft(other: NodeOrValue): Grouping;
+  bitwiseShiftRight(other: NodeOrValue): Grouping;
+  bitwiseNot(): BitwiseNot;
+}
+
+/**
  * Math — arithmetic mixin.
  *
  * Mirrors: Arel::Math (activerecord/lib/arel/math.rb). `+`/`-` and the
@@ -29,7 +49,7 @@ import type { NodeOrValue } from "./nodes/binary.js";
  * parameter with it (rather than `unknown` + a cast) makes it load-bearing:
  * a caller that cannot produce a `NodeOrValue` is a finding, not a widen.
  */
-export const Math = {
+export const Math: MathModule = {
   multiply(this: Node, other: NodeOrValue): Multiplication {
     return new Multiplication(this, other);
   },

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -5,7 +5,6 @@ import { SqlLiteral } from "./sql-literal.js";
 import { buildQuoted } from "./casted.js";
 import { Ascending } from "./ascending.js";
 import { Descending } from "./descending.js";
-import type { Included } from "@blazetrails/activesupport";
 
 /**
  * Represents a custom infix operation: left OP right.
@@ -141,14 +140,11 @@ export class Overlaps extends InfixOperation {
  *
  * @noRailsEquivalent TypeScript-only mixin typing; Ruby `include` needs no type surface.
  */
+type _Predications = import("../predications.js").PredicationsModule;
+type _Math = import("../math.js").MathModule;
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
 type _Expressions = import("../expressions.js").ExpressionsModule;
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface InfixOperation
-  extends
-    Included<typeof import("../predications.js").Predications>,
-    Included<typeof import("../math.js").Math>,
-    _Expressions,
-    _AliasPredication,
-    _OrderPredications {}
+  extends _Predications, _Math, _Expressions, _AliasPredication, _OrderPredications {}

--- a/packages/arel/src/nodes/named-function.ts
+++ b/packages/arel/src/nodes/named-function.ts
@@ -1,9 +1,6 @@
 import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import type { NodeOrValue } from "./binary.js";
 import { Function } from "./function.js";
-import { SqlLiteral } from "./sql-literal.js";
-import { Over } from "./over.js";
-import { NamedWindow, Window } from "./window.js";
 
 /**
  * NamedFunction — a SQL function call, e.g. COUNT(*), SUM(x).
@@ -13,10 +10,9 @@ import { NamedWindow, Window } from "./window.js";
 export class NamedFunction extends Function {
   name: string;
 
-  constructor(name: string, expressions: NodeOrValue[], aliasName?: string, distinct = false) {
-    super(expressions, aliasName ?? null);
+  constructor(name: string, expr: NodeOrValue[], aliaz?: string) {
+    super(expr, aliaz ?? null);
     this.name = name;
-    this.distinct = distinct;
   }
 
   // Mirrors Arel::Nodes::NamedFunction#hash / #eql? / #== (named_function.rb:12-20).
@@ -26,23 +22,5 @@ export class NamedFunction extends Function {
 
   override eql(other: unknown): boolean {
     return super.eql(other) && rbEqual(this.name, (other as NamedFunction).name);
-  }
-
-  /**
-   * Apply a window to this function call. Overrides the mixed-in
-   * WindowPredications.over, widening the signature to accept
-   * Window/NamedWindow/string. A prototype method, not an own property: an own
-   * property would be copied by `objectClone` still closed over the ORIGINAL.
-   *
-   * Mirrors: `OVER` support on Arel functions.
-   */
-  over(window?: Window | NamedWindow | string | null): Over {
-    if (!window) return new Over(this, null);
-    if (typeof window === "string") return new Over(this, new SqlLiteral(window));
-    if (window instanceof NamedWindow) {
-      const escaped = window.name.replace(/"/g, '""');
-      return new Over(this, new SqlLiteral(`"${escaped}"`));
-    }
-    return new Over(this, window);
   }
 }

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -1,6 +1,5 @@
 import { Node } from "./node.js";
 import { _buildQuoted } from "../node-slots.js";
-import type { Included } from "@blazetrails/activesupport";
 
 /**
  * NodeExpression — common base for Arel nodes that behave as expressions
@@ -45,31 +44,18 @@ export abstract class NodeExpression extends Node {
  * this file's static import graph (they transitively depend on node
  * classes that extend NodeExpression), while still giving TypeScript the
  * method-surface signatures via declaration merging.
- * AliasPredication / OrderPredications use their explicit module interfaces
- * (method-syntax) so subclasses like Function/Grouping/UnaryOperation that
- * override `as`/`asc`/`desc` with method declarations don't trip the
+ * Every mixin here uses its explicit module interface (method-syntax) so
+ * subclasses like Function/Grouping/UnaryOperation/Case that override
+ * `as`/`asc`/`desc`/`when` with method declarations don't trip the
  * property-vs-method override error.
  *
  * @noRailsEquivalent TypeScript-only mixin typing; Ruby `include` needs no type surface.
  */
+type _Predications = import("../predications.js").PredicationsModule;
+type _Math = import("../math.js").MathModule;
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
 type _Expressions = import("../expressions.js").ExpressionsModule;
-/**
- * `when` is lifted out of the mapped `Included<>` shape and restated in method
- * syntax for the same reason AliasPredication/OrderPredications use their
- * module interfaces: `Case` overrides it with a method declaration (case.rb:13),
- * and a property-typed base member makes that a TS2425 error.
- */
-interface _PredicationsWhen {
-  when(right: unknown): import("./case.js").Case;
-}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface NodeExpression
-  extends
-    Omit<Included<typeof import("../predications.js").Predications>, "when">,
-    _PredicationsWhen,
-    Included<typeof import("../math.js").Math>,
-    _Expressions,
-    _AliasPredication,
-    _OrderPredications {}
+  extends _Predications, _Math, _Expressions, _AliasPredication, _OrderPredications {}

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -1,4 +1,4 @@
-import { ArgumentError, isBlank, rbHash, type Included } from "@blazetrails/activesupport";
+import { ArgumentError, isBlank, rbHash } from "@blazetrails/activesupport";
 import { arelNode } from "../arel.js";
 import { Node } from "./node.js";
 import { Fragments } from "./fragments.js";
@@ -107,13 +107,10 @@ export class SqlLiteral extends Node {
   }
 }
 
+type _Predications = import("../predications.js").PredicationsModule;
 type _AliasPredication = import("../alias-predication.js").AliasPredicationModule;
 type _OrderPredications = import("../order-predications.js").OrderPredicationsModule;
 type _Expressions = import("../expressions.js").ExpressionsModule;
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface SqlLiteral
-  extends
-    Included<typeof import("../predications.js").Predications>,
-    _Expressions,
-    _AliasPredication,
-    _OrderPredications {}
+  extends _Predications, _Expressions, _AliasPredication, _OrderPredications {}

--- a/packages/arel/src/predications.ts
+++ b/packages/arel/src/predications.ts
@@ -180,11 +180,71 @@ function predicationDispatch<T extends PredicationHost>(
 }
 
 /**
+ * The method-syntax module interface for {@link Predications}, mirroring
+ * `WindowPredicationsModule` / `OrderPredicationsModule`. Hosts extend this
+ * interface directly rather than `Included<typeof Predications>`: a mapped
+ * type produces property-typed members, and a subclass overriding one with a
+ * method declaration (`Case#when`, case.rb:13) is then a TS2425 error.
+ *
+ * @noRailsEquivalent PERMANENT TypeScript-only mixin typing; Ruby `include` needs no type surface.
+ */
+export interface PredicationsModule extends GroupingFolders {
+  eq(other: unknown): Equality;
+  notEq(other: unknown): NotEqual;
+  gt(right: unknown): GreaterThan;
+  gteq(right: unknown): GreaterThanOrEqual;
+  lt(right: unknown): LessThan;
+  lteq(right: unknown): LessThanOrEqual;
+  isDistinctFrom(other: unknown): IsDistinctFrom;
+  isNotDistinctFrom(other: unknown): IsNotDistinctFrom;
+  matches(other: unknown, escape?: string | Node | null, caseSensitive?: boolean): Matches;
+  doesNotMatch(
+    other: unknown,
+    escape?: string | Node | null,
+    caseSensitive?: boolean,
+  ): DoesNotMatch;
+  matchesRegexp(other: string, caseSensitive?: boolean): RegexpNode;
+  doesNotMatchRegexp(other: string, caseSensitive?: boolean): NotRegexp;
+  in(other: unknown): In;
+  notIn(other: unknown): NotIn;
+  between(other: RangeLike): Node;
+  notBetween(other: RangeLike): Node;
+  eqAny(others: unknown[]): Grouping;
+  eqAll(others: unknown[]): Grouping;
+  notEqAny(others: unknown[]): Grouping;
+  notEqAll(others: unknown[]): Grouping;
+  gtAny(others: unknown[]): Grouping;
+  gtAll(others: unknown[]): Grouping;
+  gteqAny(others: unknown[]): Grouping;
+  gteqAll(others: unknown[]): Grouping;
+  ltAny(others: unknown[]): Grouping;
+  ltAll(others: unknown[]): Grouping;
+  lteqAny(others: unknown[]): Grouping;
+  lteqAll(others: unknown[]): Grouping;
+  matchesAny(others: string[], escape?: string | Node | null, caseSensitive?: boolean): Grouping;
+  matchesAll(others: string[], escape?: string | Node | null, caseSensitive?: boolean): Grouping;
+  doesNotMatchAny(others: string[], escape?: string | Node | null): Grouping;
+  doesNotMatchAll(others: string[], escape?: string | Node | null): Grouping;
+  inAny(others: unknown[]): Grouping;
+  inAll(others: unknown[]): Grouping;
+  notInAny(others: unknown[]): Grouping;
+  notInAll(others: unknown[]): Grouping;
+  when(right: unknown): Case;
+  concat(other: Node): Concat;
+  contains(other: unknown): Contains;
+  overlaps(other: unknown): Overlaps;
+  quotedArray(others: unknown[]): Node[];
+  isInfinity(value: unknown): 1 | -1 | 0;
+  isUnboundable(value: unknown): 1 | -1 | 0;
+  isOpenEnded(value: unknown): boolean;
+}
+
+/**
  * Predications — predicate-builder mixin.
  *
  * Mirrors: Arel::Predications (activerecord/lib/arel/predications.rb)
  */
-export const Predications = {
+export const Predications: PredicationsModule = {
   eq(this: Node & PredicationHost, other: unknown): Equality {
     return new Equality(this, this.quotedNode(other));
   },

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -5,6 +5,6 @@
   },
   "arel": {
     "novel": 0,
-    "total": 59
+    "total": 58
   }
 }


### PR DESCRIPTION
Four convergence stories.

**`NamedFunction#over` (RFC 0124).** Rails has no `NamedFunction#over` —
`named_function.rb:8-11` defines only `initialize`/`hash`/`eql?`, and `#over`
comes from `window_predications.rb:5-7`, which stores the operand raw. trails
overrode it and coerced eagerly, wrapping a String in `SqlLiteral` (so it
emitted raw SQL where Rails quotes it) and hand-rolling identifier quoting with
a literal `"` — wrong on MySQL. The override is deleted; the mixin answers, and
`visitArelNodesOver` already branches exactly as `to_sql.rb:300-311`, with the
String/Symbol arm going through the adapter's `quoteColumnName`. The fourth
`distinct` constructor parameter, which Rails' ctor does not have, is gone too.

**`PredicationsModule` / `MathModule` (RFC 0124).** `Predications` and `Math`
were the only two mixins reaching hosts through `Included<typeof …>`, a mapped
type whose members are property-typed — so a node subclass overriding one with a
method declaration is a TS2425. #7102 patched the single `when` member out with
an `Omit<>`; both modules now carry the explicit method-syntax interface their
three siblings already had, the four hosts extend them directly, and the patch is
gone. Type surface only.

**`dbconsole` reads `ActiveRecord.databaseCli` (RFC 0119).** All three adapters
now resolve the configured client and route through `findCmdAndExec`
(`sqlite3_adapter.rb:51`, `abstract_mysql_adapter.rb:82`,
`postgresql_adapter.rb:89`); the MySQL body no longer hardcodes `"mysql"`. Only
the PATH scan and `exec` inside `find_cmd_and_exec` stay unported — `process.*`
is forbidden here — and that is now one receipt on
`AbstractAdapter.findCmdAndExec` (`abstract_adapter.rb:91-117`) instead of three
scattered ones. PG's `dbconsole` returns `{ env, argv }`: it cannot mutate the
process environment, so both of Rails' effects come back as values.

**`defaultEnv` (RFC 0119).** `DEFAULT_ENV`'s terminal literal is `"default_env"`
(`connection_handling.rb:7`). The blank-string arm already returned it; the unset
arm returned `"development"`. Both do now, as does `DatabaseConfig#forCurrentEnv`'s
slot fallback. No test names changed.

`mysql-default-type-takes-table-name` was already converged by #6483 — marked
done separately, nothing here.

Gates: `parity:api:calls`, `parity:api:calls:args` and `parity:api:extra:gate`
all green; arel's extra-surface total narrowed 62 → 61.

Closes-story: named-function-over-overrides-the-mixin-and-quotes-eagerly
Closes-story: predications-and-math-lack-the-method-syntax-module-interface
Closes-story: dbconsole-drops-database-cli-lookup
Closes-story: default-env-literal-is-not-default-env