### PR TITLE
refactor(activerecord): thread prepare:, wrap raw binds, and type values_list from columns (RFC 0077)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/statement-pool.trails.test.ts
@@ -4,6 +4,13 @@
  * Rails name. Subject under test is `Mysql2StatementPool`, our subclass of the
  * port of `AbstractMysqlAdapter::StatementPool`
  * (activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb).
+ *
+ * The pool is driven through `internal_exec_query` with an explicit `prepare:`
+ * because that is the only path Rails prepares on: `prepare:` is decided once in
+ * `to_sql_and_binds` (`prepared_statements && preparable`,
+ * abstract/database_statements.rb:74) and threaded down, while `execute` takes
+ * no binds at all in Ruby (abstract/database_statements.rb:196) and defaults
+ * `prepare: false` through `raw_execute` (`:552`).
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import {
@@ -31,13 +38,13 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("statement pool tracks distinct prepared queries", async () => {
       await adapter.beginDbTransaction();
       try {
-        await adapter.execute("SELECT ? AS n", [1]);
-        await adapter.execute("SELECT ? AS n", [2]);
+        await adapter.internalExecQuery("SELECT ? AS n", "SQL", [1], { prepare: true });
+        await adapter.internalExecQuery("SELECT ? AS n", "SQL", [2], { prepare: true });
         const pool = adapter._statements!;
         expect(pool).toBeDefined();
         expect(pool.length).toBe(1);
 
-        await adapter.execute("SELECT ? AS s", ["a"]);
+        await adapter.internalExecQuery("SELECT ? AS s", "SQL", ["a"], { prepare: true });
         expect(pool.length).toBe(2);
       } finally {
         await adapter.rollback();
@@ -53,8 +60,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       adapter.preparedStatements = true;
       await adapter.beginDbTransaction();
       try {
-        await adapter.execute("SELECT ? AS n", [1]);
-        await adapter.execute("SELECT ? AS s", ["a"]);
+        await adapter.internalExecQuery("SELECT ? AS n", "SQL", [1], { prepare: true });
+        await adapter.internalExecQuery("SELECT ? AS s", "SQL", ["a"], { prepare: true });
         expect(adapter._statements!.length).toBe(1);
       } finally {
         await adapter.rollback();
@@ -71,7 +78,9 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
         // no zero-limit case either: `while 0 <= cache.size` runs on the empty
         // cache and `nil.last` raises (statement_pool.rb:31-33). So a
         // `statement_limit` of 0 is unsupported rather than a caching switch.
-        await expect(adapter.execute("SELECT ? AS n", [1])).rejects.toThrow();
+        await expect(
+          adapter.internalExecQuery("SELECT ? AS n", "SQL", [1], { prepare: true }),
+        ).rejects.toThrow();
       } finally {
         await adapter.rollback();
         await adapter.close();
@@ -85,8 +94,22 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       );
       await adapter.beginDbTransaction();
       try {
-        await adapter.executeMutation(`INSERT INTO \`sp_mut\` (\`name\`) VALUES (?)`, ["a"]);
-        await adapter.executeMutation(`INSERT INTO \`sp_mut\` (\`name\`) VALUES (?)`, ["b"]);
+        await adapter.internalExecQuery(
+          `INSERT INTO \`sp_mut\` (\`name\`) VALUES (?)`,
+          "SQL",
+          ["a"],
+          {
+            prepare: true,
+          },
+        );
+        await adapter.internalExecQuery(
+          `INSERT INTO \`sp_mut\` (\`name\`) VALUES (?)`,
+          "SQL",
+          ["b"],
+          {
+            prepare: true,
+          },
+        );
         const pool = adapter._statements!;
         expect(pool.length).toBe(1);
       } finally {
@@ -99,7 +122,7 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
       const closable = new Mysql2Adapter(MYSQL_TEST_URL);
       closable.preparedStatements = true;
       await closable.beginDbTransaction();
-      await closable.execute("SELECT ? AS n", [1]);
+      await closable.internalExecQuery("SELECT ? AS n", "SQL", [1], { prepare: true });
       const pool = closable._statements!;
       await closable.rollback();
       await closable.close();
@@ -159,8 +182,8 @@ describeIfMysqlAdapter("Mysql2Adapter", () => {
     it("clearCacheBang drops cached plans on the active connection", async () => {
       await adapter.beginDbTransaction();
       try {
-        await adapter.execute("SELECT ? AS n", [1]);
-        await adapter.execute("SELECT ? AS s", ["a"]);
+        await adapter.internalExecQuery("SELECT ? AS n", "SQL", [1], { prepare: true });
+        await adapter.internalExecQuery("SELECT ? AS s", "SQL", ["a"], { prepare: true });
         const pool = adapter._statements!;
         expect(pool.length).toBe(2);
         await adapter.clearCacheBang();

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -11,6 +11,13 @@ import { Temporal } from "@blazetrails/date";
 import { Array as OidArray } from "../../connection-adapters/postgresql/oid/array.js";
 import { ValueType } from "@blazetrails/activemodel";
 
+// PG's `type_cast` has one array arm, `when OID::Array::Data then
+// encode_array(value)` (postgresql/quoting.rb:177-185), because a pg-ruby bind
+// is an already-encoded String by then. Raw `execute(sql, binds)` callers below
+// hand the same `Data` the write path produces (`OID::Array#serialize`,
+// oid/array.rb:38-44) rather than a bare JS array.
+const textArray = new OidArray(new ValueType());
+
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 });
@@ -360,28 +367,36 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("strings with quotes", async () => {
       const tags = ["this has", 'some "s that need to be escaped"'];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(tags),
+      ]);
       const rows = await adapter.execute(`SELECT tags FROM pg_arrays`);
       expect(rows[0].tags).toEqual(tags);
     });
 
     it("strings with commas", async () => {
       const tags = ["this,has", "many,values"];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(tags),
+      ]);
       const rows = await adapter.execute(`SELECT tags FROM pg_arrays`);
       expect(rows[0].tags).toEqual(tags);
     });
 
     it("strings with array delimiters", async () => {
       const tags = ["{", "}"];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(tags),
+      ]);
       const rows = await adapter.execute(`SELECT tags FROM pg_arrays`);
       expect(rows[0].tags).toEqual(tags);
     });
 
     it("strings with null strings", async () => {
       const tags = ["NULL", "NULL"];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(tags),
+      ]);
       const rows = await adapter.execute(`SELECT tags FROM pg_arrays`);
       expect(rows[0].tags).toEqual(tags);
     });
@@ -432,7 +447,9 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("escaping", async () => {
       const unknown = 'foo\\",bar,baz,\\';
       const tags = [`hello_${unknown}`];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(tags),
+      ]);
       const rows = await adapter.execute(`SELECT tags FROM pg_arrays`);
       expect(rows[0].tags).toEqual(tags);
     });
@@ -452,7 +469,9 @@ describeIfPg("PostgreSQLAdapter", () => {
         "ten\r",
         "NULL",
       ];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(tags),
+      ]);
       const rows = await adapter.execute(`SELECT tags FROM pg_arrays`);
       expect(rows[0].tags).toEqual(tags);
     });
@@ -473,10 +492,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("mutate array", async () => {
-      // PG's type_cast has one array arm, `when OID::Array::Data`
-      // (postgresql/quoting.rb:177-185), so a raw bind hands the same `Data`
-      // the write path produces (`OID::Array#serialize`, oid/array.rb:38-44).
-      const textArray = new OidArray(new ValueType());
       await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
         textArray.serialize(["one", "two"]),
       ]);
@@ -639,7 +654,9 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("encoding arrays of utf8 strings", async () => {
       const tags = ["nový", "ファイル"];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(tags),
+      ]);
       const rows = await adapter.execute(`SELECT tags FROM pg_arrays`);
       expect(rows[0].tags).toEqual(tags);
     });

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -8,6 +8,8 @@ import { fixtures } from "../../test-fixtures.js";
 import { Base, serialize, ColumnNotSerializableError, StatementInvalid } from "../../index.js";
 import { TimeWithZone, TimeZone, setZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/date";
+import { Array as OidArray } from "../../connection-adapters/postgresql/oid/array.js";
+import { ValueType } from "@blazetrails/activemodel";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -471,12 +473,21 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("mutate array", async () => {
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [["one", "two"]]);
+      // PG's type_cast has one array arm, `when OID::Array::Data`
+      // (postgresql/quoting.rb:177-185), so a raw bind hands the same `Data`
+      // the write path produces (`OID::Array#serialize`, oid/array.rb:38-44).
+      const textArray = new OidArray(new ValueType());
+      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [
+        textArray.serialize(["one", "two"]),
+      ]);
       const rows = await adapter.execute(`SELECT id, tags FROM pg_arrays`);
       const id = rows[0].id;
       const tags = rows[0].tags as string[];
       tags.push("three");
-      await adapter.execute(`UPDATE pg_arrays SET tags = $1 WHERE id = $2`, [tags, id]);
+      await adapter.execute(`UPDATE pg_arrays SET tags = $1 WHERE id = $2`, [
+        textArray.serialize(tags),
+        id,
+      ]);
       const updated = await adapter.execute(`SELECT tags FROM pg_arrays WHERE id = $1`, [id]);
       expect(updated[0].tags).toEqual(["one", "two", "three"]);
     });

--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -7,6 +7,7 @@ import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { fixtures } from "../../test-fixtures.js";
 import { Base } from "../../index.js";
+import { BinaryData } from "@blazetrails/activemodel";
 import { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
 // Rails: class ByteaDataType < ActiveRecord::Base
@@ -93,7 +94,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails: data = "\u001F"
       // Rails: @connection.execute "insert into bytea_data_type (payload) VALUES ('#{data}')"
       const data = Buffer.from([0x1f]);
-      await connection.execute(`INSERT INTO bytea_data_type (payload) VALUES ($1)`, [data]);
+      await connection.execute(`INSERT INTO bytea_data_type (payload) VALUES ($1)`, [
+        new BinaryData(data),
+      ]);
       // Rails: record = ByteaDataType.first
       const record = await (ByteaDataType as any).first();
       // Rails: assert_equal(data, record.payload)

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -6,6 +6,7 @@ import "../../index.js";
 import { describeIfSqlite } from "../../support/describe-if-sqlite.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-fixtures.js";
+import { BinaryData } from "@blazetrails/activemodel";
 import type { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 
 let adapter: SQLite3Adapter;
@@ -58,7 +59,9 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   it("type cast binary encoding without logger", async () => {
     await adapter.exec(`CREATE TABLE "bin_enc" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
     const buf = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
-    await adapter.executeMutation(`INSERT INTO "bin_enc" ("data") VALUES (?)`, [buf]);
+    await adapter.executeMutation(`INSERT INTO "bin_enc" ("data") VALUES (?)`, [
+      new BinaryData(buf),
+    ]);
     const rows = await adapter.execute(`SELECT "data" FROM "bin_enc"`);
     expect(Buffer.from(rows[0].data as Buffer)).toEqual(buf);
   });

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -7,6 +7,7 @@ import { itIfSupports } from "../../support/supports.js";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../../connection-adapters/better-sqlite3-adapter.js";
 import { Notifications } from "@blazetrails/activesupport";
+import { BinaryData } from "@blazetrails/activemodel";
 import type {
   SqliteDriver,
   SqliteOpenConfig,
@@ -278,7 +279,9 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   it("quote binary column escapes it", async () => {
     await adapter.exec(`CREATE TABLE "bin_esc" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
     const buf = Buffer.from([0x00, 0x01, 0x02, 0xff]);
-    await adapter.executeMutation(`INSERT INTO "bin_esc" ("data") VALUES (?)`, [buf]);
+    await adapter.executeMutation(`INSERT INTO "bin_esc" ("data") VALUES (?)`, [
+      new BinaryData(buf),
+    ]);
     const rows = await adapter.execute(`SELECT "data" FROM "bin_esc"`);
     expect(Buffer.from(rows[0].data as Buffer)).toEqual(buf);
   });
@@ -287,7 +290,9 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     await adapter.exec(`CREATE TABLE "enc_test" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
     const original = Buffer.from("hello world");
     const copy = Buffer.from(original);
-    await adapter.executeMutation(`INSERT INTO "enc_test" ("data") VALUES (?)`, [copy]);
+    await adapter.executeMutation(`INSERT INTO "enc_test" ("data") VALUES (?)`, [
+      new BinaryData(copy),
+    ]);
     expect(original).toEqual(Buffer.from("hello world"));
   });
 

--- a/packages/activerecord/src/binary.trails.test.ts
+++ b/packages/activerecord/src/binary.trails.test.ts
@@ -55,18 +55,17 @@ describe("binary type_casted_binds payload", () => {
   });
 
   it("casts both byte forms Rails reaches type_cast with", async () => {
-    // Rails sees bytes here two ways, and both arms are inherited from the
-    // abstract chain now that sqlite3/mysql end at `else super`:
-    //   - `Type::Binary::Data`, which `BinaryType#serialize` wraps at the source
-    //     (binary.rb:30-33) → unwrapped by rb:96's `value.to_s`.
-    //   - a BINARY/ASCII-8BIT `String` on the `execute(sql, binds)` boundary →
-    //     passed through by rb:102's `when nil, Numeric, String then value`.
-    //     A JS string can't hold arbitrary bytes, so a byte view is that form.
+    // Rails sees bytes here two ways — `Type::Binary::Data`, which
+    // `BinaryType#serialize` wraps at the source (binary.rb:30-33), and a
+    // BINARY/ASCII-8BIT `String` bound straight to `execute(sql, binds)`. A JS
+    // string can't hold arbitrary bytes, so trails' raw-`execute` callers wrap
+    // that second form in a `Data` too: rb:96's `value.to_s` is the single byte
+    // arm, and rb:102's `when nil, Numeric, String` stays string-only as in
+    // Ruby. An unwrapped byte view therefore falls to the `raise TypeError`.
     const bytes = new Uint8Array([0xde, 0xad]);
     expect(new BinaryType().serialize(bytes)).toBeInstanceOf(BinaryData);
     const conn = await Base.connection;
-    for (const cast of [conn.typeCast(new BinaryData(bytes)), conn.typeCast(bytes)]) {
-      expect(new Uint8Array(cast as Uint8Array)).toEqual(bytes);
-    }
+    expect(new Uint8Array(conn.typeCast(new BinaryData(bytes)) as Uint8Array)).toEqual(bytes);
+    expect(() => conn.typeCast(bytes)).toThrow(TypeError);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/quoting.ts
@@ -193,16 +193,11 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   // Rails: `when BigDecimal then value.to_s("F")` — bound as a fixed-form string.
   if (value instanceof BigDecimal) return value.toString("F");
   if (typeof value === "number" || typeof value === "bigint") return value;
-  // Rails: `when nil, Numeric, String then value` (rb:102). A Ruby String here
-  // is frequently a BINARY/ASCII-8BIT one — `execute(sql, binds)` callers bind
-  // raw bytes that way, which is what sqlite3's `test_type_cast_binary_encoding_
-  // _without_logger` (test/cases/adapters/sqlite3/quoting_test.rb:32) and
-  // `test_type_cast_should_not_mutate_encoding` (sqlite3_adapter_test.rb:482)
-  // pass. A JS string is UTF-16 and cannot carry arbitrary bytes, so the byte
-  // views are this arm's analogue, not a fourth branch: they pass through
-  // untouched exactly as Rails passes the String through.
+  // Rails: `when nil, Numeric, String then value` (rb:102). Ruby's byte payloads
+  // reach `type_cast` as a BINARY/ASCII-8BIT String and land here; a JS string
+  // is UTF-16 and cannot carry arbitrary bytes, so trails' byte binds arrive
+  // wrapped in a `Type::Binary::Data` and are answered by the rb:96 arm above.
   if (typeof value === "string") return value;
-  if (ArrayBuffer.isView(value)) return value;
   // Rails dispatches `Type::Time::Value` through `self.quoted_time` and
   // `Date`/`Time` through `self.quoted_date` (abstract/quoting.rb:103-104), the
   // same self-dispatch `quote` uses. Thread `this` so adapter overrides — e.g.

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -578,7 +578,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             // `raw_execute` → `perform_query` (`:588-591` → `:552-558`) — one
             // perform_query primitive per adapter, not a second inline driver call.
             const raw = await this.performQuery(mysqlConn, driverSql, binds ?? [], driverBinds, {
-              prepare: options?.prepare,
+              // Rails' internal_exec_query defaults `prepare: false`
+              // (abstract/database_statements.rb:546); the flag is decided in
+              // to_sql_and_binds and threaded, never re-derived from bind count.
+              prepare: options?.prepare ?? false,
               notificationPayload: payload,
             });
             return this.castResult(raw);
@@ -863,6 +866,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         return await this.withRawConnection({ allowRetry }, async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
           const raw = await this.performQuery(mysqlConn, driverSql, binds, driverBinds, {
+            // Rails' raw_execute default (abstract/database_statements.rb:552).
+            prepare: false,
             notificationPayload: payload,
           });
           if (raw.rows == null) return [];
@@ -907,6 +912,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         return await this.withRawConnection(async (conn) => {
           const mysqlConn = conn as unknown as mysql.Connection;
           const raw = await this.performQuery(mysqlConn, driverSql, binds, driverBinds, {
+            // Rails' raw_execute default (abstract/database_statements.rb:552).
+            prepare: false,
             notificationPayload: payload,
           });
           // Source affected rows through the `affected_rows` port (reads the
@@ -1062,7 +1069,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     {
       materializeTransactions = true,
       allowRetry = false,
-      prepare: prepareOption,
+      // Rails' internal_execute defaults `prepare: false`
+      // (abstract/database_statements.rb:588).
+      prepare: prepareOption = false,
     }: {
       materializeTransactions?: boolean;
       allowRetry?: boolean;

--- a/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2/database-statements.ts
@@ -119,7 +119,6 @@ interface PerformQueryHost {
   _statements?: StatementPool | null;
   handleWarnings?(sql: string): void | Promise<void>;
   verified?(): void;
-  preparedStatements?: boolean;
   _trackPrepared?(conn: unknown, sql: string): void;
 }
 
@@ -291,17 +290,19 @@ export async function performQuery(
   sql: string,
   binds: unknown[],
   typeCastedBinds: unknown[],
-  options: {
-    prepare?: boolean;
+  {
+    prepare,
+    notificationPayload,
+  }: {
+    // Required, as in Rails (mysql2/database_statements.rb:41) — the
+    // prepared-statement decision is made once in `to_sql_and_binds`
+    // (`prepared_statements && preparable`, abstract/database_statements.rb:74)
+    // and threaded down; `perform_query` never re-derives it.
+    prepare: boolean;
     notificationPayload?: Record<string, unknown>;
     batch?: boolean;
-  } = {},
+  },
 ): Promise<Mysql2RawResult> {
-  const { notificationPayload } = options;
-  // Rails' `raw_execute` always states `prepare:`; where a trails caller does
-  // not, fall back to Rails' own gate, `prepared_statements && preparable`
-  // (abstract/database_statements.rb:74).
-  const prepare = options.prepare ?? (this.preparedStatements === true && binds.length > 0);
   const hasBinds = binds != null && binds.length > 0;
 
   // Rails' prepared arm is `@statements[sql] ||= raw_connection.prepare(sql)`

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -294,15 +294,6 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
     // Rails: `when OID::Array::Data then encode_array(value)`.
     return encodeArray.call(this, value);
   }
-  // Rails' `when OID::Array::Data` above is the only array arm it needs, because
-  // a pg-ruby bind is always a String — the encoder has already run.
-  // node-postgres instead accepts a JS array and encodes it itself, so
-  // `execute(sql, [["one", "two"]])` (array.test.ts "mutate array") reaches here
-  // unwrapped. The elements still go through `type_cast_array`
-  // (postgresql/quoting.rb:221-226) so a Temporal or BinaryData element is cast
-  // rather than handed to the driver raw — the encoder is what this skips, not
-  // the per-element cast.
-  if (Array.isArray(value)) return typeCastArray.call(this, value);
   if (value instanceof Range) {
     return encodeRange.call(this, value);
   }

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -589,23 +589,29 @@ export class Builder implements InsertBuilder {
    * Mirrors: ActiveRecord::InsertAll::Builder#extract_types_from_columns_on
    * (insert_all.rb:306-313).
    *
-   * Rails reads `@model.schema_cache.columns_hash(table_name)`. trails' sync
-   * read of that hash is `Model.columnsHash()` (model-schema.ts), which is
-   * bound to the model's own table — `SchemaCache#columnsHash` is async here and
-   * this builder path cannot await (the RFC 0073 constraint
-   * `getCachedColumnsHash` documents). `tableName` therefore does not steer the
-   * read; it is kept because Rails' signature has it and its sole caller passes
-   * `model.table_name`, so the two reads are the same hash.
+   * Rails reads `@model.schema_cache.columns_hash(table_name)`, which blocks on
+   * a connection checkout when the entry is cold. `SchemaCache#columnsHash` is
+   * async in trails and this builder path cannot await, so the read is the
+   * query-free `getCachedColumnsHash` off `internalSchemaCache` — the sync-peek
+   * slot behind `AbstractAdapter#schema_cache` (the RFC 0073 constraint both
+   * document).
    * @internal
    */
   private extractTypesFromColumnsOn(tableName: string, keys: string[]): Record<string, Type> {
-    const columns = this.model.columnsHash();
+    const columns = (
+      this._connection as unknown as {
+        internalSchemaCache: {
+          getCachedColumnsHash(t: string): Record<string, unknown> | undefined;
+        };
+      }
+    ).internalSchemaCache.getCachedColumnsHash(tableName);
 
-    // Ruby's `columns_hash` blocks on a checkout, so it is never empty for a
-    // real table; trails' sync read can be cold, and judging keys against an
-    // empty hash would raise on every column of a model whose `table_name=`
-    // reset the schema (`Book.table_name = "db.books"`, insert_all_test.rb).
-    if (Object.keys(columns).length > 0) {
+    // Ruby's blocking read always has the columns to judge against. A cold
+    // entry here means trails cannot yet know them, and judging the keys
+    // against nothing would raise on a column the reflect is about to produce
+    // — `Book.table_name = "\${db}.books"` (insert_all_test.rb:836-845) resets
+    // the schema and inserts before anything has warmed the qualified name.
+    if (columns != null) {
       const unknownColumn = keys.find((key) => !(key in columns));
       if (unknownColumn !== undefined) {
         // UnknownAttributeError only reads record?.constructor?.name; skip the

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -1,11 +1,10 @@
 import { Temporal } from "@blazetrails/date";
 import { Nodes, Visitors } from "@blazetrails/arel";
-import { ArgumentError, SerializeCastValue } from "@blazetrails/activemodel";
+import { ArgumentError, SerializeCastValue, type Type } from "@blazetrails/activemodel";
 import { IndexDefinition } from "./connection-adapters/abstract/schema-definitions.js";
 import { UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
 
-import { isSchemaLoaded } from "./model-schema.js";
 import { isFinderNeedsTypeCondition } from "./inheritance.js";
 import type { Relation } from "./relation.js";
 import { Result } from "./result.js";
@@ -16,11 +15,6 @@ import { withConnection } from "./connection-handling.js";
 import { allTimestampAttributesInModel, timestampAttributesForUpdateInModel } from "./timestamp.js";
 
 type ModelClass = typeof Base;
-
-// Mirrors timestamp.ts CREATED_ATTRS/UPDATED_ATTRS: both _at and _on are magic
-// timestamp columns, so verifyAttributes must allow either pair even when only
-// the other is in the model's declared attribute set.
-const TIMESTAMP_ATTR_ALLOWLIST = ["created_at", "created_on", "updated_at", "updated_on"] as const;
 
 // Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#column_name_with_order_matcher
 // Intentionally more restrictive than Rails: quoted identifiers ("col", `col`) and COLLATE
@@ -206,8 +200,6 @@ export class InsertAll {
       this.keys.add(key);
     }
 
-    this.verifyAttributeNamesAreKnown();
-
     if (this.returning === undefined) {
       this.returning = facts.supportsInsertReturning ? this.primaryKeys() : false;
     }
@@ -315,31 +307,6 @@ export class InsertAll {
     const rowKeys = new Set(Object.keys(attributes));
     if (rowKeys.size !== expected.size || ![...expected].every((k) => rowKeys.has(k))) {
       throw new ArgumentError("All objects being inserted must have the same keys");
-    }
-  }
-
-  /** @internal */
-  private verifyAttributeNamesAreKnown(): void {
-    // Rails raises UnknownAttributeError in extract_types_from_columns_on against
-    // schema_cache.columns_hash (insert_all.rb:306-313); we mirror the same
-    // intent against the model's declared attribute set so the error surfaces
-    // before any SQL is built. Rails reads that hash through a blocking
-    // reflect, so it never judges a model whose schema is not loaded — this
-    // check must not either, or a table_name= that reset the schema
-    // (`Book.table_name = "db.books"`, insert_all_test.rb) would raise on a
-    // column the reflect is about to produce.
-    if (!isSchemaLoaded.call(this.model as never)) return;
-    const known = new Set(this.model.attributeNames());
-    if (known.size === 0) return;
-    for (const pk of this.primaryKeys()) known.add(pk);
-    for (const col of TIMESTAMP_ATTR_ALLOWLIST) known.add(col);
-    for (const key of this.keys) {
-      if (!known.has(key)) {
-        // UnknownAttributeError only reads record?.constructor?.name; skip the
-        // full constructor (attribute init, defaults, callbacks) on the error
-        // path by handing it a bare object with the right constructor link.
-        throw new UnknownAttributeError({ constructor: this.model }, key);
-      }
     }
   }
 
@@ -618,6 +585,41 @@ export class Builder implements InsertBuilder {
     this._connection = insertAll.connection;
   }
 
+  /**
+   * Mirrors: ActiveRecord::InsertAll::Builder#extract_types_from_columns_on
+   * (insert_all.rb:306-313).
+   *
+   * Rails reads `@model.schema_cache.columns_hash(table_name)`. trails' sync
+   * read of that hash is `Model.columnsHash()` (model-schema.ts), which is
+   * bound to the model's own table — `SchemaCache#columnsHash` is async here and
+   * this builder path cannot await (the RFC 0073 constraint
+   * `getCachedColumnsHash` documents). `tableName` therefore does not steer the
+   * read; it is kept because Rails' signature has it and its sole caller passes
+   * `model.table_name`, so the two reads are the same hash.
+   * @internal
+   */
+  private extractTypesFromColumnsOn(tableName: string, keys: string[]): Record<string, Type> {
+    const columns = this.model.columnsHash();
+
+    // Ruby's `columns_hash` blocks on a checkout, so it is never empty for a
+    // real table; trails' sync read can be cold, and judging keys against an
+    // empty hash would raise on every column of a model whose `table_name=`
+    // reset the schema (`Book.table_name = "db.books"`, insert_all_test.rb).
+    if (Object.keys(columns).length > 0) {
+      const unknownColumn = keys.find((key) => !(key in columns));
+      if (unknownColumn !== undefined) {
+        // UnknownAttributeError only reads record?.constructor?.name; skip the
+        // full constructor (attribute init, defaults, callbacks) on the error
+        // path by handing it a bare object with the right constructor link.
+        throw new UnknownAttributeError({ constructor: this.model }, unknownColumn);
+      }
+    }
+
+    const types: Record<string, Type> = {};
+    for (const key of keys) types[key] = this.model.typeForAttribute(key);
+    return types;
+  }
+
   /** Mirrors Rails `quote_column` → `connection.quote_column_name`. @internal */
   private quoteColumn(name: string): string {
     return this._connection.quoteColumnName(name);
@@ -676,10 +678,13 @@ export class Builder implements InsertBuilder {
   }
 
   valuesList(): Nodes.ValuesList {
-    const model = this._insertAll.model;
+    const types = this.extractTypesFromColumnsOn(this.model.tableName, [
+      ...this._insertAll.keysIncludingTimestamps(),
+    ]);
+
     const rows = this._insertAll.mapKeyWithValue<unknown>((key, value) => {
       if (value instanceof Nodes.SqlLiteral) return value;
-      const type = model.typeForAttribute(key);
+      const type = types[key];
       value = SerializeCastValue.serialize(type, type.cast(value));
       // Rails hands the serialized value to the ValuesList *as a value*
       // (insert_all.rb:246): `connection.visitor.compile` renders it, quoting


### PR DESCRIPTION
Four RFC 0077 convergences at the quoting/binds boundary.

### 1. mysql2 `perform_query` takes `prepare:` as a required argument

Rails decides prepared-statement routing once, in `to_sql_and_binds`
(`prepared_statements && preparable`, `abstract/database_statements.rb:74`), and
threads it down; `perform_query`'s `prepare:` is a required kwarg
(`mysql2/database_statements.rb:41`). trails carried a fallback,
`options.prepare ?? (this.preparedStatements === true && binds.length > 0)` — a
bind count standing in for Arel's `preparable` flag.

That fallback is deleted and `prepare` is required. Every mysql2 caller now
states it, defaulting to Rails' own defaults: `raw_execute` (`:552`),
`internal_execute` (`:588`) and `internal_exec_query` (`:546`) all default
`prepare: false`, so `execute` / `executeMutation` pass `false` and
`internalExecute` / `internalExecQuery` default their forwarded option to
`false`. The unused `preparedStatements` field is dropped from the
`perform_query` host interface.

### 2. Raw byte binds are wrapped in `Type::Binary::Data`

Rails reaches `type_cast` with bytes as a `Type::Binary::Data`
(`abstract/quoting.rb:96`) or as a BINARY/ASCII-8BIT `String` caught by
`when nil, Numeric, String` (`:102`). A JS string cannot carry arbitrary bytes,
so trails had a third arm, `if (ArrayBuffer.isView(value)) return value;`, at
the rb:102 position — a documented boundary, not a converged one.

The raw-`execute(sql, binds)` callers now hand a `BinaryData` for byte payloads,
so rb:96 is the only byte arm and the rb:102 position stays string-only. The
`ArrayBuffer.isView` arm is deleted and the chain is arm-for-arm with
`abstract/quoting.rb:94-105`. `binary.trails.test.ts` "casts both byte forms
Rails reaches type_cast with" is updated to that reality: a `Data` casts, a bare
view falls to the `raise TypeError`.

(The `isView` arm in `quote` and in `toBytes` is untouched — `quote`'s is the
rb:83 `Type::Binary::Data` position and out of scope here.)

### 3. PG array binds are wrapped in `OID::Array::Data`

Rails' PG `type_cast` has exactly one array arm,
`when OID::Array::Data then encode_array(value)`
(`postgresql/quoting.rb:177-185`), because a pg-ruby bind is already an encoded
String by then. node-postgres accepts a JS array, so a raw
`execute(sql, [["one", "two"]])` reached `type_cast` unwrapped and trails
carried a bare-`Array` arm for it.

The raw-`execute` callers now hand the same `Data` the write path produces
(`OID::Array#serialize`, `oid/array.rb:38-44` — the shape #6293 already
converged on), so the bare-`Array` arm is deleted and PG is arm-for-arm with
rb:177-185. `array.test.ts` is otherwise unchanged.

### 4. `values_list` resolves types from columns

`InsertAll::Builder#values_list` resolved each key's type from the model's
attribute definitions, which disagrees with Rails whenever a column exists in
the table with no declared attribute. `extract_types_from_columns_on`
(`insert_all.rb:281-287`) is ported at the Rails name and used by `values_list`,
and the unknown-column `UnknownAttributeError` moves with it out of the
`InsertAll` constructor (where trails' `verifyAttributeNamesAreKnown` stand-in
raised it) into the helper, as in Rails. The serialize call is the unconditional
rb:241 `SerializeCastValue.serialize(type, type.cast(value))`.

Rails reads `@model.schema_cache.columns_hash(table_name)`; trails' sync read of
that hash is `Model.columnsHash()` — `SchemaCache#columnsHash` is async and this
builder path cannot await (the same RFC 0073 constraint `getCachedColumnsHash`
documents). A cold hash is not judged, so a model whose `table_name=` reset the
schema still builds, as before.

### Verification

- `parity:api:calls`, `parity:api:calls:args`, `parity:api:extra:gate` all OK,
  no new baseline rows.
- SQLite lane green locally (`connection-adapters/`, `adapters/sqlite3/`,
  `insert-all`, `binary.trails`, `quoting`).
- PG and MySQL lanes verified in CI — no local server credentials here.

Closes-story: mysql2-raw-execute-preparable-is-a-bind-count-approximation
Closes-story: execute-binds-wrap-arrays-in-oid-array-data
Closes-story: execute-binds-wrap-bytes-in-binary-data
Closes-story: insert-all-values-list-types-from-columns
