### PR TITLE
fix(activerecord): create subscribers on the raw pool in the uniqueness adapter-resolution test

### DIFF
--- a/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
@@ -14,6 +14,7 @@ import { Topic } from "../test-helpers/models/topic.js";
 import { checkoutRawTestAdapter } from "../test-adapter.js";
 import type { TestDatabaseAdapter } from "../test-adapter.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
+import { rebuildCanonicalTables } from "../support/canonical-table-rebuild.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
 describe("UniquenessValidationContextTest", () => {
@@ -96,6 +97,13 @@ describe("UniquenessCoveredByUniqueIndexAdapterResolutionTest", () => {
 
   beforeAll(async () => {
     ({ adapter, pool } = await checkoutRawTestAdapter());
+    // The raw pool builds its own connection, and on the `:memory:` lane that
+    // is a private, empty database — nothing has laid the canonical schema in
+    // it. Guarded on absence so the file-backed lanes, where the table is
+    // already there and shared with every other file, are left untouched.
+    if (!(await adapter.tableExists("subscribers"))) {
+      await rebuildCanonicalTables(adapter, ["subscribers"]);
+    }
     (DirectSubscriber as unknown as { _adapter: TestDatabaseAdapter })._adapter = adapter;
   });
 


### PR DESCRIPTION
## Root cause

`Active Record SQLite :memory: Tests` went red at f5d2641f, the fix for the
previous red (#7109). That PR repointed
`UniquenessCoveredByUniqueIndexAdapterResolutionTest` from a rebuilt-and-indexed
`topics` onto `subscribers`, whose canonical unique index on `nick` already
gives `covered_by_unique_index?` what it needs — removing the schema mutation
that was leaking onto the shared worker DB. That part is right.

What it also removed was the only thing creating a table in that describe's
**raw pool**. `checkoutRawTestAdapter` builds its own `ConnectionPool`, and on
the `sqlite3_mem` lane (`ARCONN=sqlite3_mem`, `database: ':memory:'`) a new
connection is a brand-new, *private*, empty database — the canonical schema laid
into the ambient lane's connection is not visible in it. So the describe ran
against a database with no tables:

```
MissingAttributeError: can't write unknown attribute `nick`
StatementInvalid: no such table: subscribers
```

The previous shape happened to hide this because `rebuildCanonicalTables(adapter,
["topics"])` created its table in that private DB as a side effect. On the
file-backed lanes (`ARCONN` default / PG / MariaDB) the raw pool reaches the same
database as everything else, so `subscribers` is already there and those lanes
stayed green.

## The fix

Lay `subscribers` on the raw adapter **only when it is absent**:

```ts
if (!(await adapter.tableExists("subscribers"))) {
  await rebuildCanonicalTables(adapter, ["subscribers"]);
}
```

- On `:memory:` the table is always absent and the database is private to this
  pool, so nothing can leak out of the file — the failure mode #7109 fixed
  cannot recur here.
- On every file-backed lane the guard is false and the shared database is left
  untouched, which is the property #7109 was buying.

`rebuildCanonicalTables` is the sanctioned test-file loader
(`eslint/no-internal-canonical-loaders.mjs:19-22`); `ensureCanonicalTables` is
banned from test files, which is why the absence check is written at the call
site rather than delegated.

## Verification

Fails on the parent commit and passes here:

```
ARCONN=sqlite3_mem pnpm vitest run \
  packages/activerecord/src/validations/uniqueness-validation.trails.test.ts
```

And #7109's own regression repro stays green on the file-backed lane:

```
pnpm vitest run --no-file-parallelism \
  packages/activerecord/src/validations/uniqueness-validation.trails.test.ts \
  packages/activerecord/src/relation/leading-colon-string-writes.trails.test.ts
```

Test-only change; no ported body, no public surface, no test names touched.

Closes-story: red-f5d2641f
