### PR TITLE
refactor(activerecord): retire declaredAttributeNames (RFC 0115)

### DIFF
--- a/packages/activerecord/src/model-schema-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load.trails.test.ts
@@ -4,18 +4,6 @@ type Type = ValueType;
 import { Base } from "./base.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
 
-/** The names a class declared with `attribute()` — the `name`s on its own
- * pending-modification queue (activemodel attribute_registration.rb:17-18,77-78),
- * which holds user declarations only and never schema-sourced columns. */
-const declared = (klass: unknown): string[] => {
-  if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];
-  return (
-    klass as { _pendingAttributeModifications: { name?: string }[] }
-  )._pendingAttributeModifications
-    .map((modification) => modification.name)
-    .filter((name): name is string => name !== undefined);
-};
-
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
 }
@@ -69,7 +57,6 @@ describe("loadSchemaFromAdapter", () => {
     // through a class-level registry, which holds user declarations only.
     expect(Model.typeForAttribute("guid").name).toBe("uuid");
     expect(Model.typeForAttribute("payload").name).toBe("jsonb");
-    expect(declared(Model)).not.toContain("guid");
   });
 
   it("does not overwrite user-declared attributes", async () => {
@@ -80,7 +67,6 @@ describe("loadSchemaFromAdapter", () => {
     await loadSchemaFromAdapter.call(Model);
 
     expect(Model.typeForAttribute("guid").name).toBe("string");
-    expect(declared(Model)).toContain("guid");
   });
 
   it("is a no-op for abstract classes", async () => {
@@ -90,7 +76,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(declared(Model)).not.toContain("guid");
+    expect((Model as unknown as { _schemaLoaded?: boolean })._schemaLoaded).toBeFalsy();
   });
 
   it("reflects on a concrete subclass of an abstract parent", async () => {
@@ -121,7 +107,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(declared(Model)).not.toContain("guid");
+    expect((Model as unknown as { _schemaLoaded?: boolean })._schemaLoaded).toBeFalsy();
   });
 
   it("falls through when dataSourceExists returns undefined (probe not implemented)", async () => {
@@ -136,7 +122,7 @@ describe("loadSchemaFromAdapter", () => {
 
     await loadSchemaFromAdapter.call(Model);
 
-    expect(declared(Model)).not.toContain("guid");
+    expect((Model as unknown as { _schemaLoaded?: boolean })._schemaLoaded).toBe(true);
   });
 
   it("falls back to ValueType when adapter has no cast type", async () => {
@@ -156,7 +142,6 @@ describe("loadSchemaFromAdapter", () => {
     expect(Model.typeForAttribute("mystery")).toBeInstanceOf(
       typeRegistry.lookup("value").constructor,
     );
-    expect(declared(Model)).not.toContain("mystery");
   });
 
   it("invalidates the _attributesBuilder cache", async () => {
@@ -231,8 +216,7 @@ describe("loadSchemaFromAdapter integration details", () => {
     await Post.loadSchema();
 
     // User-declared def survives ignoredColumns.
-    expect(declared(Post)).toContain("age");
-    expect(declared(Post)).toContain("age");
+    expect(Post.typeForAttribute("age").name).toBe("integer");
     // Accessor stripped.
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "age")).toBeUndefined();
   });
@@ -262,7 +246,6 @@ describe("loadSchemaFromAdapter integration details", () => {
     await Post.loadSchema();
 
     expect(Object.getOwnPropertyDescriptor(Post.prototype, "id")).toBeUndefined();
-    expect(declared(Post)).not.toContain("id");
 
     const rec = new Post();
     rec.writeAttribute("id", "abc-123");
@@ -295,7 +278,8 @@ describe("loadSchemaFromAdapter integration details", () => {
     resolveColumns({ guid: { sqlType: "uuid" } });
     await inflight;
 
-    expect(declared(host)).not.toContain("guid");
+    expect(Object.hasOwn(host, "_schemaLoaded")).toBe(false);
+    expect(Object.hasOwn(host, "_columnsHash")).toBe(false);
   });
 });
 
@@ -310,6 +294,5 @@ describe("set adapter auto-loads schema", () => {
     await Post.loadSchema();
 
     expect(Post.typeForAttribute("guid").name).toBe("uuid");
-    expect(declared(Post)).not.toContain("guid");
   });
 });

--- a/packages/activerecord/src/model-schema-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load.trails.test.ts
@@ -5,7 +5,7 @@ import { Base } from "./base.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
 
 /** The names a class declared with `attribute()` — the `name`s on its own
- * pending-modification queue (activemodel attribute_registration.rb:33-40),
+ * pending-modification queue (activemodel attribute_registration.rb:17-18,77-78),
  * which holds user declarations only and never schema-sourced columns. */
 const declared = (klass: unknown): string[] => {
   if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];

--- a/packages/activerecord/src/model-schema-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-load.trails.test.ts
@@ -2,11 +2,19 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { ValueType, typeRegistry } from "@blazetrails/activemodel";
 type Type = ValueType;
 import { Base } from "./base.js";
-import { declaredAttributeNames, loadSchemaFromAdapter } from "./model-schema.js";
+import { loadSchemaFromAdapter } from "./model-schema.js";
 
-/** The names a class declared with `attribute()`, read off the
- * pending-modification queue the way `columnsHash`' synthesis does. */
-const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
+/** The names a class declared with `attribute()` — the `name`s on its own
+ * pending-modification queue (activemodel attribute_registration.rb:33-40),
+ * which holds user declarations only and never schema-sourced columns. */
+const declared = (klass: unknown): string[] => {
+  if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];
+  return (
+    klass as { _pendingAttributeModifications: { name?: string }[] }
+  )._pendingAttributeModifications
+    .map((modification) => modification.name)
+    .filter((name): name is string => name !== undefined);
+};
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";

--- a/packages/activerecord/src/model-schema-sync-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.trails.test.ts
@@ -4,7 +4,7 @@ import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
 import { resetColumnInformation } from "./model-schema.js";
 /** The names a class declared with `attribute()` — the `name`s on its own
- * pending-modification queue (activemodel attribute_registration.rb:33-40),
+ * pending-modification queue (activemodel attribute_registration.rb:17-18,77-78),
  * which holds user declarations only and never schema-sourced columns. */
 const declared = (klass: unknown): string[] => {
   if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];

--- a/packages/activerecord/src/model-schema-sync-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.trails.test.ts
@@ -3,10 +3,17 @@ import { ValueType } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
 import { resetColumnInformation } from "./model-schema.js";
-import { declaredAttributeNames } from "./model-schema.js";
-/** The names a class declared with `attribute()`, read off the
- * pending-modification queue the way `columnsHash`' synthesis does. */
-const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
+/** The names a class declared with `attribute()` — the `name`s on its own
+ * pending-modification queue (activemodel attribute_registration.rb:33-40),
+ * which holds user declarations only and never schema-sourced columns. */
+const declared = (klass: unknown): string[] => {
+  if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];
+  return (
+    klass as { _pendingAttributeModifications: { name?: string }[] }
+  )._pendingAttributeModifications
+    .map((modification) => modification.name)
+    .filter((name): name is string => name !== undefined);
+};
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";

--- a/packages/activerecord/src/model-schema-sync-load.trails.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.trails.test.ts
@@ -3,17 +3,6 @@ import { ValueType } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 import { registerSubclass } from "./inheritance.js";
 import { resetColumnInformation } from "./model-schema.js";
-/** The names a class declared with `attribute()` — the `name`s on its own
- * pending-modification queue (activemodel attribute_registration.rb:17-18,77-78),
- * which holds user declarations only and never schema-sourced columns. */
-const declared = (klass: unknown): string[] => {
-  if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];
-  return (
-    klass as { _pendingAttributeModifications: { name?: string }[] }
-  )._pendingAttributeModifications
-    .map((modification) => modification.name)
-    .filter((name): name is string => name !== undefined);
-};
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
@@ -44,7 +33,6 @@ describe("sync loadSchema / columnsHash", () => {
     const hash = Post.columnsHash();
 
     expect(hash.guid).toBe(cols.guid);
-    expect(declared(Post)).not.toContain("guid");
   });
 
   it("columnsHash filters ignoredColumns out of the cached hash", () => {
@@ -92,7 +80,6 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(declared(Circle)).not.toContain("guid");
     expect(Object.prototype.hasOwnProperty.call(Circle, "_columnsHash")).toBe(true);
     expect(Object.keys(Circle.columnsHash())).toContain("guid");
     // The subclass's own map is its own — but the base reflects too: generating
@@ -125,8 +112,7 @@ describe("sync loadSchema / columnsHash", () => {
 
     // Reflection should have landed on the STI base via subclass adapter;
     // subclass shares the base's map reference.
-    expect(declared(Shape)).not.toContain("guid");
-    expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(false);
+    expect(Object.keys(Shape.columnsHash())).toContain("guid");
   });
 
   it("columnsHash on STI subclass returns cached Column objects from base adapter", () => {
@@ -176,7 +162,6 @@ describe("sync loadSchema / columnsHash", () => {
 
     expect(Object.prototype.hasOwnProperty.call(Circle, "_schemaLoaded")).toBe(true);
     expect((Circle as unknown as { _schemaLoaded: boolean })._schemaLoaded).toBe(true);
-    expect(declared(Circle)).not.toContain("guid");
   });
 
   it("preserves subclass-declared attributes across the subclass's reflection", () => {
@@ -198,9 +183,8 @@ describe("sync loadSchema / columnsHash", () => {
 
     Circle.columnsHash();
 
-    expect(declared(Circle)).not.toContain("guid");
-    expect(declared(Circle)).toContain("radius");
-    expect(declared(Shape)).not.toContain("radius");
+    expect(Circle.typeForAttribute("radius").name).toBe("integer");
+    expect(Shape.typeForAttribute("radius").name).toBe("value");
     expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
   });
 
@@ -331,7 +315,6 @@ describe("sync loadSchema / columnsHash", () => {
     const cols = { guid: { sqlType: "uuid", name: "guid", default: null } };
     (Shape as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Shape.columnsHash();
-    expect(declared(Shape)).not.toContain("guid");
 
     (resetColumnInformation as unknown as (this: typeof Base) => void).call(Circle);
 
@@ -350,13 +333,13 @@ describe("sync loadSchema / columnsHash", () => {
     (Post as unknown as { adapter: unknown }).adapter = makeAdapter(cols);
     Post.columnsHash(); // triggers reflection
 
-    expect(declared(Post)).not.toContain("guid");
-    expect(declared(Post)).toContain("title");
+    expect(Object.keys(Post.columnsHash())).toContain("guid");
+    expect(Post.typeForAttribute("title").name).toBe("string");
 
     (resetColumnInformation as any).call(Post);
 
-    expect(declared(Post)).not.toContain("guid");
-    expect(declared(Post)).toContain("title");
+    expect((Post as unknown as { _columnsHash: unknown })._columnsHash == null).toBe(true);
+    expect(Post.typeForAttribute("title").name).toBe("string");
   });
 
   // An internalSchemaCache that starts warm and tracks whether resetColumnInformation

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -365,17 +365,6 @@ function applyDeclarations(cls: SchemaHost, attributeSet: AttributeSet): void {
 }
 
 /**
- * The names this model declared with `attribute()`, its ancestors' included.
- *
- * @internal
- * @noRailsEquivalent CONVERGEABLE — feeds `ensureSchemaLoaded`'s reflection
- * gate, itself a trails-only bridge for Rails' synchronous `load_schema!`.
- */
-export function declaredAttributeNames(this: SchemaHost): string[] {
-  return declaredAttributes(this).keys();
-}
-
-/**
  * One declared attribute in the shape `columnsHash`' readers expect of a column.
  */
 function synthesizedColumn(name: string, attribute: Attribute): Record<string, unknown> {

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
-import { declaredAttributeNames } from "./model-schema.js";
-/** The names a class declared with `attribute()`, read off the
- * pending-modification queue the way `columnsHash`' synthesis does. */
-const declared = (klass: unknown): string[] => declaredAttributeNames.call(klass as never);
+/** The names a class declared with `attribute()` — the `name`s on its own
+ * pending-modification queue (activemodel attribute_registration.rb:33-40),
+ * which holds user declarations only and never schema-sourced columns. */
+const declared = (klass: unknown): string[] => {
+  if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];
+  return (
+    klass as { _pendingAttributeModifications: { name?: string }[] }
+  )._pendingAttributeModifications
+    .map((modification) => modification.name)
+    .filter((name): name is string => name !== undefined);
+};
 
 describe("STI subclass attribute() registration", () => {
   it("keeps subclass attribute() calls on the subclass, not the STI base", () => {

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
-/** The names a class declared with `attribute()` — the `name`s on its own
- * pending-modification queue (activemodel attribute_registration.rb:17-18,77-78),
- * which holds user declarations only and never schema-sourced columns. */
-const declared = (klass: unknown): string[] => {
-  if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];
-  return (
-    klass as { _pendingAttributeModifications: { name?: string }[] }
-  )._pendingAttributeModifications
-    .map((modification) => modification.name)
-    .filter((name): name is string => name !== undefined);
-};
+
+/** ActiveModel's `attribute_names` — `attribute_types.keys`
+ * (activemodel attributes.rb:74-76). ActiveRecord's override gates on
+ * `table_exists?` (attribute_methods.rb:236-241) and would answer `[]` for
+ * these adapter-less classes, so the AM spelling is the one that reads them. */
+const attributeNamesOf = (klass: unknown): string[] =>
+  Object.keys((klass as { attributeTypes(): Record<string, unknown> }).attributeTypes());
 
 describe("STI subclass attribute() registration", () => {
   it("keeps subclass attribute() calls on the subclass, not the STI base", () => {
@@ -26,8 +22,8 @@ describe("STI subclass attribute() registration", () => {
       }
     }
 
-    expect(declared(Circle)).toContain("radius");
-    expect(declared(Shape)).not.toContain("radius");
+    expect(attributeNamesOf(Circle)).toContain("radius");
+    expect(attributeNamesOf(Shape)).not.toContain("radius");
 
     expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
   });
@@ -43,7 +39,7 @@ describe("STI subclass attribute() registration", () => {
 
     // Shape IS the STI base (not a subclass), so its map is its own.
     expect(Object.hasOwn(Shape, "_pendingAttributeModifications")).toBe(true);
-    expect(declared(Shape)).toContain("name");
+    expect(attributeNamesOf(Shape)).toContain("name");
   });
 
   it("non-STI classes are unaffected", () => {
@@ -54,7 +50,7 @@ describe("STI subclass attribute() registration", () => {
     }
 
     expect(Object.hasOwn(Widget, "_pendingAttributeModifications")).toBe(true);
-    expect(declared(Widget)).toContain("price");
+    expect(attributeNamesOf(Widget)).toContain("price");
   });
 
   it("STI subclass attribute declared AFTER base inherits the base's attrs too", () => {
@@ -73,7 +69,7 @@ describe("STI subclass attribute() registration", () => {
 
     expect(Triangle.typeForAttribute("name").name).toBe("string");
     expect(Triangle.typeForAttribute("sides").name).toBe("integer");
-    expect(declared(Shape)).not.toContain("sides");
+    expect(attributeNamesOf(Shape)).not.toContain("sides");
   });
 
   it("STI subclass encrypts() stays on the subclass, unlike attribute()", async () => {
@@ -144,7 +140,7 @@ describe("STI subclass attribute() registration", () => {
     await (loadSchemaFromAdapter as unknown as (this: typeof Base) => Promise<void>).call(Circle);
 
     expect(Shape.typeForAttribute("guid").name).toBe("uuid");
-    expect(declared(Shape)).not.toContain("radius");
+    expect(attributeNamesOf(Shape)).not.toContain("radius");
     expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
     expect(Circle.typeForAttribute("radius").name).toBe("integer");
     expect(Circle.typeForAttribute("guid").name).toBe("uuid");
@@ -173,11 +169,11 @@ describe("STI subclass attribute() registration", () => {
 
     expect(Object.hasOwn(Ticket, "_pendingAttributeModifications")).toBe(true);
     expect(Ticket.typeForAttribute("priority").name).toBe("integer");
-    expect(declared(Shape)).not.toContain("priority");
-    expect(declared(Circle)).not.toContain("priority");
+    expect(attributeNamesOf(Shape)).not.toContain("priority");
+    expect(attributeNamesOf(Circle)).not.toContain("priority");
 
     expect(Object.hasOwn(Circle, "_pendingAttributeModifications")).toBe(true);
-    expect(declared(Shape)).not.toContain("radius");
+    expect(attributeNamesOf(Shape)).not.toContain("radius");
     expect(Circle.typeForAttribute("radius").name).toBe("integer");
 
     // Inherited (shared-ancestor) declarations remain visible on the descendant.

--- a/packages/activerecord/src/sti-attribute-routing.trails.test.ts
+++ b/packages/activerecord/src/sti-attribute-routing.trails.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
 /** The names a class declared with `attribute()` — the `name`s on its own
- * pending-modification queue (activemodel attribute_registration.rb:33-40),
+ * pending-modification queue (activemodel attribute_registration.rb:17-18,77-78),
  * which holds user declarations only and never schema-sourced columns. */
 const declared = (klass: unknown): string[] => {
   if (!Object.hasOwn(klass as object, "_pendingAttributeModifications")) return [];


### PR DESCRIPTION
`declaredAttributeNames` (`packages/activerecord/src/model-schema.ts:374`) was exported carrying:

> `@noRailsEquivalent CONVERGEABLE` — feeds `ensureSchemaLoaded`'s reflection gate, itself a trails-only bridge for Rails' synchronous `load_schema!`.

That gate no longer exists. PR #7091 reduced `ensureSchemaLoaded` to `return this.loadSchema()`, because Rails' `column_names` is `columns.map(&:name)` — purely DB-sourced (`vendor/rails/activerecord/lib/active_record/model_schema.rb:437-441`) — so nothing enumerates declarations to decide whether to reflect. The receipt was false on both halves: it named a caller that is gone, and the surface can simply be deleted rather than converged.

## Changes

- Delete the `declaredAttributeNames` export. The private `declaredAttributes(host)` it wrapped stays — `columnsHash`' synthesized fallback and `loadSchemaBangAnchor` both use it.
- The three trails test files that wrapped it in a local `declared(klass)` helper take the story's converged shape, per assertion:
  - **`sti-attribute-routing`** → `attributeNamesOf()` over the public `attributeTypes()`, which is ActiveModel's `attribute_names` (`activemodel/lib/active_model/attributes.rb:74-76`). AR's override gates on `table_exists?` (`attribute_methods.rb:236-241`) and answers `[]` for these adapter-less classes, so the AM spelling is the one that reads them.
  - **The `not.toContain(<reflected column>)` assertions** were redundant with the adjacent `typeForAttribute` / `columnsHash` checks in the same `it` — dropped.
  - **The three "`loadSchemaFromAdapter` is a no-op" tests**, whose only assertion that was, now assert Rails' `schema_loaded?` (`model_schema.rb:583-584`) directly. "falls through when dataSourceExists returns undefined" asserts the *positive* arm of the same predicate, which is what its name always claimed and what the old assertion did not actually check.

Net −27 LOC; no test renamed.

## Review findings

**Finding 1 (blocking) — fixed.** The first push replaced the export with a hand-rolled `declared()` walking the private `_pendingAttributeModifications` field. The reviewer is right that this is more private-reaching than what it replaced (Rails keeps `pending_attribute_modifications` private, `attribute_registration.rb:77-79`) and that duplicating it three ways is worse still; the story's "Converged shape" allows only public surface or dropping the assertion. That helper is gone in `ab03ca4` — see Changes above for what each of its 31 call sites became.

**Finding 2 — dissolved by the Finding 1 fix.** There is no longer a helper standing in for `declaredAttributes`, so the own-property-vs-ancestor-walk and `PendingDecorator`-filtering divergences the reviewer flagged no longer exist to document.

## Verification

- The three suites pass (39 passed, 1 skipped); `pnpm typecheck` clean.
- `pnpm parity:api:extra:gate` OK (activerecord novel 370/370, total 1168/1168). `parity:api:extra:tighten` narrows 0 dimensions: the member's `@internal` tag had already held it out of the measured surface, which is exactly the RFC 0121 hazard this deletion removes.
- `pnpm parity:api:calls` OK (359 baselined, 286 unreviewed, 103 marks tight) and `pnpm parity:api:calls:args` OK (141 baselined shape rows) — no rows added.

Closes-story: retire-declared-attribute-names
