### PR TITLE
feat(parity): credit the symbol-keyed Concern hook in parity:api:extra (RFC 0115)

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -13,6 +13,8 @@ import {
   gateUnclassified,
   gateStale,
   gateFileTagRejections,
+  concernHookNames,
+  concernHookKey,
 } from "./extra-surface.js";
 import type { TaggedEntry, TaggedSummary } from "./extra-surface.js";
 import { extractFromProgram } from "./extract-ts-api.js";
@@ -294,6 +296,137 @@ describe("buildReport — ActiveSupport::Concern allow-set", () => {
 
   it("does not allow them on a class that does not include the Concern", () => {
     expect(run([]).sort()).toEqual(["modelName", "validates"]);
+  });
+});
+
+describe("concernHookNames", () => {
+  it("credits [included] for an `included do` block", () => {
+    // activemodel/lib/active_model/conversion.rb:27-33 — the block only calls
+    // `class_attribute`, so nothing about it reaches the manifest.
+    const source = [
+      "module ActiveModel",
+      "  module Conversion",
+      "    extend ActiveSupport::Concern",
+      "",
+      "    included do",
+      '      class_attribute :param_delimiter, default: "-"',
+      "    end",
+      "  end",
+      "end",
+    ].join("\n");
+    expect([...concernHookNames(source)]).toEqual(["[included]"]);
+  });
+
+  it("credits [included] for a `def self.included` hook", () => {
+    expect([...concernHookNames("  def self.included(base)\n  end\n")]).toEqual(["[included]"]);
+  });
+
+  it("credits [extended] for a `def self.extended` hook", () => {
+    // activemodel/lib/active_model/callbacks.rb:66.
+    expect([...concernHookNames("    def self.extended(base) # :nodoc:\n    end\n")]).toEqual([
+      "[extended]",
+    ]);
+  });
+
+  it("credits nothing for a module with no hook", () => {
+    const source = ["module ActiveModel", "  module Naming", "  end", "end"].join("\n");
+    expect([...concernHookNames(source)]).toEqual([]);
+  });
+
+  it("does not credit an `included` call that is not the block form", () => {
+    expect([...concernHookNames("  self.included_modules\n  included?(x)\n")]).toEqual([]);
+  });
+});
+
+describe("buildReport — symbol-keyed Concern hook", () => {
+  function makeManifests(): { ruby: ApiManifest; ts: ApiManifest } {
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {},
+          modules: {
+            "ActiveModel::Conversion": {
+              name: "Conversion",
+              file: "conversion.rb",
+              includes: [],
+              extends: ["ActiveSupport::Concern"],
+              instanceMethods: [],
+              classMethods: [],
+            },
+            "ActiveModel::Naming": {
+              name: "Naming",
+              file: "naming.rb",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [],
+            },
+          },
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activemodel: {
+          classes: {
+            Conversion: {
+              name: "Conversion",
+              file: "conversion.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [method("[included]")],
+            },
+            Naming: {
+              name: "Naming",
+              file: "naming.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [method("[included]")],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    return { ruby, ts };
+  }
+
+  const run = (concernHooks: Map<string, Set<string>>): Record<string, string[]> => {
+    const { ruby, ts } = makeManifests();
+    const report = buildReport(ruby, ts, {
+      filterPkg: null,
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+      concernHooks,
+    });
+    return Object.fromEntries(
+      (report.packages[0]?.extraFiles ?? []).map((f) => [f.tsFile, f.extras.map((e) => e.name)]),
+    );
+  };
+
+  it("credits the hook where the Ruby file declares an included block", () => {
+    const hooks = new Map([
+      [concernHookKey("activemodel", "conversion.rb"), new Set(["[included]"])],
+    ]);
+    expect(run(hooks)["conversion.ts"]).toBeUndefined();
+  });
+
+  it("keeps the hook novel where the Ruby file declares none", () => {
+    const hooks = new Map([
+      [concernHookKey("activemodel", "conversion.rb"), new Set(["[included]"])],
+    ]);
+    expect(run(hooks)["naming.ts"]).toEqual(["[included]"]);
+  });
+
+  it("credits nothing when no hooks are supplied", () => {
+    expect(run(new Map())["conversion.ts"]).toEqual(["[included]"]);
   });
 });
 

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -87,7 +87,7 @@
 import * as fs from "fs";
 import * as fsp from "fs/promises";
 import * as path from "path";
-import type { ApiManifest, ClassInfo, MethodInfo } from "@blazetrails/parity/types";
+import type { ApiManifest, ClassInfo, MethodInfo, PackageInfo } from "@blazetrails/parity/types";
 import { OUTPUT_DIR, apiComparePackageRoots } from "./config.js";
 import {
   SKIP,
@@ -1251,7 +1251,7 @@ export function concernHookKey(pkg: string, rubyFile: string): string {
 }
 
 /** Every `.rb` the manifest attributes surface to, in the package's entry. */
-function rubyFilesOf(pkg: ApiManifest["packages"][string]): Set<string> {
+function rubyFilesOf(pkg: PackageInfo): Set<string> {
   const files = new Set<string>();
   for (const info of [...Object.values(pkg.classes), ...Object.values(pkg.modules)]) {
     if (info.file) files.add(info.file);
@@ -1811,9 +1811,6 @@ function buildPackageReport(
       }
     }
 
-    // The symbol-keyed Concern hook: Rails' `included do` / `self.extended`
-    // block is real Rails surface with no method name of its own, so the TS
-    // port of it is not extra — see `concernHookNames`.
     if (rubyFile !== null) {
       for (const hook of concernHooks.get(concernHookKey(pkg, rubyFile)) ?? []) allowed.add(hook);
     }

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -1161,41 +1161,6 @@ function foldClassMethodsModules(modules: Record<string, ClassInfo>): Set<string
 }
 
 /**
- * For one Ruby file's entities, compute the union of all TS candidate names
- * produced by `rubyMethodToTs`. Mirrors `compare.flattenIncludedMethodInfos`
- * mixin routing exactly:
- *
- *   - `include M`: M's instance methods land on the host as instance methods.
- *     A nested `include N` inside M chains through (instance methods only).
- *     M's own `extend` chain does NOT propagate to the host — Ruby `extend`
- *     affects only the receiver's singleton class.
- *   - `extend M` (at host level): M's instance methods land as class methods.
- *   - Module `classMethods` are NOT propagated through include/extend (Ruby
- *     semantics; `flattenIncludedMethodInfos` only pushes `instanceMethods`).
- *     The `ActiveSupport::Concern` "class methods via include" pattern is
- *     handled by `foldClassMethodsModules` above, which moves the nested
- *     `ClassMethods` submodule's instanceMethods into the parent's own
- *     `classMethods` — flattening still only reads `instanceMethods`, so
- *     ASC class methods become entity-level surface, not propagated mixins.
- *   - A mixin whose source file is unported (`UNPORTED_FILES`) is skipped, so
- *     its methods never enter `allowed` — matching the `isSourceUnported`
- *     guard at compare.ts:507. The check uses the module's *owning* package.
- *
- * The matched file's `fileConstants` names join `allowed` too (see
- * `rubyConstantCandidates`): a faithfully-ported `ER_DUP_ENTRY` is not extra
- * surface. Constants have no mixin routing — they belong to the file, not to
- * an entity — so they're added once up front rather than per entity.
- *
- * Since `allowed` is a flat name set (instance vs class collapsed on the TS
- * side anyway), we simply union both `instanceMethods` and `classMethods`
- * for the *host* entity, but ONLY `instanceMethods` for walked-into mixins.
- *
- * `include` names are resolved via compare.ts's `resolveModuleName`, which
- * walks namespace prefixes — `AbstractAdapter` including `"Quoting"` maps
- * only to `ConnectionAdapters::Quoting`, never to PG/MySQL siblings of the
- * same short name. Cross-package / stdlib mixins are silently skipped.
- */
-/**
  * The two symbol-keyed members trails uses to port a Ruby Concern's hooks —
  * `included do ... end` and `def self.extended(base)` — as
  * `static [included](base)` / `static [extended](base)`, keyed by the symbols
@@ -1290,6 +1255,41 @@ export async function loadConcernHooks(
   return hooks;
 }
 
+/**
+ * For one Ruby file's entities, compute the union of all TS candidate names
+ * produced by `rubyMethodToTs`. Mirrors `compare.flattenIncludedMethodInfos`
+ * mixin routing exactly:
+ *
+ *   - `include M`: M's instance methods land on the host as instance methods.
+ *     A nested `include N` inside M chains through (instance methods only).
+ *     M's own `extend` chain does NOT propagate to the host — Ruby `extend`
+ *     affects only the receiver's singleton class.
+ *   - `extend M` (at host level): M's instance methods land as class methods.
+ *   - Module `classMethods` are NOT propagated through include/extend (Ruby
+ *     semantics; `flattenIncludedMethodInfos` only pushes `instanceMethods`).
+ *     The `ActiveSupport::Concern` "class methods via include" pattern is
+ *     handled by `foldClassMethodsModules` above, which moves the nested
+ *     `ClassMethods` submodule's instanceMethods into the parent's own
+ *     `classMethods` — flattening still only reads `instanceMethods`, so
+ *     ASC class methods become entity-level surface, not propagated mixins.
+ *   - A mixin whose source file is unported (`UNPORTED_FILES`) is skipped, so
+ *     its methods never enter `allowed` — matching the `isSourceUnported`
+ *     guard at compare.ts:507. The check uses the module's *owning* package.
+ *
+ * The matched file's `fileConstants` names join `allowed` too (see
+ * `rubyConstantCandidates`): a faithfully-ported `ER_DUP_ENTRY` is not extra
+ * surface. Constants have no mixin routing — they belong to the file, not to
+ * an entity — so they're added once up front rather than per entity.
+ *
+ * Since `allowed` is a flat name set (instance vs class collapsed on the TS
+ * side anyway), we simply union both `instanceMethods` and `classMethods`
+ * for the *host* entity, but ONLY `instanceMethods` for walked-into mixins.
+ *
+ * `include` names are resolved via compare.ts's `resolveModuleName`, which
+ * walks namespace prefixes — `AbstractAdapter` including `"Quoting"` maps
+ * only to `ConnectionAdapters::Quoting`, never to PG/MySQL siblings of the
+ * same short name. Cross-package / stdlib mixins are silently skipped.
+ */
 function collectAllowedNames(
   entities: RubyEntity[],
   pkg: string,

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -85,6 +85,7 @@
  */
 
 import * as fs from "fs";
+import * as fsp from "fs/promises";
 import * as path from "path";
 import type { ApiManifest, ClassInfo, MethodInfo } from "@blazetrails/parity/types";
 import { OUTPUT_DIR, apiComparePackageRoots } from "./config.js";
@@ -102,6 +103,7 @@ import { resolveModuleName } from "./compare.js";
 import { operatorSpelling } from "./operator-order-spelling.js";
 import { isSourceUnported } from "@blazetrails/parity/unported-files";
 import { manifestIsStale } from "./build-freshness.js";
+import { libPathsManifest } from "../../vendor/sources.js";
 
 /**
  * Track the FQN alongside the entity so namespace-scoped include resolution
@@ -1193,6 +1195,101 @@ function foldClassMethodsModules(modules: Record<string, ClassInfo>): Set<string
  * only to `ConnectionAdapters::Quoting`, never to PG/MySQL siblings of the
  * same short name. Cross-package / stdlib mixins are silently skipped.
  */
+/**
+ * The two symbol-keyed members trails uses to port a Ruby Concern's hooks —
+ * `included do ... end` and `def self.extended(base)` — as
+ * `static [included](base)` / `static [extended](base)`, keyed by the symbols
+ * `packages/activesupport/src/include.ts` exports
+ * (`Symbol.for("@blazetrails/activesupport:included")` and its `extended`
+ * twin). CLAUDE.md § "Module mixins" ratifies the shape repo-wide.
+ *
+ * The extractor records a computed member by its source text
+ * (`getMemberName`), so the manifest name IS the bracketed spelling below —
+ * which is also how the symbol import resolves at every site in the repo,
+ * since the binding is imported under the activesupport name.
+ *
+ * The string-named `included` / `extended` / `inherited` methods are a
+ * different thing and stay drift: `SKIP_GROUPS` in `scripts/parity/conventions.ts`
+ * marks them `tsMirrorIsDrift`, and a bracketed name never collides with a
+ * bare one.
+ */
+export const CONCERN_HOOK_MEMBERS = {
+  included: "[included]",
+  extended: "[extended]",
+} as const;
+
+/** `included do ... end` — activemodel/lib/active_model/api.rb:65. */
+const INCLUDED_BLOCK_RE = /^[ \t]*included do\b/m;
+/** `def self.included(base)` — the pre-Concern spelling of the same hook. */
+const SELF_INCLUDED_RE = /^[ \t]*def self\.included\b/m;
+/** `def self.extended(base)` — activemodel/lib/active_model/callbacks.rb:66. */
+const SELF_EXTENDED_RE = /^[ \t]*def self\.extended\b/m;
+
+/**
+ * Which hook members the given Ruby source earns, read off the `.rb` text
+ * rather than the manifest: the extractor flattens an `included do extend X end`
+ * into the module's `extends` and drops a block that only calls
+ * `class_attribute` (conversion.rb:27-33), so the manifest cannot tell a
+ * Concern with a hook from one without.
+ *
+ * The credit is conditional on the Ruby side actually declaring the block, so
+ * a hook written into a TS file whose counterpart has none stays novel and the
+ * rule cannot launder an invented hook.
+ */
+export function concernHookNames(rubySource: string): Set<string> {
+  const names = new Set<string>();
+  if (INCLUDED_BLOCK_RE.test(rubySource) || SELF_INCLUDED_RE.test(rubySource)) {
+    names.add(CONCERN_HOOK_MEMBERS.included);
+  }
+  if (SELF_EXTENDED_RE.test(rubySource)) names.add(CONCERN_HOOK_MEMBERS.extended);
+  return names;
+}
+
+/** Key into the `concernHooks` map: one entry per (package, Ruby file). */
+export function concernHookKey(pkg: string, rubyFile: string): string {
+  return `${pkg}\u0000${rubyFile}`;
+}
+
+/** Every `.rb` the manifest attributes surface to, in the package's entry. */
+function rubyFilesOf(pkg: ApiManifest["packages"][string]): Set<string> {
+  const files = new Set<string>();
+  for (const info of [...Object.values(pkg.classes), ...Object.values(pkg.modules)]) {
+    if (info.file) files.add(info.file);
+  }
+  for (const file of Object.keys(pkg.fileConstants ?? {})) files.add(file);
+  return files;
+}
+
+/**
+ * Read every mapped `.rb` and record the Concern hooks it declares, so
+ * `buildReport` can credit the TS port of each. Done once per run, off the
+ * vendored lib dirs `vendor/sources.ts` already resolves for the extractor; a
+ * file the manifest names but vendor no longer has is simply skipped.
+ */
+export async function loadConcernHooks(
+  ruby: ApiManifest,
+  filterPkg: string | null,
+): Promise<Map<string, Set<string>>> {
+  const libPaths = libPathsManifest();
+  const hooks = new Map<string, Set<string>>();
+  for (const [pkg, rubyPkg] of Object.entries(ruby.packages)) {
+    if (filterPkg !== null && pkg !== filterPkg) continue;
+    const libDir = libPaths[pkg];
+    if (libDir === undefined) continue;
+    for (const rubyFile of rubyFilesOf(rubyPkg)) {
+      let source: string;
+      try {
+        source = await fsp.readFile(path.join(libDir, rubyFile), "utf-8");
+      } catch {
+        continue;
+      }
+      const names = concernHookNames(source);
+      if (names.size > 0) hooks.set(concernHookKey(pkg, rubyFile), names);
+    }
+  }
+  return hooks;
+}
+
 function collectAllowedNames(
   entities: RubyEntity[],
   pkg: string,
@@ -1525,6 +1622,7 @@ function buildPackageReport(
   tagKeys: Set<string>,
   matchedTagKeys: Set<string>,
   fileTagRejections: FileTagRejection[],
+  concernHooks: Map<string, Set<string>>,
 ): PackageTotals {
   const rubyPkg = ruby.packages[pkg];
   const tsPkg = ts.packages[pkg];
@@ -1711,6 +1809,13 @@ function buildPackageReport(
         );
         if (sourceAllowed.has(fn.name)) allowed.add(fn.name);
       }
+    }
+
+    // The symbol-keyed Concern hook: Rails' `included do` / `self.extended`
+    // block is real Rails surface with no method name of its own, so the TS
+    // port of it is not extra — see `concernHookNames`.
+    if (rubyFile !== null) {
+      for (const hook of concernHooks.get(concernHookKey(pkg, rubyFile)) ?? []) allowed.add(hook);
     }
 
     // `compare_range.rb` declares `CompareWithRange`: the container synthesized
@@ -2012,8 +2117,15 @@ export function buildReport(
     excludeGlobs: string[];
     novelOnly: boolean;
     topN: number;
+    /**
+     * Per-(package, Ruby file) Concern hooks from `loadConcernHooks`. Optional
+     * so a caller measuring a synthetic manifest need not stage `.rb` files on
+     * disk; absent, no hook is credited.
+     */
+    concernHooks?: Map<string, Set<string>>;
   },
 ): Report {
+  const concernHooks = opts.concernHooks ?? new Map<string, Set<string>>();
   const tagged = collectTaggedEntries(ts);
   const tagKeys = new Set(tagged.map(allowKeyOf));
   const matchedTagKeys = new Set<string>();
@@ -2041,6 +2153,7 @@ export function buildReport(
         tagKeys,
         matchedTagKeys,
         fileTagRejections,
+        concernHooks,
       ),
     );
   }
@@ -2222,6 +2335,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     excludeGlobs: args.excludeGlobs,
     novelOnly: args.novelOnly,
     topN: args.topN,
+    concernHooks: await loadConcernHooks(ruby, args.filterPkg),
   });
 
   if (args.json) {

--- a/scripts/api-compare/lint-extra-surface-ratchet.ts
+++ b/scripts/api-compare/lint-extra-surface-ratchet.ts
@@ -34,7 +34,7 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { OUTPUT_DIR, ROOT_DIR } from "./config.js";
 import type { ApiManifest } from "@blazetrails/parity/types";
-import { buildReport } from "./extra-surface.js";
+import { buildReport, loadConcernHooks } from "./extra-surface.js";
 import {
   MARK_PATH,
   exceedances,
@@ -59,6 +59,7 @@ async function main(tighten: boolean): Promise<number> {
     excludeGlobs: [],
     novelOnly: false,
     topN: 0,
+    concernHooks: await loadConcernHooks(ruby, null),
   });
   const current = measure(report.packages);
 


### PR DESCRIPTION
`parity:api:extra` scored the symbol-keyed `[included]` / `[extended]` Concern
hook as **novel** surface in every activemodel file that ports an
`ActiveSupport::Concern`. That hook is the sanctioned trails port of Ruby's
`included do ... end` / `def self.extended(base)` block (CLAUDE.md § "Module
mixins", keyed by the symbols `packages/activesupport/src/include.ts` exports),
so the score was a tooling gap, not a port defect.

`extra-surface.ts` now credits the bracketed hook name when the mapped `.rb`
actually declares the block — read off the Ruby source text, because the
extractor flattens `included do extend X end` into the module's `extends` and
drops a block that only calls `class_attribute`
(`activemodel/lib/active_model/conversion.rb:27-33`), so the manifest cannot
tell a Concern with a hook from one without. The credit is per-(package, Ruby
file) and conditional, so a hook in a TS file whose counterpart has none stays
novel.

Rails sites: `api.rb:65`, `conversion.rb:27`, `attributes.rb:35`,
`validations.rb:40`, `serializers/json.rb:12`, `dirty.rb:127`,
`callbacks.rb:66` (`def self.extended`).

Measured after the change (`pnpm parity:api:extra --package activemodel`):
`api.ts`, `conversion.ts`, `attributes.ts`, `callbacks.ts` and `dirty.ts` drop
off the report entirely (0 novel / 0 moved); `validations.ts` and
`serializers/json.ts` go 1 novel → 0 novel. `pnpm parity:api:extra:gate` stays
green with no mark change (arel novel 0/0, total 47/47; activerecord 367/367,
995/995), so there was nothing to tighten.

Note `SKIP_GROUPS` still marks the *string-named* `included` / `extended` /
`inherited` methods `tsMirrorIsDrift` — a bracketed name never collides with a
bare one, so that entry is untouched.

Closes-story: credit-the-concern-included-hook-in-extra-surface
