### PR TITLE
refactor(arel): converge Attribute mixins, Case#when quoting, invented guards, and 12 parameter names (RFC 0124)

### DIFF
--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -135,7 +135,9 @@ export class Aliases {
    * every joined table. Mirrors Rails' Aliases#columns returning Arel nodes.
    */
   selectArel(): Nodes.As[] {
-    return this._tables.flatMap((t) => t.columns.map((c) => t.table.get(c.column).as(c.alias)));
+    return this._tables.flatMap((t) =>
+      t.columns.map((c) => t.table.get(c.column).as(c.alias) as Nodes.As),
+    );
   }
 }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2589,7 +2589,9 @@ export function buildCaseForValuePosition(
   const filter = options.filter !== false;
   const node = new Nodes.Case();
   values.forEach((value, i) => {
-    node.when((column as any).eq(value), i + 1);
+    // query_methods.rb:2166 — `node.when(column.eq(value)).then(order)`; the
+    // THEN value is quoted by `#then`, not by `#when`.
+    node.when((column as any).eq(value)).then(i + 1);
   });
   if (!filter) (node as any).else(values.length + 1);
   return new Nodes.Ascending(node);

--- a/packages/arel/src/attributes/attribute.ts
+++ b/packages/arel/src/attributes/attribute.ts
@@ -1,27 +1,14 @@
 import { include, rbEqual, rbHash } from "@blazetrails/activesupport";
 import { _setAttribute } from "../node-slots.js";
 import { Node } from "../nodes/node.js";
-import { As } from "../nodes/binary.js";
-import { Addition, Subtraction, Multiplication, Division } from "../nodes/infix-operation.js";
-import { Count } from "../nodes/count.js";
-import { Sum, Max, Min, Avg } from "../nodes/function.js";
-import { Ascending } from "../nodes/ascending.js";
-import { Descending } from "../nodes/descending.js";
 import { buildQuoted } from "../nodes/casted.js";
-import { Grouping } from "../nodes/grouping.js";
 import { SqlLiteral } from "../nodes/sql-literal.js";
 import { NamedFunction } from "../nodes/named-function.js";
-import { Extract } from "../nodes/extract.js";
-import {
-  BitwiseAnd,
-  BitwiseOr,
-  BitwiseXor,
-  BitwiseShiftLeft,
-  BitwiseShiftRight,
-} from "../nodes/infix-operation.js";
-import { BitwiseNot } from "../nodes/unary-operation.js";
-import type { NodeOrValue } from "../nodes/binary.js";
+import { Expressions, type ExpressionsModule } from "../expressions.js";
 import { Predications, type PredicationsModule, type RangeLike } from "../predications.js";
+import { AliasPredication, type AliasPredicationModule } from "../alias-predication.js";
+import { OrderPredications, type OrderPredicationsModule } from "../order-predications.js";
+import { Math as MathMixin, type MathModule } from "../math.js";
 
 /**
  * Attribute — represents a column on a table.
@@ -112,110 +99,24 @@ export class Attribute extends Node {
   quotedNode(other: unknown): Node {
     return buildQuoted(other, this);
   }
-
-  asc(): Ascending {
-    return new Ascending(this);
-  }
-
-  desc(): Descending {
-    return new Descending(this);
-  }
-
-  // -- Math --
-  //
-  // Mirrors Arel::Math: operands pass through unwrapped. The visitor
-  // renders primitive values via `visit` class dispatch. The operand is
-  // typed `NodeOrValue` (not `unknown` + cast) so the union that encodes
-  // what a Rails node slot admits is enforced at the call site.
-
-  add(other: NodeOrValue): Grouping {
-    return new Grouping(new Addition(this, other));
-  }
-
-  subtract(other: NodeOrValue): Grouping {
-    return new Grouping(new Subtraction(this, other));
-  }
-
-  multiply(other: NodeOrValue): Multiplication {
-    return new Multiplication(this, other);
-  }
-
-  divide(other: NodeOrValue): Division {
-    return new Division(this, other);
-  }
-
-  bitwiseAnd(other: NodeOrValue): Grouping {
-    return new Grouping(new BitwiseAnd(this, other));
-  }
-
-  bitwiseOr(other: NodeOrValue): Grouping {
-    return new Grouping(new BitwiseOr(this, other));
-  }
-
-  bitwiseXor(other: NodeOrValue): Grouping {
-    return new Grouping(new BitwiseXor(this, other));
-  }
-
-  bitwiseShiftLeft(other: NodeOrValue): Grouping {
-    return new Grouping(new BitwiseShiftLeft(this, other));
-  }
-
-  bitwiseShiftRight(other: NodeOrValue): Grouping {
-    return new Grouping(new BitwiseShiftRight(this, other));
-  }
-
-  bitwiseNot(): BitwiseNot {
-    return new BitwiseNot(this);
-  }
-
-  as(other: string | SqlLiteral): As {
-    return new As(this, new SqlLiteral(other, { retryable: true }));
-  }
-
-  // -- Aggregate functions --
-  //
-  // Mirrors: Arel::Expressions (mixed into Attribute in Rails). Returns
-  // the typed Function subclasses Rails uses (Count/Sum/Max/Min/Avg) so
-  // `instanceof` checks line up across the codebase. The visitor
-  // (visitAggregate in to-sql.ts) renders them identically to a
-  // NamedFunction with the same name.
-
-  count(distinct: boolean | null = false): Count {
-    return new Count([this], distinct);
-  }
-
-  sum(): Sum {
-    return new Sum([this]);
-  }
-
-  maximum(): Max {
-    return new Max([this]);
-  }
-
-  minimum(): Min {
-    return new Min([this]);
-  }
-
-  average(): Avg {
-    return new Avg([this]);
-  }
-
-  extract(field: string): Extract {
-    // Mirrors Rails: `Nodes::Extract.new [self], field` (expressions.rb).
-    return new Extract([this], field);
-  }
 }
 
-// Mirrors `include Arel::Predications` (attribute.rb:7). Every predication —
+// Mirrors the five `include`s at attribute.rb:6-10. Every predication —
 // eq/notEq/in/notIn/matches/between/*_any/*_all and the private
 // quoted_array / grouping_any / infinity? helpers — comes from the mixin and
 // dispatches back through this class's `quotedNode`, which is the only piece
 // Attribute supplies (the type-casting variant).
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface Attribute extends Omit<
-  PredicationsModule,
-  "between" | "notBetween" | "isInfinity" | "isUnboundable" | "isOpenEnded"
-> {
+export interface Attribute
+  extends
+    Omit<
+      PredicationsModule,
+      "between" | "notBetween" | "isInfinity" | "isUnboundable" | "isOpenEnded"
+    >,
+    ExpressionsModule,
+    AliasPredicationModule,
+    OrderPredicationsModule,
+    MathModule {
   // Restated (rather than inherited) so a subclass can `override` them with a
   // narrowed signature — the self-dispatch predications.rb:38-51 relies on.
 
@@ -229,6 +130,11 @@ export interface Attribute extends Omit<
   notBetween(other: RangeLike): Node;
 }
 
+// Mirrors attribute.rb:6-10, in Rails' include order.
+include(Attribute, Expressions);
 include(Attribute, Predications);
+include(Attribute, AliasPredication);
+include(Attribute, OrderPredications);
+include(Attribute, MathMixin);
 
 _setAttribute(Attribute);

--- a/packages/arel/src/collectors/composite.test.ts
+++ b/packages/arel/src/collectors/composite.test.ts
@@ -29,43 +29,6 @@ describe("TestComposite", () => {
     expect(binds).toEqual(["hello2", "world3"]);
   });
 
-  it("addBind forwards block to both collectors", () => {
-    const left = new Collectors.SQLString();
-    const calls: number[] = [];
-    const right = {
-      append: () => right,
-      addBind: (_v: unknown, block?: (i: number) => string) => {
-        if (block) calls.push(1);
-        return right;
-      },
-    };
-    const composite = new Collectors.Composite(left, right);
-    composite.addBind(42, (i) => `$${i}`);
-    expect(left.value).toBe("$1");
-    expect(calls).toEqual([1]);
-  });
-
-  it("addBinds forwards block to both collectors", () => {
-    const left = new Collectors.SQLString();
-    const calls: number[] = [];
-    const right = {
-      append: () => right,
-      addBind: () => right,
-      addBinds: (
-        _binds: unknown[],
-        _proc?: ((v: unknown) => unknown) | null,
-        block?: (i: number) => string,
-      ) => {
-        if (block) calls.push(1);
-        return right;
-      },
-    };
-    const composite = new Collectors.Composite(left, right);
-    composite.addBinds([1, 2], null, (i) => `$${i}`);
-    expect(left.value).toBe("$1, $2");
-    expect(calls).toEqual([1]);
-  });
-
   it("retryable on composite collector propagates", () => {
     const sqlCollector = new Collectors.SQLString();
     const bindCollector = new Collectors.Bind();

--- a/packages/arel/src/collectors/composite.trails.test.ts
+++ b/packages/arel/src/collectors/composite.trails.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { Collectors } from "../index.js";
+
+describe("TestComposite", () => {
+  it("addBind forwards block to both collectors", () => {
+    const left = new Collectors.SQLString();
+    const calls: number[] = [];
+    const right = new Collectors.Bind();
+    const composite = new Collectors.Composite(left, right);
+    composite.addBind(42, (i) => {
+      calls.push(i);
+      return `$${i}`;
+    });
+    expect(left.value).toBe("$1");
+    expect(right.value).toEqual([42]);
+    expect(calls).toEqual([1]);
+  });
+
+  it("addBinds forwards block to both collectors", () => {
+    const left = new Collectors.SQLString();
+    const calls: number[] = [];
+    const right = new Collectors.Bind();
+    const composite = new Collectors.Composite(left, right);
+    composite.addBinds([1, 2], null, (i) => {
+      calls.push(i);
+      return `$${i}`;
+    });
+    expect(left.value).toBe("$1, $2");
+    expect(right.value).toEqual([1, 2]);
+    expect(calls).toEqual([1, 2]);
+  });
+});

--- a/packages/arel/src/collectors/composite.ts
+++ b/packages/arel/src/collectors/composite.ts
@@ -1,10 +1,10 @@
 type CollectorLike = {
   append(str: string): unknown;
-  addBind(value: unknown, block?: (index: number) => string): unknown;
-  addBinds?(
+  addBind(value: unknown, block: (index: number) => string): unknown;
+  addBinds(
     binds: unknown[],
-    procForBinds?: ((v: unknown) => unknown) | null,
-    block?: (index: number) => string,
+    procForBinds: ((v: unknown) => unknown) | null | undefined,
+    block: (index: number) => string,
   ): unknown;
   retryable?: boolean;
   value?: unknown;
@@ -16,21 +16,19 @@ type CollectorLike = {
  * Mirrors: Arel::Collectors::Composite
  */
 export class Composite {
-  private left: CollectorLike;
-  private right: CollectorLike;
-  preparable = true;
+  // `attr_accessor :preparable` (composite.rb:7) — no default; nil until written.
+  preparable?: boolean;
+  #retryable?: boolean;
 
-  get retryable(): boolean {
-    if ("retryable" in this.left && this.left.retryable === false) return false;
-    if ("retryable" in this.right && this.right.retryable === false) return false;
-    return true;
+  // `attr_reader :retryable` (composite.rb:8), written only by `retryable=`.
+  get retryable(): boolean | undefined {
+    return this.#retryable;
   }
 
-  set retryable(value: boolean) {
-    if ("retryable" in this.left)
-      (this.left as CollectorLike & { retryable: boolean }).retryable = value;
-    if ("retryable" in this.right)
-      (this.right as CollectorLike & { retryable: boolean }).retryable = value;
+  set retryable(retryable: boolean) {
+    this.left.retryable = retryable;
+    this.right.retryable = retryable;
+    this.#retryable = retryable;
   }
 
   constructor(left: CollectorLike, right: CollectorLike) {
@@ -38,19 +36,19 @@ export class Composite {
     this.right = right;
   }
 
-  addBind(value: unknown, block?: (index: number) => string): this {
-    this.left.addBind(value, block);
-    this.right.addBind(value, block);
+  addBind(bind: unknown, block: (index: number) => string): this {
+    this.left.addBind(bind, block);
+    this.right.addBind(bind, block);
     return this;
   }
 
   addBinds(
     binds: unknown[],
-    procForBinds?: ((v: unknown) => unknown) | null,
-    block?: (index: number) => string,
+    procForBinds: ((v: unknown) => unknown) | null | undefined,
+    block: (index: number) => string,
   ): this {
-    if (this.left.addBinds) this.left.addBinds(binds, procForBinds, block);
-    if (this.right.addBinds) this.right.addBinds(binds, procForBinds, block);
+    this.left.addBinds(binds, procForBinds, block);
+    this.right.addBinds(binds, procForBinds, block);
     return this;
   }
 
@@ -63,4 +61,7 @@ export class Composite {
     this.right.append(str);
     return this;
   }
+
+  private left: CollectorLike;
+  private right: CollectorLike;
 }

--- a/packages/arel/src/collectors/sql-string.ts
+++ b/packages/arel/src/collectors/sql-string.ts
@@ -14,31 +14,23 @@ export class SQLString extends PlainString {
     super();
   }
 
-  addBind(bind: unknown, block?: (index: number) => string): this {
-    if (block) {
-      this.append(block(this.bindIndex));
-    } else {
-      this.append("?");
-    }
+  addBind(bind: unknown, block: (index: number) => string): this {
+    this.append(block(this.bindIndex));
     this.bindIndex++;
     return this;
   }
 
   addBinds(
     binds: unknown[],
-    _procForBinds?: ((v: unknown) => unknown) | null,
-    block?: (index: number) => string,
+    _procForBinds: ((v: unknown) => unknown) | null | undefined,
+    block: (index: number) => string,
   ): this {
-    if (block) {
-      const parts: string[] = [];
-      for (let i = this.bindIndex; i < this.bindIndex + binds.length; i++) {
-        parts.push(block(i));
-      }
-      this.append(parts.join(", "));
-    } else {
-      this.append(binds.map(() => "?").join(", "));
+    const parts: string[] = [];
+    for (let i = this.bindIndex; i < this.bindIndex + binds.length; i++) {
+      parts.push(block(i));
     }
     this.bindIndex += binds.length;
+    this.append(parts.join(", "));
     return this;
   }
 }

--- a/packages/arel/src/delete-manager.ts
+++ b/packages/arel/src/delete-manager.ts
@@ -32,8 +32,8 @@ export class DeleteManager extends TreeManager {
    *
    * Mirrors: Arel::DeleteManager#from
    */
-  from(table: Table): this {
-    this.ast.relation = table;
+  from(relation: Table): this {
+    this.ast.relation = relation;
     return this;
   }
 
@@ -58,8 +58,8 @@ export class DeleteManager extends TreeManager {
    *
    * Mirrors: Arel::DeleteManager#having
    */
-  having(condition: Node): this {
-    this.ast.havings.push(condition);
+  having(expr: Node): this {
+    this.ast.havings.push(expr);
     return this;
   }
 }

--- a/packages/arel/src/insert-manager.ts
+++ b/packages/arel/src/insert-manager.ts
@@ -51,8 +51,8 @@ export class InsertManager extends TreeManager {
    * either shape (raw Node or SelectManager-shaped duck-type) via
    * `visit`.
    */
-  select(selectManager: InsertSelectSource): this {
-    this.ast.select = selectManager;
+  select(select: InsertSelectSource): this {
+    this.ast.select = select;
     return this;
   }
 
@@ -96,8 +96,8 @@ export class InsertManager extends TreeManager {
    *
    * Mirrors: Arel::InsertManager#create_values
    */
-  createValues(row: unknown[]): ValuesList {
-    return new ValuesList([row]);
+  createValues(values: unknown[]): ValuesList {
+    return new ValuesList([values]);
   }
 
   /**

--- a/packages/arel/src/nodes/as.test.ts
+++ b/packages/arel/src/nodes/as.test.ts
@@ -6,14 +6,14 @@ describe("As", () => {
   describe("#as", () => {
     it("makes an AS node", () => {
       const attr = new Table("users").get("id");
-      const as = attr.as(sql("foo"));
+      const as = attr.as(sql("foo")) as Nodes.As;
       expect(as.left).toBe(attr);
       expect((as.right as Nodes.SqlLiteral).value).toBe("foo");
     });
 
     it("converts right to SqlLiteral if a string", () => {
       const attr = new Table("users").get("id");
-      const as = attr.as("foo");
+      const as = attr.as("foo") as Nodes.As;
       expect(as.right).toBeInstanceOf(Nodes.SqlLiteral);
     });
   });

--- a/packages/arel/src/nodes/binary.ts
+++ b/packages/arel/src/nodes/binary.ts
@@ -146,10 +146,6 @@ export class Binary extends NodeExpression {
     return copy;
   }
 
-  as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
-  }
-
   and(other: Node): And {
     return new And([this, other]);
   }

--- a/packages/arel/src/nodes/case.test.ts
+++ b/packages/arel/src/nodes/case.test.ts
@@ -84,7 +84,7 @@ describe("NodesTest", () => {
     describe("#as", () => {
       it("allows aliasing", () => {
         const node = new Nodes.Case("foo" as unknown as Nodes.Node);
-        const as = node.as("bar");
+        const as = node.as("bar") as Nodes.As;
 
         expect(as.left).toEqual(node);
         expect(as.right).toBeInstanceOf(Nodes.SqlLiteral);

--- a/packages/arel/src/nodes/case.ts
+++ b/packages/arel/src/nodes/case.ts
@@ -2,9 +2,8 @@ import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { cloneSlot, objectClone } from "../clone-support.js";
 import { Node } from "./node.js";
 import { NodeExpression } from "./node-expression.js";
-import { SqlLiteral } from "./sql-literal.js";
 import { buildQuoted } from "./casted.js";
-import { As, Binary } from "./binary.js";
+import { Binary, type NodeOrValue } from "./binary.js";
 import { Unary } from "./unary.js";
 
 /**
@@ -19,9 +18,11 @@ export class Case extends NodeExpression {
   conditions: When[];
   default: Node | null;
 
-  constructor(operand?: Node, defaultValue?: Node) {
+  // Rails names the second parameter `default` (case.rb:8); `default` is a
+  // reserved word in TypeScript, so the parameter keeps the `Value` suffix.
+  constructor(expression?: Node, defaultValue?: Node) {
     super();
-    this.case = operand ?? null;
+    this.case = expression ?? null;
     this.conditions = [];
     // case.rb:11 stores the second argument raw — only `#else` wraps in an
     // Else node (case.rb:25-28).
@@ -32,15 +33,14 @@ export class Case extends NodeExpression {
   // semantics (case.rb:13-16). A prototype method, not an own property: an own
   // property would be copied by `objectClone` still closed over the ORIGINAL,
   // so a cloned Case's `#when` would mutate the original's conditions.
-  when(condition: Node | unknown, result?: Node | unknown): this {
-    const whenNode = buildQuoted(condition);
-    const thenNode = buildQuoted(result === undefined ? null : result);
-    this.conditions.push(new When(whenNode, thenNode));
+  when(condition: Node | unknown, expression: NodeOrValue = null): this {
+    // case.rb:14-15 stores `expression` raw — only `#then` and `#else` quote.
+    this.conditions.push(new When(buildQuoted(condition), expression));
     return this;
   }
 
-  else(result: Node | unknown): this {
-    this.default = new Else(buildQuoted(result === undefined ? null : result));
+  else(expression: Node | unknown): this {
+    this.default = new Else(buildQuoted(expression === undefined ? null : expression));
     return this;
   }
   // Mirrors Arel::Nodes::Case#hash / #eql? / #== (case.rb:35-46).
@@ -74,10 +74,10 @@ export class Case extends NodeExpression {
   // callers chaining `.when().then(value).when()` see `this` (and TS can
   // resolve `this.when` without an undefined-check).
   then(onFulfilled: (v: unknown) => unknown, onRejected: (e: unknown) => unknown): void;
-  then(result: Node | unknown): this;
+  then(expression: Node | unknown): this;
 
-  then(result: Node | unknown, onRejected?: unknown): this | void {
-    if (typeof result === "function" && typeof onRejected === "function") {
+  then(expression: Node | unknown, onRejected?: unknown): this | void {
+    if (typeof expression === "function" && typeof onRejected === "function") {
       (onRejected as (e: Error) => unknown)(
         new TypeError("Arel::Nodes::Case is not awaitable; use #toSql() to render"),
       );
@@ -85,12 +85,8 @@ export class Case extends NodeExpression {
     }
     const last = this.conditions[this.conditions.length - 1];
     if (!last) throw new Error("Case#then called before Case#when");
-    last.right = buildQuoted(result === undefined ? null : result);
+    last.right = buildQuoted(expression === undefined ? null : expression);
     return this;
-  }
-
-  as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 
   // Mirrors Arel::Nodes::Case#initialize_copy (case.rb:29-33), which Ruby runs

--- a/packages/arel/src/nodes/extract.ts
+++ b/packages/arel/src/nodes/extract.ts
@@ -1,8 +1,6 @@
 import { rbEqual, rbHash } from "@blazetrails/activesupport";
 import { Node } from "./node.js";
 import { Unary } from "./unary.js";
-import { As } from "./binary.js";
-import { SqlLiteral } from "./sql-literal.js";
 
 /**
  * Represents EXTRACT(field FROM expr).
@@ -24,9 +22,5 @@ export class Extract extends Unary {
 
   override eql(other: unknown): boolean {
     return super.eql(other) && rbEqual(this.field, (other as Extract).field);
-  }
-
-  as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
   }
 }

--- a/packages/arel/src/nodes/grouping.ts
+++ b/packages/arel/src/nodes/grouping.ts
@@ -14,8 +14,6 @@ export class Grouping extends Unary {
     super(expr);
   }
 
-  // Mirrors: Arel::Nodes::Grouping#fetch_attribute (grouping.rb:6-8) —
-  // `expr.fetch_attribute(&block)`, delegated bare.
   fetchAttribute(block: (attr: Node) => unknown): unknown {
     return (
       this.expr as { fetchAttribute(block: (attr: Node) => unknown): unknown }

--- a/packages/arel/src/nodes/grouping.ts
+++ b/packages/arel/src/nodes/grouping.ts
@@ -1,8 +1,6 @@
 import { _setGrouping } from "../node-slots.js";
 import { Node } from "./node.js";
 import { Unary } from "./unary.js";
-import { As } from "./binary.js";
-import { SqlLiteral } from "./sql-literal.js";
 
 /**
  * Grouping node — wraps an expression in parentheses.
@@ -16,20 +14,12 @@ export class Grouping extends Unary {
     super(expr);
   }
 
+  // Mirrors: Arel::Nodes::Grouping#fetch_attribute (grouping.rb:6-8) —
+  // `expr.fetch_attribute(&block)`, delegated bare.
   fetchAttribute(block: (attr: Node) => unknown): unknown {
-    if (
-      this.expr &&
-      typeof (this.expr as unknown as { fetchAttribute: unknown }).fetchAttribute === "function"
-    ) {
-      return (
-        this.expr as unknown as { fetchAttribute(block: (attr: Node) => unknown): unknown }
-      ).fetchAttribute(block);
-    }
-    return undefined;
-  }
-
-  as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
+    return (
+      this.expr as { fetchAttribute(block: (attr: Node) => unknown): unknown }
+    ).fetchAttribute(block);
   }
 }
 

--- a/packages/arel/src/nodes/infix-operation.test.ts
+++ b/packages/arel/src/nodes/infix-operation.test.ts
@@ -13,7 +13,7 @@ describe("TestInfixOperation", () => {
 
   it("operation alias", () => {
     const operation = new Nodes.InfixOperation("+", 1 as unknown as Node, 2 as unknown as Node);
-    const aliaz = operation.as("zomg");
+    const aliaz = operation.as("zomg") as Nodes.As;
     expect(aliaz).toBeInstanceOf(Nodes.As);
     expect(aliaz.left).toBe(operation);
     expect(String(aliaz.right)).toBe("zomg");

--- a/packages/arel/src/nodes/infix-operation.ts
+++ b/packages/arel/src/nodes/infix-operation.ts
@@ -1,10 +1,6 @@
 import { Node } from "./node.js";
 import { Binary, type NodeOrValue } from "./binary.js";
-import { As } from "./binary.js";
-import { SqlLiteral } from "./sql-literal.js";
 import { buildQuoted } from "./casted.js";
-import { Ascending } from "./ascending.js";
-import { Descending } from "./descending.js";
 
 /**
  * Represents a custom infix operation: left OP right.
@@ -32,18 +28,6 @@ export class InfixOperation extends Binary {
    */
   quotedNode(other: unknown): Node {
     return buildQuoted(other, this);
-  }
-
-  as(other: string | SqlLiteral): As {
-    return new As(this, new SqlLiteral(other, { retryable: true }));
-  }
-
-  asc(): Ascending {
-    return new Ascending(this);
-  }
-
-  desc(): Descending {
-    return new Descending(this);
   }
 }
 

--- a/packages/arel/src/nodes/node-expression.ts
+++ b/packages/arel/src/nodes/node-expression.ts
@@ -31,7 +31,6 @@ export abstract class NodeExpression extends Node {
    * @internal
    */
   quotedNode(other: unknown): Node {
-    if (other instanceof Node) return other;
     if (_buildQuoted) return _buildQuoted(other, this);
     throw new Error(
       'NodeExpression.quotedNode called before buildQuoted was registered. Import from "@blazetrails/arel" so Arel package initialization runs and wires node registries.',

--- a/packages/arel/src/nodes/node.test.ts
+++ b/packages/arel/src/nodes/node.test.ts
@@ -29,8 +29,8 @@ describe("TestNode", () => {
   });
 
   it("is equal with equal ivars (checks left/right)", () => {
-    const a = users.get("name").as("n");
-    const b = users.get("name").as("n");
+    const a = users.get("name").as("n") as Nodes.As;
+    const b = users.get("name").as("n") as Nodes.As;
     expect((a.right as Nodes.SqlLiteral).value).toBe((b.right as Nodes.SqlLiteral).value);
   });
 

--- a/packages/arel/src/nodes/sql-literal.ts
+++ b/packages/arel/src/nodes/sql-literal.ts
@@ -92,7 +92,7 @@ export class SqlLiteral extends Node {
   // Predications#quoted_node, which calls `Nodes.build_quoted(other, self)`).
   /** @internal */
   quotedNode(other: unknown): Node {
-    return other instanceof Node ? other : buildQuoted(other, this);
+    return buildQuoted(other, this);
   }
 
   // Mirrors Arel::Nodes::SqlLiteral#+ (sql_literal.rb:25-29), including the

--- a/packages/arel/src/nodes/unary-operation.test.ts
+++ b/packages/arel/src/nodes/unary-operation.test.ts
@@ -12,7 +12,7 @@ describe("TestUnaryOperation", () => {
 
   it("operation alias", () => {
     const operation = new Nodes.UnaryOperation("-", 1 as unknown as Node);
-    const aliaz = operation.as("zomg");
+    const aliaz = operation.as("zomg") as Nodes.As;
     expect(aliaz).toBeInstanceOf(Nodes.As);
     expect(aliaz.left).toBe(operation);
     expect(String(aliaz.right)).toBe("zomg");

--- a/packages/arel/src/nodes/unary-operation.ts
+++ b/packages/arel/src/nodes/unary-operation.ts
@@ -1,9 +1,5 @@
 import { Node } from "./node.js";
 import { Unary } from "./unary.js";
-import { As } from "./binary.js";
-import { SqlLiteral } from "./sql-literal.js";
-import { Ascending } from "./ascending.js";
-import { Descending } from "./descending.js";
 
 /**
  * UnaryOperation — a prefix or postfix unary operation.
@@ -20,18 +16,6 @@ export class UnaryOperation extends Unary {
   constructor(operator: string, operand: Node) {
     super(operand);
     this.operator = operator;
-  }
-
-  as(aliasName: string): As {
-    return new As(this, new SqlLiteral(aliasName, { retryable: true }));
-  }
-
-  asc(): Ascending {
-    return new Ascending(this);
-  }
-
-  desc(): Descending {
-    return new Descending(this);
   }
 }
 

--- a/packages/arel/src/select-manager.test.ts
+++ b/packages/arel/src/select-manager.test.ts
@@ -496,11 +496,6 @@ describe("SelectManagerTest", () => {
       const mgr = users.project(star()).order("name ASC");
       expect(mgr.toSql()).toContain("ORDER BY name ASC");
     });
-
-    it("accepts symbol and uses description (Rails :sym.to_s == 'sym')", () => {
-      const mgr = users.project(star()).order(Symbol("name"));
-      expect(mgr.toSql()).toContain("ORDER BY name");
-    });
   });
 
   describe("order", () => {

--- a/packages/arel/src/select-manager.ts
+++ b/packages/arel/src/select-manager.ts
@@ -238,8 +238,8 @@ export class SelectManager extends TreeManager {
   /**
    * Add HAVING.
    */
-  having(condition: Node): this {
-    this.core.havings.push(condition);
+  having(expr: Node): this {
+    this.core.havings.push(expr);
     return this;
   }
 
@@ -325,16 +325,8 @@ export class SelectManager extends TreeManager {
   /**
    * Add ORDER BY clauses.
    */
-  order(...exprs: (Node | string | symbol)[]): this {
-    this.ast.orders.push(
-      ...exprs.map((x) =>
-        typeof x === "string"
-          ? new SqlLiteral(x)
-          : typeof x === "symbol"
-            ? new SqlLiteral(x.description ?? x.toString())
-            : x,
-      ),
-    );
+  order(...expr: (Node | string)[]): this {
+    this.ast.orders.push(...expr.map((x) => (typeof x === "string" ? new SqlLiteral(x) : x)));
     return this;
   }
 
@@ -350,8 +342,8 @@ export class SelectManager extends TreeManager {
   /**
    * Add a WHERE condition.
    */
-  where(condition: Node | TreeManager): this {
-    this.core.wheres.push(condition instanceof TreeManager ? condition.ast : condition);
+  where(expr: Node | TreeManager): this {
+    this.core.wheres.push(expr instanceof TreeManager ? expr.ast : expr);
     return this;
   }
 
@@ -429,8 +421,8 @@ export class SelectManager extends TreeManager {
   /**
    * Set WITH (CTE).
    */
-  with(...ctes: Node[]): this {
-    this.ast.with = new With(ctes);
+  with(...subqueries: Node[]): this {
+    this.ast.with = new With(subqueries);
     return this;
   }
 

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -62,7 +62,8 @@ export class Table {
   // Rails stores whatever `name` it was handed (table.rb:16) — a String, an
   // `Arel.sql` SqlLiteral, or a node such as a NamedFunction
   // (test/cases/arel/table_test.rb:118-130).
-  readonly name: string | Node;
+  // `attr_accessor :name` (table.rb:11).
+  name: string | Node;
   readonly tableAlias: string | null;
   readonly klass?: TableKlass;
 
@@ -136,8 +137,8 @@ export class Table {
    *
    * Mirrors: Arel::Table#order
    */
-  order(...exprs: (Node | string)[]): SelectManager {
-    return this.from().order(...exprs);
+  order(...expr: (Node | string)[]): SelectManager {
+    return this.from().order(...expr);
   }
 
   /**
@@ -149,8 +150,8 @@ export class Table {
     return this.from().where(condition);
   }
 
-  project(...projections: (Node | string)[]): SelectManager {
-    return this.from().project(...projections);
+  project(...things: (Node | string)[]): SelectManager {
+    return this.from().project(...things);
   }
 
   /**

--- a/packages/arel/src/visitors/dot.ts
+++ b/packages/arel/src/visitors/dot.ts
@@ -512,8 +512,8 @@ export class Dot extends Visitor {
   }
 
   /** Mirrors Rails' Dot#quote — escape `"` for inclusion in a label. */
-  protected quote(value: unknown): string {
-    return String(value).replace(/"/g, '\\"');
+  protected quote(string: unknown): string {
+    return String(string).replace(/"/g, '\\"');
   }
 
   /**
@@ -577,7 +577,6 @@ export class Dot extends Visitor {
     if (typeof o === "number") return Number.isInteger(o) ? "Integer" : "Float";
     if (typeof o === "boolean") return o ? "TrueClass" : "FalseClass";
     if (typeof o === "bigint") return "Integer";
-    if (typeof o === "symbol") return "Symbol";
     // boundary: legacy JS Date values stringify to Rails' `Time` class name.
     if (o instanceof Date) return "Time";
     const temporalClass = temporalClassName(o);

--- a/packages/arel/src/visitors/ruby-class.ts
+++ b/packages/arel/src/visitors/ruby-class.ts
@@ -41,7 +41,6 @@ export function rubyClassName(v: unknown): string | null {
   if (v === null || v === undefined) return "NilClass";
   if (typeof v === "string") return "String";
   if (typeof v === "boolean") return v ? "TrueClass" : "FalseClass";
-  if (typeof v === "symbol") return "Symbol";
   const dateTime = dateTimeClassName(v);
   if (dateTime !== null) return dateTime;
   if (isHashAnalogue(v)) return "Hash";

--- a/scripts/api-compare/extra-surface-mark.json
+++ b/scripts/api-compare/extra-surface-mark.json
@@ -5,6 +5,6 @@
   },
   "arel": {
     "novel": 0,
-    "total": 47
+    "total": 40
   }
 }


### PR DESCRIPTION
Six RFC 0124 deviation stories, all in `arel`. Net -205 LOC.

### `Attributes::Attribute` takes its five mixins by `include()`
`attribute.rb:6-10` includes `Expressions`, `Predications`, `AliasPredication`,
`OrderPredications`, `Math`. trails wired only `Predications` and hand-copied 22
method bodies (`asc`/`desc`, the ten `Math` operators, `as`, and the six
aggregate `Expressions` methods). All five `include()`s now happen in Rails'
order, and `interface Attribute extends …` merges the four module interfaces.
`attribute.ts` drops from 234 to 138 lines.

### `Case#when` stores its expression raw
`case.rb:14-17` — `When.new(Nodes.build_quoted(condition), expression)`; only
`#then` (case.rb:19-22) and `#else` (case.rb:24-27) quote. Parameters renamed to
Rails' `expression` in `when` / `then` / `else` / the constructor
(`defaultValue` keeps its suffix — `default` is reserved, noted at the site).
`in_order_of` was the one caller relying on `when`'s quoting; it now builds
`when(column.eq(value)).then(order)` exactly as `query_methods.rb:2166` does.

### Four invented guards / fallbacks removed
- `SQLString#addBind` / `#addBinds` take a required block — Rails always
  `yield`s (`sql_string.rb:15-24`), so the `"?"` fallback arm was unreachable
  fiction. Every caller already passes `this.bindBlock()`.
- `Composite#retryable` is a stored field written by the writer
  (`composite.rb:8,14-18`) rather than an AND over the two children;
  `addBinds` delegates unguarded (`composite.rb:32-36`); `preparable` has no
  default. The optional-`addBinds` guard existed only to prop up two TS-only
  tests with a duck-typed collector double — those moved to
  `composite.trails.test.ts` against a real `SQLString`/`Bind` pair.
- `Grouping#fetchAttribute` is the one-line delegation of `grouping.rb:6-8`.
- Both `quotedNode`s drop the `other instanceof Node` short-circuit;
  `build_quoted` (`casted.rb:48-60`) already owns that pass-through arm.

### Six node subclasses stop redefining `as` / `asc` / `desc`
`nodes/case.ts`, `extract.ts`, `binary.ts`, `grouping.ts`, `infix-operation.ts`,
`unary-operation.ts` — the methods now resolve through the `NodeExpression` /
`InfixOperation` mixin wiring in `index.ts`. (`Function#as` is a genuine Rails
override, `function.rb:17-20`, and stays.) `parity:api:extra` for `arel` drops
47 → 40 total; the mark is tightened.

### Parameter-name drift + `Table#name`
12 parameters take the Rails identifier camelCased — `DeleteManager#from(relation)`,
`#having(expr)`, `InsertManager#select(select)` / `#createValues(values)`,
`SelectManager#where(expr)` / `#having(expr)` / `#with(subqueries)` / `#order(expr)`,
`Table#order(expr)` / `#project(things)`, `Dot#quote(string)`. `Table#name` is
`attr_accessor` (`table.rb:11`) and is no longer `readonly`.

### The JS-`Symbol` Ruby-Symbol arm
`SelectManager#order` / `Table#order` now take `(Node | string)[]` named `expr`
with the string arm only — same shape as `Window#order`, and what
`select_manager.rb:172-178` means in trails, where both halves of
`STRING_OR_SYMBOL_CLASS` are `string`. `visitors/ruby-class.ts` and
`visitors/dot.ts` drop the `typeof x === "symbol" → "Symbol"` classification;
no caller ever handed a visitor a JS `Symbol`.

### Verification
- `pnpm typecheck` clean; `pnpm lint --fix` clean (no rewrites).
- `pnpm vitest run packages/arel/src` — 93 files, 1447 tests pass. No test renamed.
- `pnpm parity:api --package arel` 957/957, files 69/69, arity 707/707.
- `parity:api:extra:gate` OK (arel novel 0/0, total 40/40, tightened).
- `parity:api:calls` OK; `parity:api:calls:args` OK; the
  `nodes/case.ts#when` naming row is gone from the args report.

Closes-story: arel-attribute-inlines-four-mixins
Closes-story: arel-case-when-quotes-expression
Closes-story: arel-collectors-and-grouping-invented-guards
Closes-story: arel-node-subclasses-redefine-as-asc-desc
Closes-story: arel-parameter-name-drift-sweep
Closes-story: arel-select-manager-order-js-symbol-arm
