### PR TITLE
refactor(activerecord): cast dirty from:/to: in the tracker and issue AR's attribute_method_* patterns from included hooks (RFC 0115)

### DIFF
--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -9,6 +9,29 @@
  * Mirrors: ActiveRecord::AttributeMethods::BeforeTypeCast
  */
 
+import { included } from "@blazetrails/activesupport";
+
+/** The host `include ActiveRecord::AttributeMethods::BeforeTypeCast` needs. */
+interface BeforeTypeCastIncludeHost {
+  attributeMethodSuffix(...suffixes: Array<string | { parameters?: string | null | false }>): void;
+}
+
+/**
+ * `ActiveRecord::AttributeMethods::BeforeTypeCast` — the module whose
+ * `included do` block (before_type_cast.rb:31-34) declares the
+ * `*_before_type_cast` / `*_for_database` / `*_came_from_user?` patterns. Its
+ * instance methods are the `this`-typed functions below (CLAUDE.md, "Module
+ * mixins"), so the module object itself carries only the hook.
+ *
+ * Mirrors: ActiveRecord::AttributeMethods::BeforeTypeCast
+ */
+export const BeforeTypeCast = {
+  [included](base: BeforeTypeCastIncludeHost): void {
+    base.attributeMethodSuffix("BeforeTypeCast", "ForDatabase", { parameters: false });
+    base.attributeMethodSuffix("CameFromUser", { parameters: false });
+  },
+};
+
 interface BeforeTypeCastRecord extends AttributeOwner {
   _attributes: AttributeOwner["_attributes"] & {
     valuesBeforeTypeCast(): Record<string, unknown>;

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -7,6 +7,7 @@
  * Mirrors: ActiveRecord::AttributeMethods::Dirty
  */
 
+import { classAttribute, included } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/date";
 import type {
   AttributeMutationTracker,
@@ -104,6 +105,18 @@ export function attributeInDatabase(record: DirtyRecord, attr: string): unknown 
 }
 
 /**
+ * The host `include ActiveRecord::AttributeMethods::Dirty` needs — a class that
+ * already carries `ActiveModel::Dirty`, which dirty.rb:42 includes.
+ */
+interface DirtyIncludeHost {
+  attributeMethodPrefix(...prefixes: Array<string | { parameters?: string | null | false }>): void;
+  attributeMethodSuffix(...suffixes: Array<string | { parameters?: string | null | false }>): void;
+  attributeMethodAffix(
+    ...affixes: Array<{ prefix?: string; suffix?: string; parameters?: string | null | false }>
+  ): void;
+}
+
+/**
  * The half of ActiveRecord::AttributeMethods::Dirty whose Ruby bodies are
  * zero-arg readers, so they port as accessor properties (CLAUDE.md,
  * "Generated attribute readers are properties"). A class module rather than a
@@ -114,6 +127,29 @@ export function attributeInDatabase(record: DirtyRecord, attr: string): unknown 
  * Mirrors: ActiveRecord::AttributeMethods::Dirty
  */
 export class Dirty {
+  /**
+   * Mirrors: dirty.rb:44-59 — the module's `included do` block.
+   *
+   * Ruby tells the predicate `saved_change_to_name?` (dirty.rb:53) from the
+   * array-returning `saved_change_to_name` (dirty.rb:54) by the trailing `?`,
+   * which the camel spelling drops; the `is*` prefix
+   * (docs/ruby-ts-conventions.md) is where TypeScript puts the same
+   * distinction, so it goes in the pattern's own prefix and the derived
+   * `${prefix}Attribute${suffix}` proxy target (attribute_methods.rb:481)
+   * lands on `isSavedChangeToAttribute` unchanged.
+   */
+  static [included](base: DirtyIncludeHost): void {
+    classAttribute.call(base, "partialUpdates", { instanceWriter: false, default: true });
+    classAttribute.call(base, "partialInserts", { instanceWriter: false, default: true });
+
+    base.attributeMethodAffix({ prefix: "isSavedChangeTo", parameters: "**options" });
+    base.attributeMethodPrefix("savedChangeTo", { parameters: false });
+    base.attributeMethodSuffix("BeforeLastSave", { parameters: false });
+
+    base.attributeMethodAffix({ prefix: "isWillSaveChangeTo", parameters: "**options" });
+    base.attributeMethodSuffix("ChangeToBeSaved", "InDatabase", { parameters: false });
+  }
+
   /**
    * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_changes
    * (dirty.rb:118-120) — `mutations_before_last_save.changes`.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4619,6 +4619,10 @@ include(Base, {
   storeAccessorFor: _storeAccessorFor,
 });
 include(Base, ModelSchema.InstanceMethods);
+// attribute_methods.rb:14 includes BeforeTypeCast ahead of Dirty, so its
+// `included do` patterns (before_type_cast.rb:32-33) precede both halves of
+// Dirty's in `attributeMethodPatterns`.
+include(Base, _BeforeTypeCast);
 // `include ActiveModel::Dirty` (attribute_methods/dirty.rb:42) — the surface
 // `ActiveRecord::AttributeMethods::Dirty` builds on, and which
 // `ActiveModel::Model` does NOT carry (model.rb:42-45). A class module, so
@@ -4627,10 +4631,6 @@ include(Base, ModelSchema.InstanceMethods);
 // splices the module's `init_internals` / `initialize_dup` links (dirty.rb:
 // 371-376, :248-251) into this prototype's chains, below Core — the position
 // they had while `ActiveModel::Model` carried them on its own prototype.
-// attribute_methods.rb:14 includes BeforeTypeCast ahead of Dirty, so its
-// `included do` patterns (before_type_cast.rb:32-33) precede both halves of
-// Dirty's in `attributeMethodPatterns`.
-include(Base, _BeforeTypeCast);
 include(Base, AMDirty);
 // The accessor-property half of AttributeMethods::Dirty. A class module, so
 // `include()` copies the getter descriptors rather than flattening them.

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -31,7 +31,6 @@ import type {
 } from "@blazetrails/globalid/signed-global-id";
 import {
   ArgumentError,
-  AttributeMethodPattern,
   Dirty as AMDirty,
   JSONSerializer,
   Model,
@@ -175,7 +174,6 @@ import {
   benchmark as benchmarkable,
   type BenchmarkLogger,
   runLoadHooks,
-  isBlank as _isBlankValue,
   type PrependMethod,
   singularize as _singularize,
   type Included,
@@ -247,7 +245,10 @@ import {
   writeAttribute as _writeAttributeMethod,
   _writeAttribute as _writeAttributeLowLevel,
 } from "./attribute-methods/write.js";
-import { attributeCameFromUser as _attributeCameFromUser } from "./attribute-methods/before-type-cast.js";
+import {
+  BeforeTypeCast as _BeforeTypeCast,
+  attributeCameFromUser as _attributeCameFromUser,
+} from "./attribute-methods/before-type-cast.js";
 import {
   queryAttribute as _queryAttribute,
   _queryAttribute as _queryAttributeFn,
@@ -1567,12 +1568,12 @@ export class Base extends Model {
     this._recordTimestamps = value;
   }
 
-  // Mirrors: ActiveRecord::AttributeMethods::Dirty — class_attribute
-  // :partial_updates/:partial_inserts, default: true (dirty.rb:49-50). Apps flip
+  // `class_attribute :partial_updates, :partial_inserts` (dirty.rb:50-51),
+  // installed by AttributeMethods::Dirty's `[included]` hook. Apps flip
   // partial_inserts to false via `config.load_defaults 7.0`; that belongs in a
   // config layer, not this framework default.
-  static partialUpdates = true;
-  static partialInserts = true;
+  declare static partialUpdates: boolean;
+  declare static partialInserts: boolean;
 
   static async noTouching<R>(fn: () => R | Promise<R>): Promise<R> {
     return _noTouchingBlock(this, fn);
@@ -1594,35 +1595,6 @@ export class Base extends Model {
 
   static set sequenceName(name: string | null) {
     ModelSchema.sequenceName.call(this, name);
-  }
-
-  /**
-   * The `included do` blocks of AttributeMethods::BeforeTypeCast
-   * (before_type_cast.rb:32-33) and AttributeMethods::Dirty (dirty.rb:53-59).
-   * The `class_attribute` writer gives Active Record its own array rather than
-   * mutating ActiveModel's.
-   *
-   * Ruby tells the predicate `saved_change_to_name?` (dirty.rb:53) from the
-   * array-returning `saved_change_to_name` (dirty.rb:54) by the trailing `?`,
-   * which the camel spelling drops; the `is*` prefix
-   * (docs/ruby-ts-conventions.md) is where TypeScript puts the same
-   * distinction, so it goes in the pattern's own prefix and the derived
-   * `${prefix}Attribute${suffix}` proxy target (attribute_methods.rb:481)
-   * lands on `isSavedChangeToAttribute` unchanged.
-   */
-  static {
-    this.attributeMethodPatterns = [
-      ...this.attributeMethodPatterns,
-      new AttributeMethodPattern({ suffix: "BeforeTypeCast", parameters: false }),
-      new AttributeMethodPattern({ suffix: "ForDatabase", parameters: false }),
-      new AttributeMethodPattern({ suffix: "CameFromUser", parameters: false }),
-      new AttributeMethodPattern({ prefix: "isSavedChangeTo", parameters: "**options" }),
-      new AttributeMethodPattern({ prefix: "savedChangeTo", parameters: false }),
-      new AttributeMethodPattern({ suffix: "BeforeLastSave", parameters: false }),
-      new AttributeMethodPattern({ prefix: "isWillSaveChangeTo", parameters: "**options" }),
-      new AttributeMethodPattern({ suffix: "ChangeToBeSaved", parameters: false }),
-      new AttributeMethodPattern({ suffix: "InDatabase", parameters: false }),
-    ];
   }
 
   // -- Ignored columns --
@@ -1815,59 +1787,6 @@ export class Base extends Model {
   declare static assertValidEnumOptions: typeof _EnumModule.assertValidEnumOptions;
   /** @internal */
   declare static detectNegativeEnumConditionsBang: typeof _EnumModule.detectNegativeEnumConditionsBang;
-
-  // Cast `from:`/`to:` options through the enum mapping before comparison.
-  // Rails normalises these via AttributeMutationTracker#type_cast (which calls
-  // type.cast on the attribute's EnumType); we mirror it here for both live
-  // changes (attributeChanged) and persisted changes (isSavedChangeToAttribute).
-  // All enums are label-stored via the registered EnumType with their mapping
-  // in the single `_enums` registry.
-  attributeChanged(name: string, options?: DirtyOptions): boolean {
-    if (options) {
-      const ctor = this.constructor as typeof Base;
-      const canonical = (ctor as any).attributeAliases?.[name] ?? name;
-      options = _castEnumDirtyOpts(ctor, canonical, options);
-    }
-    // `ActiveModel::Dirty` is included into this class rather than inherited
-    // from `Model` (attribute_methods/dirty.rb:42), so the module body a Ruby
-    // `super` would reach is on this same prototype and shadowed by the class
-    // body. This is Ruby's `instance_method(...).bind(self).call`.
-    return AMDirty.prototype.attributeChanged.call(this, name, options);
-  }
-
-  /**
-   * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_change_to_attribute?
-   * (attribute_methods/dirty.rb:86-88), declared alongside its
-   * `attribute_method_affix` in `attributeMethodPatterns` above.
-   *
-   * The body is the port in `attribute-methods/dirty.ts`. What stays here is
-   * what Rails does inside `AttributeMutationTracker#changed?`
-   * (attribute_mutation_tracker.rb:44-48) and trails cannot: alias resolution
-   * and the `type_cast(attr_name, …)` of each option through the attribute's
-   * `EnumType`, both of which need the class, not the record.
-   */
-  isSavedChangeToAttribute(name: string, options?: DirtyOptions): boolean {
-    const ctor = this.constructor as typeof Base;
-    if (options) {
-      const canonical = (ctor as any).attributeAliases?.[name] ?? name;
-      options = _castEnumDirtyOpts(ctor, canonical, options);
-    }
-    return _isSavedChangeToAttribute.call(this as any, ctor.resolveAttributeName(name), options);
-  }
-
-  /**
-   * Mirrors: ActiveRecord::AttributeMethods::Dirty#will_save_change_to_attribute?
-   * (attribute_methods/dirty.rb:138-140). Same split as
-   * {@link Base.isSavedChangeToAttribute}.
-   */
-  isWillSaveChangeToAttribute(name: string, options?: DirtyOptions): boolean {
-    const ctor = this.constructor as typeof Base;
-    if (options) {
-      const canonical = (ctor as any).attributeAliases?.[name] ?? name;
-      options = _castEnumDirtyOpts(ctor, canonical, options);
-    }
-    return _isWillSaveChangeToAttribute.call(this as any, ctor.resolveAttributeName(name), options);
-  }
 
   // -- Explain --
 
@@ -4220,10 +4139,7 @@ export class Base extends Model {
 // name on base.ts's surface.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface Base
-  extends
-    Included<typeof AutosaveAssociation>,
-    Omit<JSONSerializer, "toJSON">,
-    Omit<AMDirty, "attributeChanged"> {
+  extends Included<typeof AutosaveAssociation>, Omit<JSONSerializer, "toJSON">, AMDirty {
   /** Mirrors: ActiveRecord::Normalization#normalize_attribute (normalization.rb:26). */
   normalizeAttribute(name: string): void;
   /**
@@ -4316,6 +4232,12 @@ export interface Base
    */
   readonly attributesInDatabase: Record<string, unknown>;
   /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#saved_change_to_attribute?
+   * (attribute_methods/dirty.rb:86-88). Ported and mixed in as
+   * {@link Base.attributeBeforeLastSave} is.
+   */
+  isSavedChangeToAttribute(attr: string, options?: DirtyOptions): boolean;
+  /**
    * Mirrors: ActiveRecord::AttributeMethods::Dirty#attribute_before_last_save
    * (attribute_methods/dirty.rb:108-110).
    *
@@ -4325,6 +4247,12 @@ export interface Base
    * port.
    */
   attributeBeforeLastSave(attr: string): unknown;
+  /**
+   * Mirrors: ActiveRecord::AttributeMethods::Dirty#will_save_change_to_attribute?
+   * (attribute_methods/dirty.rb:138-140). Ported and mixed in as
+   * {@link Base.attributeBeforeLastSave} is.
+   */
+  isWillSaveChangeToAttribute(attr: string, options?: DirtyOptions): boolean;
   /**
    * Mirrors: ActiveRecord::AttributeMethods::Dirty#attribute_change_to_be_saved
    * (attribute_methods/dirty.rb:152-154). Ported and mixed in as
@@ -4398,36 +4326,6 @@ export interface Base
   clone(): this;
   becomes<K extends typeof Base>(klass: K): InstanceType<K>;
   becomesBang<K extends typeof Base>(klass: K): InstanceType<K>;
-}
-
-// Normalise a single `from:` or `to:` option value through the enum mapping so
-// that label / symbol / integer forms all compare equal to the stored value.
-// All enums register their mapping in the single `_enums` registry (the former
-// `defineEnum` EnumType registry has been folded in).
-function _castEnumDirtyOpts(
-  ctor: typeof Base,
-  name: string,
-  opts: { from?: unknown; to?: unknown },
-): { from?: unknown; to?: unknown } {
-  const mapping = ctor._enums?.get(name);
-  if (mapping) {
-    // Since I-2, _enum stores label strings in _attributes (via EnumType.cast).
-    // Normalise both label inputs and integer storage-value inputs to the label
-    // string so the comparison matches the in-memory value.
-    const entries = Object.entries(mapping) as [string, number | string][];
-    const cast = (v: unknown): unknown => {
-      if (typeof v === "string" && Object.prototype.hasOwnProperty.call(mapping, v)) return v;
-      const found = entries.find(([, sv]) => sv === v);
-      if (found) return found[0];
-      if (_isBlankValue(v)) return null;
-      return v;
-    };
-    const result: { from?: unknown; to?: unknown } = {};
-    if ("from" in opts) result.from = cast(opts.from);
-    if ("to" in opts) result.to = cast(opts.to);
-    return result;
-  }
-  return opts;
 }
 
 // ---------------------------------------------------------------------------
@@ -4729,6 +4627,10 @@ include(Base, ModelSchema.InstanceMethods);
 // splices the module's `init_internals` / `initialize_dup` links (dirty.rb:
 // 371-376, :248-251) into this prototype's chains, below Core — the position
 // they had while `ActiveModel::Model` carried them on its own prototype.
+// attribute_methods.rb:14 includes BeforeTypeCast ahead of Dirty, so its
+// `included do` patterns (before_type_cast.rb:32-33) precede both halves of
+// Dirty's in `attributeMethodPatterns`.
+include(Base, _BeforeTypeCast);
 include(Base, AMDirty);
 // The accessor-property half of AttributeMethods::Dirty. A class module, so
 // `include()` copies the getter descriptors rather than flattening them.
@@ -4862,9 +4764,8 @@ include(Base, {
   // with `include(Base, _PrimaryKey)` / `include(Base, _CompositePrimaryKey)`
   // above: the readers are accessor properties, and only those calls copy
   // descriptors — this object literal is read by value and would flatten them.
-  // `isSavedChangeToAttribute` / `isWillSaveChangeToAttribute` are absent on
-  // purpose: this literal lands on the prototype after the class body and would
-  // clobber the overrides there that carry the alias + enum type_cast step.
+  isSavedChangeToAttribute: _isSavedChangeToAttribute,
+  isWillSaveChangeToAttribute: _isWillSaveChangeToAttribute,
   savedChangeToAttribute: _savedChangeToAttribute,
   attributeBeforeLastSave: _attributeBeforeLastSave,
   attributeChangeToBeSaved: _attributeChangeToBeSaved,

--- a/packages/activerecord/src/dirty-generated-methods.trails.test.ts
+++ b/packages/activerecord/src/dirty-generated-methods.trails.test.ts
@@ -158,3 +158,43 @@ describe("attributeInDatabase / attributeBeforeLastSave", () => {
     expect(u.isSavedChangeToAttribute("name", { from: "Wrong", to: "Bob" })).toBe(false);
   });
 });
+
+describe("enum from/to through the generated predicates", () => {
+  class Card extends Base {
+    static {
+      this.attribute("status", "integer");
+      this.enum("status", { proposed: 0, written: 1 });
+    }
+  }
+
+  interface GeneratedEnum {
+    status: string | null;
+    changesApplied(): void;
+    statusChanged(options?: { from?: unknown; to?: unknown }): boolean;
+    isSavedChangeToStatus(options?: { from?: unknown; to?: unknown }): boolean;
+    isWillSaveChangeToStatus(options?: { from?: unknown; to?: unknown }): boolean;
+  }
+
+  // The generated predicates reach `AttributeMutationTracker#changed?` without
+  // passing through any `Base` body, so they are the path that proves the
+  // `from:`/`to:` cast lives in the tracker (attribute_mutation_tracker.rb:
+  // 41-51) rather than at a call site.
+  it("attributeChanged casts a stored value through the attribute's EnumType", () => {
+    const card = new Card({ status: "proposed" }) as unknown as GeneratedEnum;
+    card.changesApplied();
+    card.status = "written";
+    expect(card.statusChanged({ from: "proposed", to: "written" })).toBe(true);
+    expect(card.statusChanged({ from: 0, to: 1 })).toBe(true);
+    expect(card.statusChanged({ to: "proposed" })).toBe(false);
+  });
+
+  it("willSaveChangeTo and savedChangeTo cast the same way", () => {
+    const card = new Card({ status: "proposed" }) as unknown as GeneratedEnum;
+    card.changesApplied();
+    card.status = "written";
+    expect(card.isWillSaveChangeToStatus({ from: 0, to: 1 })).toBe(true);
+    card.changesApplied();
+    expect(card.isSavedChangeToStatus({ from: 0, to: 1 })).toBe(true);
+    expect(card.isSavedChangeToStatus({ from: 1 })).toBe(false);
+  });
+});


### PR DESCRIPTION
Two convergences on the same wiring block in `base.ts`.

## Type-cast `from:` / `to:` inside the mutation tracker

`AttributeMutationTracker#changed?` normalises both options through
`type_cast` (`attribute_mutation_tracker.rb:41-51`, `:86-88`), which trails
already ports. The three `Base` overrides that hoisted the cast to the call
site — `attributeChanged`, `isSavedChangeToAttribute`,
`isWillSaveChangeToAttribute` — and their `_castEnumDirtyOpts` helper had
nothing left to do, so they are gone.

- The two AR predicates go back to the ported bodies in
  `attribute-methods/dirty.ts` (`dirty.rb:86-88`, `:138-140`) through the
  prototype literal; neither Ruby body resolves an alias, so the extra
  `resolveAttributeName` step goes with them (`ActiveModel::Dirty` still
  resolves it one level down, unchanged by this PR).
- `interface Base` extends a plain `AMDirty` again — the
  `Omit<AMDirty, "attributeChanged">` and the bound-method `super`
  (`AMDirty.prototype.attributeChanged.call`) that PR #7113 needed are both
  retired.
- New covering cases in `dirty-generated-methods.trails.test.ts` drive an
  enum's `from:` / `to:` through the *generated* predicates
  (`statusChanged`, `isWillSaveChangeToStatus`, `isSavedChangeToStatus`) —
  the path that never passed through the deleted overrides.

## Issue AR's `attribute_method_*` patterns from `included` hooks

`base.ts`'s `static {}` block reconstructed the resulting
`attributeMethodPatterns` array by hand. Each module now issues its own macro
calls from an `[included]` hook, the shape `packages/activemodel/src/dirty.ts`
uses:

- `attribute-methods/before-type-cast.ts` → `before_type_cast.rb:31-34`
- `attribute-methods/dirty.ts` → `dirty.rb:44-59`

`include(Base, BeforeTypeCast)` is wired ahead of the two Dirty includes, so
the pattern order now matches `attribute_methods.rb:11-20`: BeforeTypeCast,
then `ActiveModel::Dirty`, then `ActiveRecord::AttributeMethods::Dirty` (it
previously ran AR's ahead of ActiveModel's).

`partialUpdates` / `partialInserts` become `class_attribute`s with
`instance_writer: false` (`dirty.rb:50-51`) issued from the same hook, rather
than plain statics.

`self < ::ActiveRecord::Timestamp` guard from `dirty.rb:45-47` is not issued —
there is no module-ancestry predicate to test it with; left as-is.

## Verification

- `pnpm typecheck` clean; `pnpm parity:api:calls` and `:args` ratchets OK;
  `pnpm parity:api:extra:gate` OK (arel 0/0-47/47, activerecord 367/367-995/995
  — unchanged).
- `dirty.test.ts`, `enum.test.ts`, `attribute-methods.test.ts`,
  `persistence.test.ts`, `attribute-methods/**`, `timestamp`, `locking`,
  `touch-later`, `habtm`, the whole `activemodel` suite: 114 files / 2371 tests
  green.

Closes-story: cast-dirty-from-to-options-inside-the-mutation-tracker
Closes-story: issue-ar-attribute-method-patterns-from-included-hooks