### PR TITLE
refactor(arel): make Table a standalone class and drop 8 canonical shields

### DIFF
--- a/eslint/no-new-rebuild-canonical-tables.test.mjs
+++ b/eslint/no-new-rebuild-canonical-tables.test.mjs
@@ -14,11 +14,18 @@ import {
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-const LISTED_ONE = "packages/activerecord/src/date.test.ts";
-const LISTED_TWO = "packages/activerecord/src/locking.test.ts";
+// Derived from the baseline rather than hardcoded: RFC 0079 burns these rows
+// down to zero, so a named path is a fixture that any burndown PR deletes out
+// from under this suite. `LISTED_TWO` is absent once no row allows more than
+// one call, and both are absent at the RFC's endpoint — the cases that need
+// them drop out rather than fail.
+const LISTED_ONE = Object.keys(REBUILD_CALLERS).find((rel) => REBUILD_CALLERS[rel] === 1);
+const LISTED_TWO = Object.keys(REBUILD_CALLERS).find((rel) => REBUILD_CALLERS[rel] >= 2);
+const LISTED_TWO_ALLOWED = LISTED_TWO === undefined ? 0 : REBUILD_CALLERS[LISTED_TWO];
 const UNLISTED = "packages/activerecord/src/relations.test.ts";
 
 const CALL = 'await rebuildCanonicalTables(Base.connection, ["topics"]);';
+const calls = (n) => Array.from({ length: n }, () => CALL).join(" ");
 
 const tester = new RuleTester({
   languageOptions: {
@@ -30,16 +37,24 @@ const tester = new RuleTester({
 
 tester.run("no-new-rebuild-canonical-tables", rule, {
   valid: [
-    {
-      name: "a listed file calling exactly its allowance",
-      filename: LISTED_ONE,
-      code: `async function f() { ${CALL} }`,
-    },
-    {
-      name: "a listed file with an allowance of two, calling twice",
-      filename: LISTED_TWO,
-      code: `async function f() { ${CALL} ${CALL} }`,
-    },
+    ...(LISTED_ONE === undefined
+      ? []
+      : [
+          {
+            name: "a listed file calling exactly its allowance",
+            filename: LISTED_ONE,
+            code: `async function f() { ${CALL} }`,
+          },
+        ]),
+    ...(LISTED_TWO === undefined
+      ? []
+      : [
+          {
+            name: "a listed file with an allowance of two, calling twice",
+            filename: LISTED_TWO,
+            code: `async function f() { ${calls(LISTED_TWO_ALLOWED)} }`,
+          },
+        ]),
     {
       name: "an unlisted file that does not call the helper",
       filename: UNLISTED,
@@ -84,30 +99,46 @@ tester.run("no-new-rebuild-canonical-tables", rule, {
       code: `async function f() { ${CALL} ${CALL} }`,
       errors: [{ messageId: "unlistedCaller" }, { messageId: "unlistedCaller" }],
     },
-    {
-      name: "a listed file over its allowance reports only the excess call",
-      filename: LISTED_ONE,
-      code: `async function f() { ${CALL} ${CALL} }`,
-      errors: [{ messageId: "tooManyCalls", data: { allowed: "1", actual: "2" } }],
-    },
-    {
-      name: "two excess calls over an allowance of two report twice",
-      filename: LISTED_TWO,
-      code: `async function f() { ${CALL} ${CALL} ${CALL} ${CALL} }`,
-      errors: [{ messageId: "tooManyCalls" }, { messageId: "tooManyCalls" }],
-    },
-    {
-      name: "a listed file that dropped to zero calls must tighten the baseline",
-      filename: LISTED_ONE,
-      code: "async function f() { return 1; }",
-      errors: [{ messageId: "staleAllowance", data: { allowed: "1", actual: "0" } }],
-    },
-    {
-      name: "a listed file that dropped one of two calls must tighten the baseline",
-      filename: LISTED_TWO,
-      code: `async function f() { ${CALL} }`,
-      errors: [{ messageId: "staleAllowance", data: { allowed: "2", actual: "1" } }],
-    },
+    ...(LISTED_ONE === undefined
+      ? []
+      : [
+          {
+            name: "a listed file over its allowance reports only the excess call",
+            filename: LISTED_ONE,
+            code: `async function f() { ${CALL} ${CALL} }`,
+            errors: [{ messageId: "tooManyCalls", data: { allowed: "1", actual: "2" } }],
+          },
+          {
+            name: "a listed file that dropped to zero calls must tighten the baseline",
+            filename: LISTED_ONE,
+            code: "async function f() { return 1; }",
+            errors: [{ messageId: "staleAllowance", data: { allowed: "1", actual: "0" } }],
+          },
+        ]),
+    ...(LISTED_TWO === undefined
+      ? []
+      : [
+          {
+            name: "two excess calls over an allowance of two report twice",
+            filename: LISTED_TWO,
+            code: `async function f() { ${calls(LISTED_TWO_ALLOWED + 2)} }`,
+            errors: [{ messageId: "tooManyCalls" }, { messageId: "tooManyCalls" }],
+          },
+          {
+            name: "a listed file that dropped one of two calls must tighten the baseline",
+            filename: LISTED_TWO,
+            code: `async function f() { ${calls(LISTED_TWO_ALLOWED - 1)} }`,
+            errors: [
+              {
+                messageId: "staleAllowance",
+                data: {
+                  allowed: String(LISTED_TWO_ALLOWED),
+                  actual: String(LISTED_TWO_ALLOWED - 1),
+                },
+              },
+            ],
+          },
+        ]),
     {
       name: "a file outside packages/ and scripts/ can never be listed, so it reports",
       filename: "tools/scratch.ts",
@@ -167,10 +198,15 @@ describe("rebuild-canonical-tables-callers.json", () => {
 
 describe("scope helpers", () => {
   it("keys the baseline off the repo-relative path, absolute or not", () => {
-    expect(repoRel(`/home/someone/trails/${LISTED_ONE}`)).toBe(LISTED_ONE);
-    expect(repoRel(LISTED_ONE)).toBe(LISTED_ONE);
+    // `UNLISTED` here only because repoRel is about path shape, not membership;
+    // the membership half below reads a real row while the baseline still has
+    // one.
+    expect(repoRel(`/home/someone/trails/${UNLISTED}`)).toBe(UNLISTED);
+    expect(repoRel(UNLISTED)).toBe(UNLISTED);
     expect(repoRel("tools/scratch.ts")).toBeNull();
-    expect(rebuildCallerAllowance(`/abs/prefix/${LISTED_ONE}`)).toBe(REBUILD_CALLERS[LISTED_ONE]);
+    for (const rel of Object.keys(REBUILD_CALLERS)) {
+      expect(rebuildCallerAllowance(`/abs/prefix/${rel}`)).toBe(REBUILD_CALLERS[rel]);
+    }
   });
 
   it("reports an unlisted or out-of-scope file as having no allowance", () => {
@@ -182,7 +218,7 @@ describe("scope helpers", () => {
     for (const rel of HELPER_MODULES) {
       expect(isRebuildHelperModule(`/abs/prefix/${rel}`)).toBe(true);
     }
-    expect(isRebuildHelperModule(LISTED_ONE)).toBe(false);
+    expect(isRebuildHelperModule(UNLISTED)).toBe(false);
   });
 
   it("ignores the JSON contract note rather than treating it as a path", () => {

--- a/eslint/rebuild-canonical-tables-callers.json
+++ b/eslint/rebuild-canonical-tables-callers.json
@@ -1,16 +1,6 @@
 {
-  "//": "RFC 0079 (drop-rebuild-canonical-tables) only-shrink baseline: repo-relative path -> number of rebuildCanonicalTables call sites that file is allowed. Enforced by eslint/no-new-rebuild-canonical-tables.mjs. Entries ONLY shrink: a burndown PR that removes a call decrements the count, or deletes the line when it reaches 0. Never add a row, and never raise a count -- if lint sent you here, stop dropping the canonical table instead. There is no reseed script, by design. Baseline: 26 call sites across 22 files, measured on origin/main at f5d2641f6 (2026-08-26). The helper is deleted, with this file, by the RFC final story.",
-  "packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts": 1,
-  "packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts": 1,
-  "packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts": 1,
-  "packages/activerecord/src/bind-parameter.test.ts": 1,
-  "packages/activerecord/src/custom-locking.test.ts": 1,
-  "packages/activerecord/src/date.test.ts": 1,
-  "packages/activerecord/src/dirty.test.ts": 1,
-  "packages/activerecord/src/dirty.trails.test.ts": 1,
-  "packages/activerecord/src/locking.test.ts": 2,
+  "//": "RFC 0079 (drop-rebuild-canonical-tables) only-shrink baseline: repo-relative path -> number of rebuildCanonicalTables call sites that file is allowed. Enforced by eslint/no-new-rebuild-canonical-tables.mjs. Entries ONLY shrink: a burndown PR that removes a call decrements the count, or deletes the line when it reaches 0. Never add a row, and never raise a count -- if lint sent you here, stop dropping the canonical table instead. There is no reseed script, by design. Baseline: 3 call sites across 3 files. The helper is deleted, with this file, by the RFC final story.",
   "packages/activerecord/src/migration/exclusion-constraint.test.ts": 1,
   "packages/activerecord/src/migration/unique-constraint.test.ts": 1,
-  "packages/activerecord/src/primary-keys.test.ts": 1,
   "packages/activerecord/src/schema-dumper.test.ts": 1
 }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -9,11 +9,13 @@ import {
   MYSQL_TEST_URL,
 } from "./test-helper.js";
 import { Base } from "../../base.js";
+
 describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
     adapter = await leaseMysqlAdapter();
   });
+
   describe("SchemaTest", () => {
     it("float limits", async () => {
       // On MariaDB a bare FLOAT is normalized to DOUBLE in information_schema.columns
@@ -170,6 +172,7 @@ describeIfMysqlAdapter("MySQLAnsiQuotesTest", () => {
     await ansi?.close();
     ansi = undefined;
   });
+
   it("primary key method with ansi quotes", async () => {
     const a = ansi!;
     // Rails reads the canonical `topics` its schema load laid; trails'

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/abstract_mysql_adapter/schema_test.rb
  */
-import { describe, it, beforeEach, afterEach, afterAll, expect } from "vitest";
+import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
   describeIfMysqlAdapter,
   leaseMysqlAdapter,
@@ -9,28 +9,11 @@ import {
   MYSQL_TEST_URL,
 } from "./test-helper.js";
 import { Base } from "../../base.js";
-import { rebuildCanonicalTables } from "../../support/canonical-table-rebuild.js";
-
-/**
- * The four canonical tables this file force-recreates in a bespoke shape, all
- * restored together from one literal list: `require-canonical-rebuild` reads
- * the list at the call site, so forwarding it through a parameter would leave
- * every drop in the file unproven.
- */
-async function restoreCanonicalTables(): Promise<void> {
-  const adapter = await leaseMysqlAdapter();
-  await rebuildCanonicalTables(adapter, ["posts", "topics", "students", "lessons_students"]);
-}
-
 describeIfMysqlAdapter("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
   beforeEach(async () => {
     adapter = await leaseMysqlAdapter();
   });
-  afterAll(async () => {
-    await restoreCanonicalTables();
-  });
-
   describe("SchemaTest", () => {
     it("float limits", async () => {
       // On MariaDB a bare FLOAT is normalized to DOUBLE in information_schema.columns
@@ -71,39 +54,22 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     async function withOmgPost(
       fn: (omgPost: typeof Base, db: string) => Promise<void>,
     ): Promise<void> {
-      // Mirror schema.rb's canonical `posts` create_table (the table @omgpost
-      // rides). Rails loads the whole schema on the shared connection; here the
-      // per-test adapter lays just this table and drops it in the finally.
-      await adapter.createTable("posts", { force: true }, (t: any) => {
-        t.integer("author_id");
-        t.string("title", { null: false });
-        t.text("body", { null: false });
-        t.string("type");
-        t.integer("legacy_comments_count", { default: 0 });
-        t.integer("taggings_with_delete_all_count", { default: 0 });
-        t.integer("taggings_with_destroy_count", { default: 0 });
-        t.integer("tags_count", { default: 0 });
-        t.integer("indestructible_tags_count", { default: 0 });
-        t.integer("tags_with_destroy_count", { default: 0 });
-        t.integer("tags_with_nullify_count", { default: 0 });
-      });
-      try {
-        const db = await adapter.currentDatabase();
-        // Mirror Rails' `def self.name; "Post"` override on the anonymous
-        // @omgpost class. Safe to override the class name here: trails' model
-        // registry is opt-in via registerModel() (no auto-`inherited` hook), and
-        // OmgPost is never registered, so this cannot collide with a canonical
-        // Post.
-        class OmgPost extends Base {
-          static _tableName = `${db}.posts`;
-          static name = "Post";
-        }
-        OmgPost.inheritanceColumn = "disabled";
-        OmgPost.adapter = adapter;
-        await fn(OmgPost, db);
-      } finally {
-        await adapter.dropTable("posts", { ifExists: true });
+      // Rails' schema load lays the canonical `posts` @omgpost rides
+      // (schema_test.rb:19-20 reads `Post.table_name`); trails' per-worker boot
+      // lays the same canonical schema, so ride it rather than re-laying it.
+      const db = await adapter.currentDatabase();
+      // Mirror Rails' `def self.name; "Post"` override on the anonymous
+      // @omgpost class. Safe to override the class name here: trails' model
+      // registry is opt-in via registerModel() (no auto-`inherited` hook), and
+      // OmgPost is never registered, so this cannot collide with a canonical
+      // Post.
+      class OmgPost extends Base {
+        static _tableName = `${db}.posts`;
+        static name = "Post";
       }
+      OmgPost.inheritanceColumn = "disabled";
+      OmgPost.adapter = adapter;
+      await fn(OmgPost, db);
     }
 
     it("schema", async () => {
@@ -115,8 +81,14 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
           "INSERT INTO `posts` (`title`, `body`, `type`) " +
             "VALUES ('Welcome to the weblog', 'Such a lovely day', 'Post')",
         );
-        const first = await (OmgPost as any).first();
-        expect(first).toBeTruthy();
+        try {
+          const first = await (OmgPost as any).first();
+          expect(first).toBeTruthy();
+        } finally {
+          await adapter.executeMutation(
+            "DELETE FROM `posts` WHERE `title` = 'Welcome to the weblog'",
+          );
+        }
       });
     });
 
@@ -198,65 +170,29 @@ describeIfMysqlAdapter("MySQLAnsiQuotesTest", () => {
     await ansi?.close();
     ansi = undefined;
   });
-  afterAll(async () => {
-    await restoreCanonicalTables();
-  });
-
   it("primary key method with ansi quotes", async () => {
     const a = ansi!;
-    // Mirror schema.rb's canonical `topics` create_table.
-    await a.createTable("topics", { force: true }, (t: any) => {
-      t.string("title", { limit: 250 });
-      t.string("author_name");
-      t.string("author_email_address");
-      // MySQL upgrades bare DATETIME to DATETIME(6) (Rails datetime-with-precision),
-      // matching the boot-laid canonical `topics` — pass precision explicitly.
-      t.datetime("written_on", { precision: 6 });
-      t.time("bonus_time");
-      t.date("last_read");
-      t.text("content");
-      t.text("important");
-      t.binary("binary_content");
-      t.boolean("approved", { default: true });
-      t.integer("replies_count", { default: 0 });
-      t.integer("unique_replies_count", { default: 0 });
-      t.integer("parent_id");
-      t.string("parent_title");
-      t.string("type");
-      t.string("group");
-      t.datetime("created_at", { null: true, precision: 6 });
-      t.datetime("updated_at", { null: true, precision: 6 });
-      t.index(["author_name", "title"]);
-    });
-    try {
-      expect(await a.primaryKey("topics")).toBe("id");
-    } finally {
-      await a.dropTable("topics", { ifExists: true });
-    }
+    // Rails reads the canonical `topics` its schema load laid; trails'
+    // per-worker boot lays the same table, so read it in place.
+    expect(await a.primaryKey("topics")).toBe("id");
   });
 
   it("foreign keys method with ansi quotes", async () => {
     const a = ansi!;
-    // Mirrors Rails test/schema/schema.rb: lessons_students is id:false with a
-    // student_id referencing students(id) — both from the canonical schema.
-    await a.createTable("students", { force: true }, (t: any) => {
-      t.string("name");
-      t.boolean("active");
-      t.integer("college_id");
-    });
-    await a.createTable("lessons_students", { force: true, id: false }, (t: any) => {
-      t.bigint("lesson_id");
-      t.bigint("student_id");
-    });
+    // Rails' schema.rb:715-726 lays `lessons_students` / `students` AND the
+    // `add_foreign_key :lessons_students, :students, on_delete: :cascade` this
+    // reads. trails' canonical schema lays the two tables but not the FK yet
+    // (`canonical-schema.ts:1074`), so add it here and take it back off again —
+    // the canonical shape is shared, and no rebuild is needed to restore it.
+    await a.addForeignKey("lessons_students", "students", { onDelete: "cascade" });
     try {
-      await a.addForeignKey("lessons_students", "students", { onDelete: "cascade" });
       const fks = await a.foreignKeys("lessons_students");
       expect(fks).toHaveLength(1);
       expect(fks[0].fromTable).toBe("lessons_students");
       expect(fks[0].toTable).toBe("students");
       expect(fks[0].onDelete).toBe("cascade");
     } finally {
-      await a.dropTable("lessons_students", "students", { ifExists: true });
+      await a.removeForeignKey("lessons_students", "students");
     }
   });
 });

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema.test.ts
@@ -183,10 +183,12 @@ describeIfMysqlAdapter("MySQLAnsiQuotesTest", () => {
   it("foreign keys method with ansi quotes", async () => {
     const a = ansi!;
     // Rails' schema.rb:715-726 lays `lessons_students` / `students` AND the
-    // `add_foreign_key :lessons_students, :students, on_delete: :cascade` this
-    // reads. trails' canonical schema lays the two tables but not the FK yet
-    // (`canonical-schema.ts:1074`), so add it here and take it back off again —
-    // the canonical shape is shared, and no rebuild is needed to restore it.
+    // `add_foreign_key :lessons_students, :students, on_delete: :cascade,
+    // deferrable: :immediate` this reads, so schema_test.rb:125-128 is a bare
+    // read. trails' canonical schema lays the two tables but not the FK
+    // (`canonical-schema.ts:1074`), so it is added and taken back off here
+    // until `lessons-students-canonical-foreign-key` closes that gap; then
+    // this reverts to the bare read.
     await a.addForeignKey("lessons_students", "students", { onDelete: "cascade" });
     try {
       const fks = await a.foreignKeys("lessons_students");

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -37,7 +37,6 @@ import {
 } from "../../errors.js";
 import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
 import { NullPool } from "../../connection-adapters/abstract/connection-pool.js";
-import { rebuildCanonicalTables } from "../../support/canonical-table-rebuild.js";
 import { Result } from "../../result.js";
 import { Base } from "../../base.js";
 import { Logger } from "@blazetrails/activesupport";
@@ -177,19 +176,6 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
     }
   });
 
-  beforeEach(async () => {
-    await adapter.executeMutation("SET FOREIGN_KEY_CHECKS=0");
-    for (const t of ["foos", "engines", "old_cars", "cars", "subscribers", "people"]) {
-      await adapter.executeMutation(`DROP TABLE IF EXISTS \`${t}\``);
-    }
-    await adapter.executeMutation("SET FOREIGN_KEY_CHECKS=1");
-    await rebuildCanonicalTables(adapter, ["people", "cars", "old_cars", "subscribers", "engines"]);
-  });
-
-  afterEach(async () => {
-    await adapter.executeMutation("DROP TABLE IF EXISTS `foos`");
-  });
-
   it("errors for bigint fks on integer pk table in alter table", async () => {
     const error = await adapter
       .addReference("engines", "old_car")
@@ -207,6 +193,9 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
     );
     expect(error.cause).toBeInstanceOf(Error);
     expect(error.connectionPool).toBe(adapter.pool);
+
+    // Rails: `ensure @conn.execute("ALTER TABLE engines DROP COLUMN old_car_id") rescue nil`
+    await adapter.executeMutation("ALTER TABLE engines DROP COLUMN old_car_id").catch(() => null);
   });
 
   // Rails: `skip "MariaDB does not return mismatched foreign key in error message" if @conn.mariadb?`
@@ -226,88 +215,108 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
       expect(error.message).toMatch(/which has type `int/i);
       expect(error.cause).toBeInstanceOf(Error);
       expect(error.connectionPool).toBe(adapter.pool);
+
+      // Rails' `ensure` block: `@conn.remove_reference(:engines, :person)` /
+      // `@conn.remove_reference(:engines, :old_car)`.
+      await adapter.removeReference("engines", "person");
+      await adapter.removeReference("engines", "old_car");
     },
   );
 
   it("errors for bigint fks on integer pk table in create table", async () => {
-    const error = await adapter
-      .executeMutation(
-        `
-          CREATE TABLE \`foos\` (
-            \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-            \`old_car_id\` BIGINT,
-            INDEX \`idx_old_car_id\` (\`old_car_id\`),
-            CONSTRAINT \`fk_foos_old_car\` FOREIGN KEY (\`old_car_id\`) REFERENCES \`old_cars\` (\`id\`)
-          ) ENGINE=InnoDB
-        `,
-      )
-      .then(() => null)
-      .catch((e) => e);
+    try {
+      const error = await adapter
+        .executeMutation(
+          `
+            CREATE TABLE \`foos\` (
+              \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+              \`old_car_id\` BIGINT,
+              INDEX \`idx_old_car_id\` (\`old_car_id\`),
+              CONSTRAINT \`fk_foos_old_car\` FOREIGN KEY (\`old_car_id\`) REFERENCES \`old_cars\` (\`id\`)
+            ) ENGINE=InnoDB
+          `,
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-    expect(error).toBeInstanceOf(MismatchedForeignKey);
-    expect(error.message).toMatch(
-      /Column `old_car_id` on table `foos` does not match column `id` on `old_cars`/,
-    );
-    expect(error.message).toMatch(/which has type `int/i);
-    expect(error.message).toMatch(
-      /To resolve this issue, change the type of the `old_car_id` column on `foos` to be :integer/,
-    );
-    expect(error.cause).toBeInstanceOf(Error);
-    expect(error.connectionPool).toBe(adapter.pool);
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `old_car_id` on table `foos` does not match column `id` on `old_cars`/,
+      );
+      expect(error.message).toMatch(/which has type `int/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `old_car_id` column on `foos` to be :integer/,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.connectionPool).toBe(adapter.pool);
+    } finally {
+      // Rails: `ensure @conn.drop_table :foos, if_exists: true`
+      await adapter.dropTable("foos", { ifExists: true });
+    }
   });
 
   it("errors for integer fks on bigint pk table in create table", async () => {
-    const error = await adapter
-      .executeMutation(
-        `
-          CREATE TABLE \`foos\` (
-            \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-            \`car_id\` INT,
-            INDEX \`idx_car_id\` (\`car_id\`),
-            CONSTRAINT \`fk_foos_car\` FOREIGN KEY (\`car_id\`) REFERENCES \`cars\` (\`id\`)
-          ) ENGINE=InnoDB
-        `,
-      )
-      .then(() => null)
-      .catch((e) => e);
+    try {
+      const error = await adapter
+        .executeMutation(
+          `
+            CREATE TABLE \`foos\` (
+              \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+              \`car_id\` INT,
+              INDEX \`idx_car_id\` (\`car_id\`),
+              CONSTRAINT \`fk_foos_car\` FOREIGN KEY (\`car_id\`) REFERENCES \`cars\` (\`id\`)
+            ) ENGINE=InnoDB
+          `,
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-    expect(error).toBeInstanceOf(MismatchedForeignKey);
-    expect(error.message).toMatch(
-      /Column `car_id` on table `foos` does not match column `id` on `cars`/,
-    );
-    expect(error.message).toMatch(/which has type `bigint/i);
-    expect(error.message).toMatch(
-      /To resolve this issue, change the type of the `car_id` column on `foos` to be :bigint/,
-    );
-    expect(error.cause).toBeInstanceOf(Error);
-    expect(error.connectionPool).toBe(adapter.pool);
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `car_id` on table `foos` does not match column `id` on `cars`/,
+      );
+      expect(error.message).toMatch(/which has type `bigint/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `car_id` column on `foos` to be :bigint/,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.connectionPool).toBe(adapter.pool);
+    } finally {
+      // Rails: `ensure @conn.drop_table :foos, if_exists: true`
+      await adapter.dropTable("foos", { ifExists: true });
+    }
   });
 
   it("errors for bigint fks on string pk table in create table", async () => {
-    const error = await adapter
-      .executeMutation(
-        `
-          CREATE TABLE \`foos\` (
-            \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-            \`subscriber_id\` BIGINT,
-            INDEX \`idx_subscriber_id\` (\`subscriber_id\`),
-            CONSTRAINT \`fk_foos_subscriber\` FOREIGN KEY (\`subscriber_id\`) REFERENCES \`subscribers\` (\`nick\`)
-          ) ENGINE=InnoDB
-        `,
-      )
-      .then(() => null)
-      .catch((e) => e);
+    try {
+      const error = await adapter
+        .executeMutation(
+          `
+            CREATE TABLE \`foos\` (
+              \`id\` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+              \`subscriber_id\` BIGINT,
+              INDEX \`idx_subscriber_id\` (\`subscriber_id\`),
+              CONSTRAINT \`fk_foos_subscriber\` FOREIGN KEY (\`subscriber_id\`) REFERENCES \`subscribers\` (\`nick\`)
+            ) ENGINE=InnoDB
+          `,
+        )
+        .then(() => null)
+        .catch((e) => e);
 
-    expect(error).toBeInstanceOf(MismatchedForeignKey);
-    expect(error.message).toMatch(
-      /Column `subscriber_id` on table `foos` does not match column `nick` on `subscribers`/,
-    );
-    expect(error.message).toMatch(/which has type `varchar/i);
-    expect(error.message).toMatch(
-      /To resolve this issue, change the type of the `subscriber_id` column on `foos` to be :string/,
-    );
-    expect(error.cause).toBeInstanceOf(Error);
-    expect(error.connectionPool).toBe(adapter.pool);
+      expect(error).toBeInstanceOf(MismatchedForeignKey);
+      expect(error.message).toMatch(
+        /Column `subscriber_id` on table `foos` does not match column `nick` on `subscribers`/,
+      );
+      expect(error.message).toMatch(/which has type `varchar/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `subscriber_id` column on `foos` to be :string/,
+      );
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.connectionPool).toBe(adapter.pool);
+    } finally {
+      // Rails: `ensure @conn.drop_table :foos, if_exists: true`
+      await adapter.dropTable("foos", { ifExists: true });
+    }
   });
 
   it("read timeout exception", () => {

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -177,34 +177,10 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
   });
 
   it("errors for bigint fks on integer pk table in alter table", async () => {
-    const error = await adapter
-      .addReference("engines", "old_car")
-      .then(() => adapter.addForeignKey("engines", "old_cars"))
-      .then(() => null)
-      .catch((e) => e);
-
-    expect(error).toBeInstanceOf(MismatchedForeignKey);
-    expect(error.message).toMatch(
-      /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
-    );
-    expect(error.message).toMatch(/which has type `int/i);
-    expect(error.message).toMatch(
-      /To resolve this issue, change the type of the `old_car_id` column on `engines` to be :integer/,
-    );
-    expect(error.cause).toBeInstanceOf(Error);
-    expect(error.connectionPool).toBe(adapter.pool);
-
-    // Rails: `ensure @conn.execute("ALTER TABLE engines DROP COLUMN old_car_id") rescue nil`
-    await adapter.executeMutation("ALTER TABLE engines DROP COLUMN old_car_id").catch(() => null);
-  });
-
-  // Rails: `skip "MariaDB does not return mismatched foreign key in error message" if @conn.mariadb?`
-  it.skipIf(isMariaDb)(
-    "errors for multiple fks on mismatched types for pk table in alter table",
-    async () => {
+    try {
       const error = await adapter
-        .addReference("engines", "person", { foreignKey: true })
-        .then(() => adapter.addReference("engines", "old_car", { foreignKey: true }))
+        .addReference("engines", "old_car")
+        .then(() => adapter.addForeignKey("engines", "old_cars"))
         .then(() => null)
         .catch((e) => e);
 
@@ -213,13 +189,41 @@ describeIfMysqlAdapter("Mysql2AdapterTest", () => {
         /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
       );
       expect(error.message).toMatch(/which has type `int/i);
+      expect(error.message).toMatch(
+        /To resolve this issue, change the type of the `old_car_id` column on `engines` to be :integer/,
+      );
       expect(error.cause).toBeInstanceOf(Error);
       expect(error.connectionPool).toBe(adapter.pool);
+    } finally {
+      // Rails: `ensure @conn.execute("ALTER TABLE engines DROP COLUMN old_car_id") rescue nil`
+      await adapter.executeMutation("ALTER TABLE engines DROP COLUMN old_car_id").catch(() => null);
+    }
+  });
 
-      // Rails' `ensure` block: `@conn.remove_reference(:engines, :person)` /
-      // `@conn.remove_reference(:engines, :old_car)`.
-      await adapter.removeReference("engines", "person");
-      await adapter.removeReference("engines", "old_car");
+  // Rails: `skip "MariaDB does not return mismatched foreign key in error message" if @conn.mariadb?`
+  it.skipIf(isMariaDb)(
+    "errors for multiple fks on mismatched types for pk table in alter table",
+    async () => {
+      try {
+        const error = await adapter
+          .addReference("engines", "person", { foreignKey: true })
+          .then(() => adapter.addReference("engines", "old_car", { foreignKey: true }))
+          .then(() => null)
+          .catch((e) => e);
+
+        expect(error).toBeInstanceOf(MismatchedForeignKey);
+        expect(error.message).toMatch(
+          /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
+        );
+        expect(error.message).toMatch(/which has type `int/i);
+        expect(error.cause).toBeInstanceOf(Error);
+        expect(error.connectionPool).toBe(adapter.pool);
+      } finally {
+        // Rails' `ensure` block: `@conn.remove_reference(:engines, :person)` /
+        // `@conn.remove_reference(:engines, :old_car)`.
+        await adapter.removeReference("engines", "person");
+        await adapter.removeReference("engines", "old_car");
+      }
     },
   );
 

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -32,7 +32,6 @@ import {
   ValueTooLong,
 } from "../../errors.js";
 import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
-import { rebuildCanonicalTables } from "../../support/canonical-table-rebuild.js";
 import { Result } from "../../result.js";
 import { Base } from "../../base.js";
 
@@ -237,11 +236,9 @@ describeIfMysqlAdapter("Mysql2Adapter (trails extensions)", () => {
   it("#exec_query queries with an empty result set still return the columns", async () => {
     // Mirrors adapter_test.rb: a zero-row SELECT must still report its
     // columns from the field descriptors, not collapse to an empty Result.
-    // Rails runs this against the canonical `subscribers` fixture table; this
-    // suite does not bootstrap the canonical schema, so lay the canonical table
-    // through the canonical loader rather than hand-rolling its DDL. It is left in place afterwards on purpose: this suite shares the
-    // per-worker database with every other file.
-    await rebuildCanonicalTables(adapter, ["subscribers"]);
+    // Rails runs this against the canonical `subscribers` fixture table, which
+    // its schema load lays; trails' per-worker boot (`test-setup-dy.ts`) lays
+    // the same canonical schema, so the table is already there.
     const result = await adapter.execQuery("SELECT * FROM subscribers WHERE 1=0");
     expect(result).toBeInstanceOf(Result);
     expect(result.rows).toEqual([]);

--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -12,7 +12,6 @@ import { QueryAttribute } from "./relation/query-attribute.js";
 import { Base, RecordNotFound } from "./index.js";
 import { registerModel } from "./associations.js";
 import { fixtures } from "./test-fixtures.js";
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { currentAdapter } from "./support/adapter-helper.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Author } from "./test-helpers/models/author.js";
@@ -80,18 +79,6 @@ describe("BindParameterTest", () => {
   fixtures(["topics", "authors", "authorAddresses", "posts"]);
 
   beforeAll(async () => {
-    // A sibling file (e.g. coders/json.test.ts's SerializedTopic) physically
-    // replaces `topics` with a bespoke shape lacking `author_name`. The worker's
-    // canonical-schema preload keeps the signature cache warm, so the fixtures'
-    // own load then fails with "table topics has no column named author_name".
-    // Drop + recreate the canonical shape verbatim (mirrors the shield in
-    // locking.test.ts / dirty.test.ts).
-    await rebuildCanonicalTables(Base.connection, [
-      "topics",
-      "authors",
-      "author_addresses",
-      "posts",
-    ]);
     registerModel(Author);
     registerModel(Post);
   });

--- a/packages/activerecord/src/custom-locking.test.ts
+++ b/packages/activerecord/src/custom-locking.test.ts
@@ -2,20 +2,14 @@
  * Mirrors: activerecord/test/cases/custom_locking_test.rb
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { adapterType } from "./test-adapter.js";
-import { Base } from "./base.js";
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { fixtures } from "./test-fixtures.js";
 import { Person } from "./test-helpers/models/person.js";
 import { assertQueriesMatch } from "./testing/query-assertions.js";
 
 describe("CustomLockingTest", () => {
   const { people } = fixtures(["people"]);
-  beforeAll(async () => {
-    await rebuildCanonicalTables(Base.connection, ["people"]);
-  });
-
   it.skipIf(adapterType !== "mysql")("custom lock", async () => {
     expect(Person.lock("LOCK IN SHARE MODE").toSql()).toMatch("SHARE MODE");
     await assertQueriesMatch(/LOCK IN SHARE MODE/, undefined, false, async () => {

--- a/packages/activerecord/src/date.test.ts
+++ b/packages/activerecord/src/date.test.ts
@@ -3,8 +3,6 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { Temporal } from "@blazetrails/date";
-import { Base } from "./base.js";
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { fixtures } from "./test-fixtures.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
@@ -16,17 +14,7 @@ describe("DateTest", () => {
   // parallel forks.
   fixtures(["topics"]);
 
-  // Force-recreate the canonical `topics` table to its full shape. The table
-  // comes from the template clone and nothing else recreates it, so a reduced
-  // `topics` shape (e.g. `attribute-methods.test.ts` / `finder.test.ts` both
-  // declare a bespoke `topics` with NO `last_read` column) that a sibling handler-suite file
-  // co-scheduled earlier in the same fork wrote to the shared worker DB. The
-  // date cases below `Topic.create({ last_read })` then fail with a missing
-  // `last_read` column — the documented PG flake. `rebuildCanonicalTables`
-  // drops + recreates `topics` unconditionally so the column is always present.
-  // Registered after `fixtures` so this `beforeAll` runs last and wins.
   beforeAll(async () => {
-    await rebuildCanonicalTables(Base.connection, ["topics"]);
     // Eagerly resolve the `last_read` date type (Rails loads schema at boot). The
     // `assign valid dates` case below builds `Topic.new` synchronously, so without
     // a warmed type registry the multiparameter assembler can't see `last_read` is

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -30,7 +30,6 @@ import { itIfSupports } from "./support/supports.js";
 import { describeIfPostgresqlAdapter } from "./support/describe-if-postgresql-adapter.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { fixtures } from "./test-fixtures.js";
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 
 import { Pirate } from "./test-helpers/models/pirate.js";
 import { Parrot, LiveParrot } from "./test-helpers/models/parrot.js";
@@ -105,31 +104,7 @@ describe("DirtyTest", () => {
   // Rails' in-test create_table); run it outside the wrapping transaction so
   // MySQL's DDL implicit-commit can't break the fixture rollback.
   fixtures([], { usesTransaction: ["field named field"] });
-
-  // Canonical-schema shield. This suite rides the preloaded canonical tables
-  // (people / topics / pirates / parrots / aircraft / numeric_data) rather than
-  // declaring its own, so the worker's signature cache keeps each plain schema
-  // load a no-op. But a sibling file that ran earlier in this worker can physically
-  // DROP+CREATE a shared table with a reduced shape (e.g. callbacks.test.ts'
-  // `topics: { title }` / `people: { name }`, clone.test.ts' trimmed `topics`,
-  // reflection.test.ts' `people: { name, age, active }`). That leaves the table
-  // missing the columns these tests read — `written_on` (datetime tests) and
-  // `created_at`/`updated_at` (whose auto-write is the only thing populating
-  // `saved_changes` after an INSERT) — so the suite reflects the wrong shape and
-  // fails. `rebuildCanonicalTables` bypasses the signature cache and rebuilds
-  // each table from the canonical schema verbatim (also clearing the adapter's
-  // per-table column cache via `createTable`), mirroring locking.test.ts' shield. The
-  // warm-up below then reflects the rebuilt canonical columns.
   beforeAll(async () => {
-    await rebuildCanonicalTables(Base.connection, [
-      "people",
-      "topics",
-      "pirates",
-      "parrots",
-      "aircraft",
-      "numeric_data",
-    ]);
-
     // Force schema reflection ONCE per worker: trails reflects columns lazily on
     // first query, and in-memory dirty tracking (`new Model()` then assign) needs
     // the attribute accessors to already exist.

--- a/packages/activerecord/src/dirty.trails.test.ts
+++ b/packages/activerecord/src/dirty.trails.test.ts
@@ -9,16 +9,14 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 import { fixtures } from "./test-fixtures.js";
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 type Rec = Base & Record<string, unknown>;
 
 describe("Dirty restore of an in-place mutation", () => {
-  fixtures([]);
+  fixtures(["topics"]);
 
   beforeAll(async () => {
-    await rebuildCanonicalTables(Base.connection, ["topics"]);
     await Topic.first();
   });
 

--- a/packages/activerecord/src/locking.test.ts
+++ b/packages/activerecord/src/locking.test.ts
@@ -14,7 +14,6 @@ import {
 } from "./index.js";
 import { Associations, association } from "./associations.js";
 
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { fixtures } from "./test-fixtures.js";
 import { Person, RichPerson } from "./test-helpers/models/person.js";
 import { Frog } from "./test-helpers/models/frog.js";
@@ -55,36 +54,6 @@ describe("OptimisticLockingTest", () => {
     "peoplesTreasures",
   ]);
   beforeAll(async () => {
-    // Force-recreate every canonical table this suite touches. The worker's
-    // canonical schema preload keeps their signatures cache-warm, so a plain
-    // schema load (including the fixtures' own) is a no-op — meaning a sibling
-    // file that physically replaced a table with a bespoke shape (e.g.
-    // autosave-association's `people: { name, first_name }`) would survive into
-    // this suite. Drop + recreate them from the canonical schema verbatim, so we
-    // never write a reduced shape that could in turn contaminate later suites.
-    // Covers the fixture tables plus the bespoke-class tables: `ships`
-    // (ReadonlyNameShip) and the `lock_without_defaults*` pair (Rails:
-    // `t.timestamps null: true`). The `jobs`/`comments`/`personal_legacy_things`
-    // tables back Person's `dependent:` associations, which `destroy with dirty
-    // primary key` traverses (see the model registrations below).
-    await rebuildCanonicalTables(Base.connection, [
-      "people",
-      "references",
-      "legacy_things",
-      "string_key_objects",
-      "ships",
-      "lock_without_defaults",
-      "lock_without_defaults_cust",
-      "treasures",
-      "peoples_treasures",
-      "cars",
-      "wheels",
-      "bulbs",
-      "engines",
-      "jobs",
-      "comments",
-      "personal_legacy_things",
-    ]);
     registerModel("Car", Car);
     registerModel("Wheel", Wheel);
     registerModel("Bulb", Bulb);
@@ -672,15 +641,6 @@ describe("OptimisticLockingWithSchemaChangeTest", () => {
   ];
   const { people, legacyThings } = fixtures(["people", "legacyThings", "references"], {
     usesTransaction: schemaChangeTests,
-  });
-  beforeAll(async () => {
-    await rebuildCanonicalTables(Base.connection, [
-      "people",
-      "legacy_things",
-      "personal_legacy_things",
-      "lock_without_defaults",
-      "lock_without_defaults_cust",
-    ]);
   });
 
   // Mirrors Rails' private add_counter_column_to / remove_counter_column_from

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -7,7 +7,6 @@ import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-fixtures.js";
-import { rebuildCanonicalTables } from "./support/canonical-table-rebuild.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Reply, SillyReply } from "./test-helpers/models/reply.js";
 import { Keyboard } from "./test-helpers/models/keyboard.js";
@@ -29,17 +28,6 @@ describe("PrimaryKeysTest", () => {
   beforeAll(async () => {
     registerModel(Reply);
     registerModel(SillyReply);
-    await rebuildCanonicalTables(Base.connection, [
-      "topics",
-      "subscribers",
-      "movies",
-      "dashboards",
-      "non_primary_keys",
-      "developers",
-      "developers_projects",
-      "cpk_books",
-      "countries",
-    ]);
   });
 
   it("to key with default primary key", async () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1188,13 +1188,12 @@ export class Relation<T extends Base> {
     // an Arel `SelectManager`, so the throwaway manager is the `[]`.
     const arel = new SelectManager(this.table);
     this.buildJoins(arel);
-    const joinedTables = arel
-      .joinSources()
-      .flatMap((join: Nodes.Join) =>
-        join instanceof Nodes.StringJoin
-          ? this.tablesInString(join.left)
-          : [(join.left as unknown as { name: string }).name],
-      );
+    const joinedTables = arel.joinSources().flatMap((join: Nodes.Join) =>
+      join instanceof Nodes.StringJoin
+        ? // A StringJoin's left is the raw SQL fragment, never a Table.
+          this.tablesInString(join.left as Nodes.Node)
+        : [(join.left as unknown as { name: string }).name],
+    );
 
     joinedTables.push(String(this.table.name));
 

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -1,4 +1,5 @@
 import type { Node } from "./nodes/node.js";
+import type { Table } from "./table.js";
 import { And } from "./nodes/nary.js";
 import { buildQuoted } from "./nodes/casted.js";
 import type { Join, NodeOrValue } from "./nodes/binary.js";
@@ -32,11 +33,11 @@ import { On } from "./nodes/unary.js";
 export interface FactoryMethodsModule {
   createTrue(): True;
   createFalse(): False;
-  createTableAlias(relation: Node, name: string | SqlLiteral): TableAlias;
+  createTableAlias(relation: Node | Table, name: string | SqlLiteral): TableAlias;
   createJoin(
-    to: Node | string,
+    to: Node | Table | string,
     constraint?: Node | string | null,
-    klass?: new (left: Node, right: Node | null) => Join,
+    klass?: new (left: Node | Table, right: Node | null) => Join,
   ): Join;
   createStringJoin(to: string | Node): StringJoin;
   createAnd(clauses: (Node | string)[]): And;
@@ -56,16 +57,16 @@ export const FactoryMethods: FactoryMethodsModule = {
     return new False();
   },
 
-  createTableAlias(relation: Node, name: string | SqlLiteral): TableAlias {
+  createTableAlias(relation: Node | Table, name: string | SqlLiteral): TableAlias {
     return new TableAlias(relation, name);
   },
 
   // Rails' create_join/create_and are duck-typed and its own tests exercise
   // them with bare strings, so the params admit `string` like Table#createJoin.
   createJoin(
-    to: Node | string,
+    to: Node | Table | string,
     constraint?: Node | string | null,
-    klass?: new (left: Node, right: Node | null) => Join,
+    klass?: new (left: Node | Table, right: Node | null) => Join,
   ): Join {
     const JoinKlass = klass ?? InnerJoin;
     return new JoinKlass(to as Node, (constraint ?? null) as Node | null);

--- a/packages/arel/src/factory-methods.ts
+++ b/packages/arel/src/factory-methods.ts
@@ -62,7 +62,7 @@ export const FactoryMethods: FactoryMethodsModule = {
   },
 
   // Rails' create_join/create_and are duck-typed and its own tests exercise
-  // them with bare strings, so the params admit `string` like Table#createJoin.
+  // them with bare strings, so the params admit `string` too.
   createJoin(
     to: Node | Table | string,
     constraint?: Node | string | null,

--- a/packages/arel/src/index.ts
+++ b/packages/arel/src/index.ts
@@ -58,7 +58,11 @@ type RuntimeModule = Record<string, (...args: unknown[]) => unknown>;
 const asRuntime = <T>(m: T): RuntimeModule => m as unknown as RuntimeModule;
 include(_Node, asRuntime(FactoryMethods));
 // Arel::Table includes FactoryMethods and AliasPredication (table.rb:5-6).
-include(_TableClass as unknown as new (...args: unknown[]) => object, asRuntime(AliasPredication));
+// `Table` is a standalone class upstream (table.rb:4), so it does not inherit
+// FactoryMethods from Node the way the node tree does.
+const _Table = _TableClass as unknown as new (...args: unknown[]) => object;
+include(_Table, asRuntime(FactoryMethods));
+include(_Table, asRuntime(AliasPredication));
 include(_TreeManager, asRuntime(FactoryMethods));
 // Mirrors Rails: Arel::Nodes::NodeExpression includes Expressions,
 // Predications, AliasPredication, OrderPredications, Math.

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -11,6 +11,7 @@ import { Not } from "./unary.js";
 import { Grouping } from "./grouping.js";
 import type { Cte } from "./cte.js";
 import type { SelectManager } from "../select-manager.js";
+import type { Table } from "../table.js";
 
 // `ModelAttribute` is not an Arel node but occupies node slots in Rails:
 // `build_quoted` returns one unwrapped into the AST (casted.rb:50), and both
@@ -43,6 +44,12 @@ export type NodeOrValue =
   // `visit_Arel_SelectManager` (to_sql.rb:358-361) is a real rendering visitor
   // that wraps `o.ast` in parens, so nothing here can reach `unsupported`.
   | SelectManager
+  // `Arel::Table` is a standalone class upstream (table.rb:4), not a Node, yet
+  // it occupies node slots throughout: `JoinSource#initialize`'s
+  // `single_source` (join_source.rb:11), `TableAlias`'s relation
+  // (table_alias.rb:8-10), and a `Join`'s left. `visit_Arel_Table`
+  // (to_sql.rb:895-901) is a real rendering visitor for it.
+  | Table
   // Rails puts bare Strings in node slots structurally: `Cte#initialize` stores
   // the CTE name as `@left` (cte.rb:10-12), `TableAlias` the alias name as
   // `@right` (table_alias.rb), and Rails' own tests build
@@ -241,10 +248,10 @@ export class NotIn extends Binary {
 
 /** Join base class — Rails defines via const_set in binary.rb */
 export abstract class Join extends Binary {
-  declare left: Node;
-  declare right: Node | null;
+  declare left: Node | Table;
+  declare right: Node | Table | null;
 
-  constructor(left: Node, right: Node | null = null) {
+  constructor(left: Node | Table, right: Node | Table | null = null) {
     super(left, right);
   }
 }

--- a/packages/arel/src/nodes/cte.ts
+++ b/packages/arel/src/nodes/cte.ts
@@ -44,7 +44,7 @@ export class Cte extends Binary {
 
   constructor(
     name: string | SqlLiteral,
-    relation: Node | SelectManager,
+    relation: Node | Table | SelectManager,
     materialized: boolean | null = null,
   ) {
     super(name, relation);

--- a/packages/arel/src/nodes/delete-statement.ts
+++ b/packages/arel/src/nodes/delete-statement.ts
@@ -1,6 +1,7 @@
 import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
+import type { Table } from "../table.js";
 
 /**
  * DeleteStatement — DELETE FROM ... WHERE ...
@@ -8,7 +9,7 @@ import { Node } from "./node.js";
  * Mirrors: Arel::Nodes::DeleteStatement
  */
 export class DeleteStatement extends Node {
-  relation: Node | null;
+  relation: Node | Table | null;
   wheres: Node[];
   orders: Node[];
   groups: Node[];
@@ -17,7 +18,7 @@ export class DeleteStatement extends Node {
   offset: Node | null;
   key: Node | Node[] | null;
 
-  constructor(relation: Node | null = null, wheres: Node[] = []) {
+  constructor(relation: Node | Table | null = null, wheres: Node[] = []) {
     super();
     this.relation = relation;
     this.wheres = wheres;

--- a/packages/arel/src/nodes/insert-statement.ts
+++ b/packages/arel/src/nodes/insert-statement.ts
@@ -1,6 +1,7 @@
 import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
+import type { Table } from "../table.js";
 
 /**
  * InsertStatement — INSERT INTO ... VALUES ...
@@ -15,12 +16,12 @@ import { Node } from "./node.js";
 export type InsertSelectSource = Node | { ast: Node; toSql: () => string } | null;
 
 export class InsertStatement extends Node {
-  relation: Node | null;
+  relation: Node | Table | null;
   columns: Node[];
   values: Node | null;
   select: InsertSelectSource;
 
-  constructor(relation: Node | null = null) {
+  constructor(relation: Node | Table | null = null) {
     super();
     this.relation = relation;
     this.columns = [];

--- a/packages/arel/src/nodes/join-source.ts
+++ b/packages/arel/src/nodes/join-source.ts
@@ -1,4 +1,5 @@
 import { Node } from "./node.js";
+import type { Table } from "../table.js";
 import { Binary } from "./binary.js";
 
 /**
@@ -9,10 +10,10 @@ import { Binary } from "./binary.js";
 export class JoinSource extends Binary {
   // Rails' JoinSource stores `joinop` (an array) as its `@right`; widen the
   // inherited `Binary#right` here to mirror that usage on the TS side.
-  declare left: Node | null;
+  declare left: Node | Table | null;
   declare right: Node[];
 
-  constructor(left: Node | null, right: Node[] = []) {
+  constructor(left: Node | Table | null, right: Node[] = []) {
     super(left, right);
     this.left = left;
     this.right = right;

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -10,10 +10,10 @@ export interface ArelEngine {
 }
 
 /** Backing store for `Arel::Table.engine`. It lives here, not in table.ts,
- *  because `Node#toSql` defaults its engine from it — a static
+ *  because `Node#toSql` defaults its engine from it, and a static
  *  `import { Table }` from this module would close a cycle back through
- *  table.ts's own node imports. `Table`
- *  exposes it as the Rails-named `Table.engine` accessor. */
+ *  table.ts's own node imports. `Table` exposes it as the Rails-named
+ *  `Table.engine` accessor. */
 export const _engine: { current: ArelEngine | null } = { current: null };
 
 /**

--- a/packages/arel/src/nodes/node.ts
+++ b/packages/arel/src/nodes/node.ts
@@ -10,8 +10,9 @@ export interface ArelEngine {
 }
 
 /** Backing store for `Arel::Table.engine`. It lives here, not in table.ts,
- *  because `Table extends Node` — a static `import { Table }` from this module
- *  would make table.ts evaluate against a half-initialised node.ts. `Table`
+ *  because `Node#toSql` defaults its engine from it — a static
+ *  `import { Table }` from this module would close a cycle back through
+ *  table.ts's own node imports. `Table`
  *  exposes it as the Rails-named `Table.engine` accessor. */
 export const _engine: { current: ArelEngine | null } = { current: null };
 

--- a/packages/arel/src/nodes/select-core.ts
+++ b/packages/arel/src/nodes/select-core.ts
@@ -1,6 +1,7 @@
 import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
+import type { Table } from "../table.js";
 import { JoinSource } from "./join-source.js";
 import type { OptimizerHints } from "./unary.js";
 
@@ -23,7 +24,7 @@ export class SelectCore extends Node {
   optimizerHints: OptimizerHints | null;
   comment: Node | null;
 
-  constructor(relation: Node | null = null) {
+  constructor(relation: Node | Table | null = null) {
     super();
     this.source = new JoinSource(relation);
     this.projections = [];
@@ -36,16 +37,16 @@ export class SelectCore extends Node {
     this.comment = null;
   }
 
-  get from(): Node | null {
+  get from(): Node | Table | null {
     return this.source.left;
   }
 
-  set from(value: Node | null) {
+  set from(value: Node | Table | null) {
     this.source.left = value;
   }
 
   /** Mirrors: `alias :froms :from` (select_core.rb:33). */
-  get froms(): Node | null {
+  get froms(): Node | Table | null {
     return this.from;
   }
 

--- a/packages/arel/src/nodes/select-statement.ts
+++ b/packages/arel/src/nodes/select-statement.ts
@@ -1,6 +1,7 @@
 import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
+import type { Table } from "../table.js";
 import { NodeExpression } from "./node-expression.js";
 import { SelectCore } from "./select-core.js";
 
@@ -21,7 +22,7 @@ export class SelectStatement extends NodeExpression {
   lock: Node | null;
   with: Node | null;
 
-  constructor(relation: Node | null = null) {
+  constructor(relation: Node | Table | null = null) {
     super();
     this.cores = [new SelectCore(relation)];
     this.orders = [];

--- a/packages/arel/src/nodes/table-alias.ts
+++ b/packages/arel/src/nodes/table-alias.ts
@@ -22,7 +22,7 @@ interface TypeCastable {
 }
 
 export class TableAlias extends Binary {
-  constructor(relation: Node, name: string | SqlLiteral) {
+  constructor(relation: Node | Table, name: string | SqlLiteral) {
     super(relation, name);
   }
 

--- a/packages/arel/src/nodes/update-statement.ts
+++ b/packages/arel/src/nodes/update-statement.ts
@@ -1,6 +1,7 @@
 import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
+import type { Table } from "../table.js";
 
 /**
  * UpdateStatement — UPDATE ... SET ... WHERE ...
@@ -8,7 +9,7 @@ import { Node } from "./node.js";
  * Mirrors: Arel::Nodes::UpdateStatement
  */
 export class UpdateStatement extends Node {
-  relation: Node | null;
+  relation: Node | Table | null;
   values: Node[];
   wheres: Node[];
   orders: Node[];
@@ -18,7 +19,7 @@ export class UpdateStatement extends Node {
   offset: Node | null;
   key: Node | Node[] | null;
 
-  constructor(relation: Node | null = null) {
+  constructor(relation: Node | Table | null = null) {
     super();
     this.relation = relation;
     this.values = [];

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -40,7 +40,7 @@ const UNION_NODE_CLASSES: Record<
 export class SelectManager extends TreeManager {
   ast: SelectStatement;
 
-  constructor(table?: Table | null) {
+  constructor(table?: Table | Node | null) {
     super();
     this.ast = new SelectStatement(table ?? null);
   }
@@ -208,8 +208,8 @@ export class SelectManager extends TreeManager {
    * Mirrors: Arel::SelectManager#join (select_manager.rb:102-113).
    */
   join(
-    relation: Node | string | null | undefined,
-    klass: new (left: Node, right: Node | null) => Join = InnerJoin,
+    relation: Node | Table | string | null | undefined,
+    klass: new (left: Node | Table, right: Node | null) => Join = InnerJoin,
   ): this {
     if (relation == null) return this;
 
@@ -219,7 +219,7 @@ export class SelectManager extends TreeManager {
     if (typeof relation === "string" || relation instanceof SqlLiteral) {
       const text = typeof relation === "string" ? relation : relation.value;
       if (text.length === 0) throw new EmptyJoinError();
-      klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
+      klass = StringJoin as unknown as new (left: Node | Table, right: Node | null) => Join;
     }
 
     this.core.source.right.push(this.createJoin(relation, null, klass));
@@ -231,7 +231,7 @@ export class SelectManager extends TreeManager {
    *
    * Mirrors: Arel::SelectManager#outer_join (select_manager.rb:115-117).
    */
-  outerJoin(relation: Node | string | null | undefined): this {
+  outerJoin(relation: Node | Table | string | null | undefined): this {
     return this.join(relation, OuterJoin);
   }
 

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -45,7 +45,7 @@ export interface TypeCaster {
  * Mirrors: Arel::Table
  */
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export class Table extends Node {
+export class Table {
   /** Mirrors: `Arel::Table.engine` (table.rb:8-9, `class << self; attr_accessor
    *  :engine`). Rails assigns `ActiveRecord::Base` from
    *  `active_record.rb:562-564`; trails assigns it at the bottom of
@@ -70,7 +70,6 @@ export class Table extends Node {
     name: string | Node,
     options?: { as?: string; klass?: TableKlass; typeCaster?: unknown },
   ) {
-    super();
     this.name = name;
     const as = options?.as ?? null;
     this.tableAlias = as === name ? null : as;
@@ -97,8 +96,8 @@ export class Table extends Node {
    * Mirrors: Arel::Table#join
    */
   join(
-    relation: Node | string | null | undefined,
-    klass: new (left: Node, right: Node | null) => Join = InnerJoin,
+    relation: Node | Table | string | null | undefined,
+    klass: new (left: Node | Table, right: Node | null) => Join = InnerJoin,
   ): SelectManager {
     if (relation == null) return this.from();
 
@@ -108,7 +107,7 @@ export class Table extends Node {
     if (typeof relation === "string" || relation instanceof SqlLiteral) {
       const text = typeof relation === "string" ? relation : relation.value;
       if (text.length === 0) throw new EmptyJoinError();
-      klass = StringJoin as unknown as new (left: Node, right: Node | null) => Join;
+      klass = StringJoin as unknown as new (left: Node | Table, right: Node | null) => Join;
     }
 
     return this.from().join(relation, klass);
@@ -119,7 +118,7 @@ export class Table extends Node {
    *
    * Mirrors: Arel::Table#outer_join
    */
-  outerJoin(relation: Node | string): SelectManager {
+  outerJoin(relation: Node | Table | string): SelectManager {
     return this.join(relation, OuterJoin);
   }
 
@@ -224,22 +223,6 @@ export class Table extends Node {
 
   isAbleToTypeCast(): boolean {
     return this.typeCaster != null;
-  }
-
-  /**
-   * Factory: create a Join node (defaults to InnerJoin).
-   * Arguments are passed directly to the join constructor, matching
-   * Ruby's Arel::FactoryMethods#create_join.
-   *
-   * Mirrors: Arel::Table#create_join
-   */
-  createJoin(
-    to: Node | string,
-    constraint?: Node | string | null,
-    klass?: new (left: Node, right: Node | null) => Join,
-  ): Join {
-    const JoinClass = klass ?? InnerJoin;
-    return new JoinClass(to as Node, (constraint ?? null) as Node | null);
   }
 }
 

--- a/packages/arel/src/visitors/mysql.ts
+++ b/packages/arel/src/visitors/mysql.ts
@@ -1,3 +1,4 @@
+import type { Table } from "../table.js";
 import { Node } from "../nodes/node.js";
 import * as Nodes from "../nodes/index.js";
 import { SQLString } from "../collectors/sql-string.js";
@@ -160,7 +161,7 @@ export class MySQL extends ToSql {
   protected override buildSubselect(
     key: Node | Node[],
     o: {
-      relation: Node | null;
+      relation: Node | Table | null;
       wheres: Node[];
       groups: Node[];
       havings: Node[];

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -93,7 +93,7 @@ export class ToSql extends Visitor {
   compile(node: Node | Table | ReadonlyArray<Nodes.NodeOrValue>): string;
   compile<T>(node: Node | Table | ReadonlyArray<Nodes.NodeOrValue>, collector: { value: T }): T;
   compile(
-    node: Node | ReadonlyArray<Nodes.NodeOrValue>,
+    node: Node | Table | ReadonlyArray<Nodes.NodeOrValue>,
     collector: { value: unknown } = new SQLString(),
   ): unknown {
     return this.accept(node, collector as unknown as SQLString).value;

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -90,8 +90,8 @@ export class ToSql extends Visitor {
     this.connection = connection;
   }
 
-  compile(node: Node | ReadonlyArray<Nodes.NodeOrValue>): string;
-  compile<T>(node: Node | ReadonlyArray<Nodes.NodeOrValue>, collector: { value: T }): T;
+  compile(node: Node | Table | ReadonlyArray<Nodes.NodeOrValue>): string;
+  compile<T>(node: Node | Table | ReadonlyArray<Nodes.NodeOrValue>, collector: { value: T }): T;
   compile(
     node: Node | ReadonlyArray<Nodes.NodeOrValue>,
     collector: { value: unknown } = new SQLString(),
@@ -1321,7 +1321,7 @@ export class ToSql extends Visitor {
     return this.unboundableSign(value) !== 0;
   }
 
-  protected hasJoinSources(o: { relation: Node | null }): boolean {
+  protected hasJoinSources(o: { relation: Node | Table | null }): boolean {
     return o.relation instanceof Nodes.JoinSource && o.relation.right.length > 0;
   }
 
@@ -1385,7 +1385,7 @@ export class ToSql extends Visitor {
   protected buildSubselect(
     key: Node | Node[],
     o: {
-      relation: Node | null;
+      relation: Node | Table | null;
       wheres: Node[];
       groups: Node[];
       havings: Node[];


### PR DESCRIPTION
Four bundled stories: one arel fidelity convergence (RFC 0124) and three RFC 0079 shield removals.

## `Arel::Table` is a standalone class (RFC 0124)

`vendor/rails/activerecord/lib/arel/table.rb:4-6` is a bare `class Table` whose
only mixins are `Arel::FactoryMethods` and `Arel::AliasPredication`. It is not
in the `Arel::Nodes` namespace and does not inherit from `Arel::Nodes::Node`.
trails had `export class Table extends Node`, so a `Table` answered
`not`/`or`/`and`/`invert`/`toSql`/`fetchAttribute`/`isEquality`, and every
`instanceof Node` guard admitted one where Ruby's `Arel::Nodes::Node === other`
does not.

`Table` now stands alone and takes `FactoryMethods` through `include()`
alongside the `AliasPredication` include it already had. Its own `createJoin`
went with it — `FactoryMethods` supplies the identical body, which is where
Rails gets it.

The slots a `Table` legitimately occupies are typed for it instead of being
typed by inheritance: `NodeOrValue` gains a `Table` arm (`JoinSource`'s
`single_source`, join_source.rb:11; `TableAlias`'s relation,
table_alias.rb:8-10; a `Join`'s left), and the four statement `relation` fields
plus `SelectCore#from` follow.

Guards audited against their Ruby counterparts:

- `buildQuoted` (casted.rb:41-51) already listed `Table` as its own arm, so it
  is unchanged and now means what Rails means — a Table no longer takes the
  `Arel::Nodes::Node` arm first.
- `arelNode` (arel.rb:64-66) excludes `Arel::Table` upstream; it now excludes
  one here too.
- `quotedNode`'s `other instanceof Node` short-circuit now falls through to
  `buildQuoted`, whose Table arm returns the same value.
- `nodes.test.ts`'s descendant walk filters on `prototype instanceof Node`, so
  `Table` leaves its population — matching Ruby's ObjectSpace walk over
  `Arel::Nodes::Node.singleton_class`, which never yields it.

`Table#hash` / `#eql` are byte-identical (table.rb:88-100); they simply stop
being overrides. `pnpm parity:api:extra:gate` is green with arel's mark
unchanged (novel 0/0, total 47/47).

## RFC 0079 — eight shields, and the culprit for each

**`mysql2-adapter.test.ts` was its own contaminator.** Its `beforeEach` raw
`DROP TABLE`d people/cars/old_cars/subscribers/engines under
`FOREIGN_KEY_CHECKS=0` and then rebuilt them — because the port had dropped
Rails' per-test `ensure` blocks. Those are restored instead:
`ALTER TABLE engines DROP COLUMN old_car_id` (mysql2_adapter_test.rb:155), the
two `remove_reference`s (:181-182), and `drop_table :foos, if_exists: true`
(:211/:239/:264, replacing the file-wide `afterEach`). With the DDL undone per
test there is nothing left to rebuild.

**`abstract-mysql-adapter/schema.test.ts`** force-created canonical `posts` and
`topics` (plus `students`/`lessons_students`) and restored them through the
`restoreCanonicalTables` helper. Rails creates none of them — `fixtures :posts`
and the schema load supply them — so the DDL is gone and the suites ride the
boot-laid canonical tables. `test_schema`'s row is deleted in a `finally`, and
the ANSI-quotes FK test adds and then removes its foreign key rather than
dropping both tables. The helper is deleted.

**`mysql2-adapter.trails.test.ts`** laid `subscribers` on the claim that "this
suite does not bootstrap the canonical schema". It leases `Base.connection`,
and the per-worker boot (`test-setup-dy.ts`) lays the canonical schema for
every AR file, so the table is already there.

### The one deviation left in `schema.test.ts`, and why it is filed rather than fixed here

`"foreign keys method with ansi quotes"` still does `addForeignKey` /
`removeForeignKey` around its assertion where Rails
(`schema_test.rb:125-128`) does a bare read. Rails can read it bare because
`schema.rb:726` lays the FK permanently —
`add_foreign_key :lessons_students, :students, on_delete: :cascade,
deferrable: :immediate` — and trails' canonical schema is one row short of
that (`canonical-schema.ts:1074`; `TEST_SCHEMA` has no `foreignKeys:` entry
for the table at all).

Closing that gap is not a one-line change, which is why it is a story rather
than part of this PR:
`support/canonical-table-rebuild-bulk-inbound-fk.trails.test.ts` clears every
`lessons_students` FK in its setup (`:72-76`) and asserts
`foreignKeys("lessons_students")` is `[]` after a rebuild (`:37`) — that test
is about a rebuild dropping an *inbound* FK, and a real canonical FK on that
table rewrites both its setup and that assertion. There is live blast radius
too: with the constraint in place, any suite inserting `lessons_students` rows
with a dangling `student_id` starts failing on PG/MySQL.

Filed as `lessons-students-canonical-foreign-key` under RFC 0079, which the
call site now names; it adds the FK to the canonical schema (with the
`deferrable: :immediate` this PR's `addForeignKey` also omits) and reverts the
test to the bare read.

**locking / custom-locking / dirty / dirty.trails / bind-parameter / date /
primary-keys** are group-B shields. Every culprit their comments name —
`autosave-association.test.ts`' `people: { name, first_name }`,
`callbacks.test.ts`, `clone.test.ts`, `reflection.test.ts`,
`coders/json.test.ts`' `SerializedTopic`, `attribute-methods.test.ts` /
`finder.test.ts`' bespoke `topics` — was a `defineSchema` site and is extinct
since RFC 0059; none of those files contains schema DDL today. The last live
`topics` shape mutator, the uniqueness suite's `topics_direct_index`, was
removed by #7109. `dirty.trails.test.ts` also moves from `fixtures([])` to
`fixtures(["topics"])` so the rows it creates roll back.

The RFC 0079 caller baseline is tightened from the 15 sites across 13 files
#7118 left to 3 across 3 — only-shrink, no rows added. `primary-keys.test.ts`
loses its row entirely: #7118 deleted its cpk prelude and this PR deletes the
`topics` shield above it, so the file has no call left.

## Verification

- `pnpm vitest run packages/arel` — 1448 passed.
- sqlite: locking, custom-locking, dirty, dirty.trails, date, bind-parameter,
  primary-keys, relation.trails, the four join/association suites the arel
  typing touches.
- MySQL 8 (own compose stack) — the ten touched suites co-scheduled with
  `adapters/`, transactions, persistence, schema-cache-dump: 698 passed.
- PostgreSQL — the seven touched non-MySQL suites: 251 passed.
- `pnpm parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate` all
  green; no test renamed.
- Built `dist/**` entry-module import checked for `table.js`, `nodes/node.js`,
  `select-manager.js`, `index.js` (no TDZ cycle introduced).

Closes-story: arel-table-extends-node-but-rails-table-is-standalone
Closes-story: shield-removal-mysql-adapter-suites
Closes-story: shield-removal-people-locking-dirty
Closes-story: shield-removal-topics-family
