### PR TITLE
refactor(activemodel): issue Validations' and Attributes' mixin contracts from their own included hooks (RFC 0115)

### DIFF
--- a/packages/activemodel/src/api.ts
+++ b/packages/activemodel/src/api.ts
@@ -10,22 +10,9 @@ import {
   sanitizeForMassAssignment,
   sanitizeForbiddenAttributes,
 } from "./forbidden-attributes-protection.js";
-import {
-  Validations,
-  ClassMethods as ValidationsClassMethods,
-  contextForValidation,
-  runValidationsBang,
-  raiseValidationError,
-  readAttributeForValidation,
-  freeze,
-  type ValidationContext,
-} from "./validations.js";
+import { Validations, type ValidationContext } from "./validations.js";
 import type { AttrNameArg } from "./validations/helper-methods.js";
-import {
-  ClassMethods as WithClassMethods,
-  validatesWith as withValidatesWith,
-} from "./validations/with.js";
-import * as Validates from "./validations/validates.js";
+import type { validatesWith as withValidatesWith } from "./validations/with.js";
 import { Conversion, ClassMethods as ConversionClassMethods } from "./conversion.js";
 import { Naming } from "./naming.js";
 import { Translation } from "./translation.js";
@@ -89,29 +76,10 @@ export class API {
       sanitizeForbiddenAttributes,
     });
 
-    // api.rb:62 — `include ActiveModel::Validations`. Ruby's Concern brings
-    // `ClassMethods` (validations.rb:57-307) along; `validations/with.rb:87`
-    // and `validations/validates.rb:110` reopen the same module, hence the
-    // further extends.
-    extend(base, ValidationsClassMethods);
-    extend(base, WithClassMethods);
-    extend(base, {
-      validates: Validates.validates,
-      validatesBang: Validates.validatesBang,
-      _validatesDefaultKeys: Validates._validatesDefaultKeys,
-      _parseValidatesOptions: Validates._parseValidatesOptions,
-    });
-    // The module's own `included do` block (validations.rb:40-50) runs from
-    // its `[included]` hook.
+    // api.rb:62 — `include ActiveModel::Validations`. The module's own
+    // `[included]` hook issues its `ClassMethods` half and its `included do`
+    // block, exactly as Ruby's Concern does.
     include(base, Validations);
-    include(base, {
-      contextForValidation,
-      runValidationsBang,
-      raiseValidationError,
-      readAttributeForValidation,
-      freeze,
-      validatesWith: withValidatesWith,
-    });
 
     // api.rb:63 — `include ActiveModel::Conversion` and its `ClassMethods`
     // half (conversion.rb:105-118); the `included do` block (:28-33) rides

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -27,8 +27,6 @@ export interface AttributeRegistrationClassMethods {
   typeForAttribute(name: string, block?: () => Type): Type;
 }
 
-export type AttributeRegistration = AttributeRegistrationClassMethods;
-
 export interface AttributeHostInternals {
   _cachedDefaultAttributes?: AttributeSet | null;
   _cachedAttributeTypes?: Record<string, Type> | null;
@@ -416,3 +414,23 @@ export function hookAttributeType(
 ): Type {
   return type;
 }
+
+/**
+ * Mirrors: ActiveModel::AttributeRegistration::ClassMethods
+ * (attribute_registration.rb:11-115) — everything `include
+ * ActiveModel::AttributeRegistration` puts on the includer's singleton,
+ * including the `private` half at :53-115 (Ruby's `private` does not take a
+ * method off the module).
+ */
+export const ClassMethods = {
+  attribute,
+  decorateAttributes,
+  _defaultAttributes,
+  attributeTypes,
+  typeForAttribute,
+  pendingAttributeModifications,
+  resetDefaultAttributesBang,
+  resolveAttributeName,
+  resolveTypeName,
+  hookAttributeType,
+};

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -1,14 +1,16 @@
-import { include, type CodeGenerator, included } from "@blazetrails/activesupport";
+import { extend, include, type CodeGenerator, included } from "@blazetrails/activesupport";
 import { Type } from "./type/value.js";
 import { AttributeSet } from "./attribute-set.js";
 import {
   AttrNames,
   ClassMethods as AttributeMethodsClassMethods,
   InstanceMethods as AttributeMethodsInstanceMethods,
+  defineMethodAttribute,
   type AttributeMethodHost,
   type AttributeMethod,
 } from "./attribute-methods.js";
 import {
+  ClassMethods as AttributeRegistrationClassMethods,
   attribute as registrationAttribute,
   type AttributeRegistrationHost,
 } from "./attribute-registration.js";
@@ -203,6 +205,10 @@ export interface Attributes {
  *
  * Mirrors: ActiveModel::Attributes (instance side, attributes.rb:31-160)
  */
+/** The class Ruby's `included(base)` hook receives (attributes.rb:35). */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- `include()`'s own AnyClass shape.
+type IncludingClass = (new (...args: any[]) => any) & { prototype: object };
+
 /** A class with `ActiveModel::AttributeMethods` already extended onto it. */
 type AttributeMethodSuffixHost = AttributeMethodHost & {
   attributeMethodSuffix(...suffixes: Array<string | { parameters?: string | null | false }>): void;
@@ -217,7 +223,32 @@ export class Attributes {
    *   end
    */
   static [included](base: AttributeMethodSuffixHost): void {
+    // attributes.rb:32-33 — `include ActiveModel::AttributeRegistration` and
+    // `include ActiveModel::AttributeMethods`. Both are Concerns whose whole
+    // contribution is a `ClassMethods` extend (attribute_registration.rb has no
+    // `included do` block); AttributeMethods lands second, which is what makes
+    // its alias-resolving `resolve_attribute_name` (attribute_methods.rb:396-398)
+    // win over the registration one (attribute_registration.rb:101-103).
+    extend(base, AttributeRegistrationClassMethods);
+    extend(base, AttributeMethodsClassMethods);
+    include(base as unknown as IncludingClass, AttributeMethodsInstanceMethods);
+
+    // attributes.rb:39 — the module's own `ClassMethods`, whose `attribute`
+    // (:59-61) and `define_method_attribute=` (:92-104) override the
+    // registration halves.
+    extend(base, ClassMethods);
+    extend(base, { defineMethodAttribute });
+
+    // attributes.rb:35 — the `included do` block.
     base.attributeMethodSuffix("=", { parameters: "value" });
+
+    // attributes.rb:156-159 — `_write_attribute` and
+    // `alias :attribute= :_write_attribute`, private instance methods this
+    // file declares as free functions rather than on the prototype.
+    include(base as unknown as IncludingClass, {
+      _writeAttribute,
+      "attribute=": _writeAttribute,
+    });
   }
 
   _attributes: AttributeSet;
@@ -277,3 +308,14 @@ export class Attributes {
 // brings `attribute_missing` with it; the interface merge above is its type
 // side.
 include(Attributes, { attributeMissing: AttributeMethodsInstanceMethods.attributeMissing });
+
+/**
+ * Mirrors: ActiveModel::Attributes::ClassMethods (attributes.rb:38-104) — the
+ * class half `include ActiveModel::Attributes` contributes, issued from the
+ * module's own `[included]` hook.
+ */
+export const ClassMethods = {
+  attribute,
+  attributeNames,
+  setDefineMethodAttribute,
+};

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -226,15 +226,25 @@ export class Attributes {
    *   end
    */
   static [included](base: AttributeMethodSuffixHost): void {
-    // attributes.rb:32-33 — `include ActiveModel::AttributeRegistration` and
-    // `include ActiveModel::AttributeMethods`. Both are Concerns whose whole
-    // contribution is a `ClassMethods` extend (attribute_registration.rb has no
+    // concern.rb:135 — `@_dependencies.each { |dep| base.include(dep) }`, this
+    // module's `include`s at attributes.rb:32-33. AttributeRegistration is all
+    // `ClassMethods` (attribute_registration.rb has no instance half and no
     // `included do` block); AttributeMethods lands second, which is what makes
     // its alias-resolving `resolve_attribute_name` (attribute_methods.rb:396-398)
-    // win over the registration one (attribute_registration.rb:101-103).
+    // win over the registration one (attribute_registration.rb:101-103), and
+    // carries its own `included do` (attribute_methods.rb:70-73) in the plain
+    // module object's `[included]` hook.
     extend(base, AttributeRegistrationClassMethods);
     extend(base, AttributeMethodsClassMethods);
     include(base, AttributeMethodsInstanceMethods);
+
+    // concern.rb:136 — `super`, the module's own instance methods, which land
+    // before the `ClassMethods` extend (:137) and the `included do` block
+    // (:138). `include()` has already copied this class module's prototype;
+    // these are the rest of it — attributes.rb:156-159's `_write_attribute` and
+    // `alias :attribute= :_write_attribute`, which this port spells as free
+    // functions rather than prototype methods.
+    include(base, { _writeAttribute, "attribute=": _writeAttribute });
 
     // attributes.rb:39 — the module's own `ClassMethods`, whose `attribute`
     // (:59-61) and `define_method_attribute=` (:92-104) override the
@@ -247,11 +257,6 @@ export class Attributes {
 
     // attributes.rb:35 — the `included do` block.
     base.attributeMethodSuffix("=", { parameters: "value" });
-
-    // attributes.rb:156-159 — `_write_attribute` and
-    // `alias :attribute= :_write_attribute`, private instance methods this
-    // file declares as free functions rather than on the prototype.
-    include(base, { _writeAttribute, "attribute=": _writeAttribute });
   }
 
   _attributes: AttributeSet;

--- a/packages/activemodel/src/attributes.ts
+++ b/packages/activemodel/src/attributes.ts
@@ -205,14 +205,17 @@ export interface Attributes {
  *
  * Mirrors: ActiveModel::Attributes (instance side, attributes.rb:31-160)
  */
-/** The class Ruby's `included(base)` hook receives (attributes.rb:35). */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- `include()`'s own AnyClass shape.
-type IncludingClass = (new (...args: any[]) => any) & { prototype: object };
-
-/** A class with `ActiveModel::AttributeMethods` already extended onto it. */
-type AttributeMethodSuffixHost = AttributeMethodHost & {
-  attributeMethodSuffix(...suffixes: Array<string | { parameters?: string | null | false }>): void;
-};
+/**
+ * The class Ruby's `included(base)` hook receives (attributes.rb:35), with the
+ * `attribute_method_suffix` macro AttributeMethods has just put on it.
+ */
+type AttributeMethodSuffixHost = AttributeMethodHost &
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `include()`'s own AnyClass shape.
+  (new (...args: any[]) => any) & { prototype: object } & {
+    attributeMethodSuffix(
+      ...suffixes: Array<string | { parameters?: string | null | false }>
+    ): void;
+  };
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class Attributes {
@@ -231,12 +234,15 @@ export class Attributes {
     // win over the registration one (attribute_registration.rb:101-103).
     extend(base, AttributeRegistrationClassMethods);
     extend(base, AttributeMethodsClassMethods);
-    include(base as unknown as IncludingClass, AttributeMethodsInstanceMethods);
+    include(base, AttributeMethodsInstanceMethods);
 
     // attributes.rb:39 — the module's own `ClassMethods`, whose `attribute`
     // (:59-61) and `define_method_attribute=` (:92-104) override the
     // registration halves.
     extend(base, ClassMethods);
+    // CLAUDE.md § "Generated attribute readers are properties" — ActiveModel has
+    // no `define_method_attribute` hook, and needs one because a zero-arg Ruby
+    // reader ports as a property that `define_proxy_call` cannot emit.
     extend(base, { defineMethodAttribute });
 
     // attributes.rb:35 — the `included do` block.
@@ -245,10 +251,7 @@ export class Attributes {
     // attributes.rb:156-159 — `_write_attribute` and
     // `alias :attribute= :_write_attribute`, private instance methods this
     // file declares as free functions rather than on the prototype.
-    include(base as unknown as IncludingClass, {
-      _writeAttribute,
-      "attribute=": _writeAttribute,
-    });
+    include(base, { _writeAttribute, "attribute=": _writeAttribute });
   }
 
   _attributes: AttributeSet;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -41,9 +41,7 @@ import * as Validates from "./validations/validates.js";
 import { ClassMethods as WithClassMethods } from "./validations/with.js";
 import {
   Attributes,
-  attribute,
-  attributeNames,
-  setDefineMethodAttribute,
+  ClassMethods as AttributesClassMethods,
   initializeDup as attributesInitializeDup,
 } from "./attributes.js";
 import {
@@ -61,16 +59,8 @@ import { Access } from "./access.js";
 import { Naming } from "./naming.js";
 import { API, initialize as apiInitialize } from "./api.js";
 
-/**
- * Mirrors: ActiveModel::Attributes::ClassMethods (attributes.rb:38-101) — the
- * class half `include ActiveModel::Attributes` contributes, mixed onto `Model`
- * by the `extend()` at the bottom of this file.
- *
- */
 /** The class half of `include ActiveModel::AttributeMethods` (attribute_methods.rb:75-501). */
 type AttributeMethodsClassMethods = Extended<typeof AttributeMethods.ClassMethods>;
-
-const AttributesClassMethods = { attribute, setDefineMethodAttribute, attributeNames };
 
 /**
  * Anything `validates_with` accepts: a full `Validator`/`EachValidator`

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -44,7 +44,6 @@ import {
   attribute,
   attributeNames,
   setDefineMethodAttribute,
-  _writeAttribute,
   initializeDup as attributesInitializeDup,
 } from "./attributes.js";
 import {
@@ -542,35 +541,11 @@ export class Model {
   declare runCallbacks: Included<typeof ASCallbacks.InstanceMethods>["runCallbacks"];
 }
 
-// Ruby `include ActiveModel::AttributeRegistration` (attribute_registration.rb:8).
-extend(Model, {
-  decorateAttributes,
-  attributeTypes,
-  typeForAttribute: staticTypeForAttribute,
-  _defaultAttributes,
-  pendingAttributeModifications: _pendingAttributeModificationsHelper,
-  resetDefaultAttributesBang: _resetDefaultAttributesBangHelper,
-  resolveTypeName: _resolveTypeNameHelper,
-  hookAttributeType: _hookAttributeTypeHelper,
-});
-// `include ActiveModel::AttributeMethods` lands after AttributeRegistration
-// (model.rb:12-14), so its alias-resolving `resolve_attribute_name` override
-// (attribute_methods.rb:396-398) wins over the registration one. The module's
-// ClassMethods land on the class and its instance methods on instances, which
-// is what lets every ported body self-send them.
-extend(Model, AttributeMethods.ClassMethods);
-// Its `included do` block (attribute_methods.rb:70-73) rides along, issued from
-// the module's own `[included]` hook.
-include(Model, AttributeMethods.InstanceMethods);
-
-// `include ActiveModel::Attributes` (attributes.rb:29) — its `included` hook
-// issues `attribute_method_suffix "=", parameters: "value"` (attributes.rb:35),
-// so it has to run after the `attributeMethodPatterns` class attribute exists.
-extend(Model, AttributesClassMethods);
-extend(Model, { defineMethodAttribute });
+// `include ActiveModel::Attributes` (attributes.rb:30), which is itself
+// `AttributeRegistration` + `AttributeMethods` (attributes.rb:32-33) — the
+// module's `[included]` hook issues all three class halves and its own
+// `included do` block, so this is the one statement Ruby writes.
 include(Model, Attributes);
-// attributes.rb:156-159 — `_write_attribute` and `alias :attribute= :_write_attribute`.
-include(Model, { _writeAttribute, "attribute=": _writeAttribute });
 
 // Ruby `include ActiveModel::Validations::Callbacks`'s ClassMethods half
 // (validations/callbacks.rb:32) and its `included do` block (:25-30).

--- a/packages/activemodel/src/validations.trails.test.ts
+++ b/packages/activemodel/src/validations.trails.test.ts
@@ -3,6 +3,8 @@ import { Range } from "@blazetrails/activesupport";
 import { include } from "@blazetrails/activesupport";
 import { Model } from "./index.js";
 import { Errors } from "./errors.js";
+import { ModelName } from "./naming.js";
+import { humanAttributeName } from "./translation.js";
 import { Validations } from "./validations.js";
 import { resetI18n } from "./test-helpers/i18n.js";
 
@@ -1825,6 +1827,16 @@ describe("ValidationsTest (trails)", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
     class Host {
+      // `extend ActiveModel::Naming` / `Callbacks` / `Translation`
+      // (validations.rb:41-43); declared only for their types.
+      declare static modelName: ModelName;
+      declare static i18nScope: string;
+      declare static lookupAncestors: () => Array<{
+        new (...args: never[]): unknown;
+        modelName: ModelName;
+      }>;
+      declare static humanAttributeName: typeof humanAttributeName;
+
       title: string | null = null;
 
       constructor() {
@@ -1847,6 +1859,15 @@ describe("ValidationsTest (trails)", () => {
 
       host.title = "hello";
       expect(await host.isValid()).toBe(true);
+    });
+
+    // `extend ActiveModel::Naming` (validations.rb:41) is what gives the host a
+    // `model_name`, which every `Translation` reader resolves through
+    // (translation.rb:20, :27, :44).
+    it("gives the includer model_name and the Translation readers that resolve through it", () => {
+      expect(Host.modelName.name).toBe("Host");
+      expect(Host.i18nScope).toBe("activemodel");
+      expect(Host.humanAttributeName("title")).toBe("Title");
     });
   });
 });

--- a/packages/activemodel/src/validations.trails.test.ts
+++ b/packages/activemodel/src/validations.trails.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { Range } from "@blazetrails/activesupport";
+import { include } from "@blazetrails/activesupport";
 import { Model } from "./index.js";
+import { Errors } from "./errors.js";
+import { Validations } from "./validations.js";
 import { resetI18n } from "./test-helpers/i18n.js";
 
 // Trails-only extras that have no `validations_test.rb` counterpart. They live
@@ -1807,6 +1810,43 @@ describe("ValidationsTest (trails)", () => {
       expect(u.errors.generateMessage("age", ":greater_than", { count: 0 })).toBe(
         "must be greater than 0",
       );
+    });
+  });
+
+  // `include ActiveModel::Validations` is a Concern (validations.rb:37), so a
+  // Ruby includer gets `ClassMethods` (validations.rb:57-307) and the
+  // reopenings at `validations/with.rb:87` and `validations/validates.rb:110`
+  // from the one `include` — no `extend` at the call site.
+  describe("include Validations", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging -- Ruby `include` (validations.rb:37); the class/interface merge is how `include()` surfaces on the type side.
+    interface Host extends Validations {
+      title: string | null;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+    class Host {
+      title: string | null = null;
+
+      constructor() {
+        this.errors = new Errors(this);
+      }
+
+      readAttributeForValidation(attribute: string): unknown {
+        return (this as unknown as Record<string, unknown>)[attribute];
+      }
+    }
+    include(Host, Validations);
+    (Host as unknown as { validates(...args: unknown[]): void }).validates("title", {
+      presence: true,
+    });
+
+    it("gives the includer the class macros and the runner", async () => {
+      const host = new Host();
+      expect(await host.isValid()).toBe(false);
+      expect(host.errors.messages.get("title")).toEqual(["can't be blank"]);
+
+      host.title = "hello";
+      expect(await host.isValid()).toBe(true);
     });
   });
 });

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -128,8 +128,23 @@ export class Validations {
    * `lookup_ancestors` and `i18n_scope` (translation.rb:20, :27, :44).
    */
   static [included](base: IncludingClass): void {
-    // `ActiveSupport::Concern#append_features` extends `ClassMethods` before it
-    // class_evals the `included do` block, so the macros land first. Ruby's
+    // `ActiveSupport::Concern#append_features` (concern.rb:135-138) mixes the
+    // module's own instance methods (`super`, :136) before it extends
+    // `ClassMethods` (:137) and class_evals the `included do` block (:138).
+    // `include()` has already copied this class module's prototype; these are
+    // the rest of `super` — the members validations.rb declares on the module
+    // itself (:296-306, :376, :437, :467-471, :589) and `with.rb:144-151`,
+    // which this port spells as free functions rather than prototype methods.
+    include(base, {
+      contextForValidation,
+      runValidationsBang,
+      raiseValidationError,
+      readAttributeForValidation,
+      freeze,
+      validatesWith: withValidatesWith,
+    });
+
+    // concern.rb:137 — `base.extend const_get(:ClassMethods)`. Ruby's
     // reopenings of the same module (`validations/with.rb:87`,
     // `validations/validates.rb:110`) ride along on the one `extend`; each
     // reopening lives in the `.ts` matching its `.rb`, so they are separate
@@ -149,19 +164,6 @@ export class Validations {
     include(base, HelperMethods);
     defineCallbacks(base.prototype, "validate", { scope: ["name"] });
     classAttribute.call(base, "_validators", { instanceWriter: false, default: new Map() });
-
-    // The module's own instance methods that this file (and
-    // `validations/with.rb:144-151`) declares as free functions rather than on
-    // the `Validations` prototype — `include()` copies a class module's
-    // prototype, so these need the second call.
-    include(base, {
-      contextForValidation,
-      runValidationsBang,
-      raiseValidationError,
-      readAttributeForValidation,
-      freeze,
-      validatesWith: withValidatesWith,
-    });
   }
 
   declare errors: Errors;

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -16,6 +16,11 @@ import { freeze as attributesFreeze, type AttributeInstanceHost } from "./attrib
 
 import { Translation, raiseOnMissingTranslations as translationRaise } from "./translation.js";
 import { HelperMethods } from "./validations/helper-methods.js";
+import {
+  ClassMethods as WithClassMethods,
+  validatesWith as withValidatesWith,
+} from "./validations/with.js";
+import * as Validates from "./validations/validates.js";
 import { ArgumentError, NoMethodError } from "./attribute-assignment.js";
 import type { CallbackFn, CallbackConditions } from "./callbacks.js";
 import {
@@ -123,12 +128,40 @@ export class Validations {
    * `lookup_ancestors` and `i18n_scope` (translation.rb:20, :27, :44).
    */
   static [included](base: IncludingClass): void {
+    // `ActiveSupport::Concern#append_features` extends `ClassMethods` before it
+    // class_evals the `included do` block, so the macros land first. Ruby's
+    // reopenings of the same module (`validations/with.rb:87`,
+    // `validations/validates.rb:110`) ride along on the one `extend`; each
+    // reopening lives in the `.ts` matching its `.rb`, so they are separate
+    // `extend()` calls here.
+    extend(base, ClassMethods);
+    extend(base, WithClassMethods);
+    extend(base, {
+      validates: Validates.validates,
+      validatesBang: Validates.validatesBang,
+      _validatesDefaultKeys: Validates._validatesDefaultKeys,
+      _parseValidatesOptions: Validates._parseValidatesOptions,
+    });
+
     extend(base, Callbacks);
     extend(base, Translation);
     extend(base, HelperMethods);
     include(base, HelperMethods);
     defineCallbacks(base.prototype, "validate", { scope: ["name"] });
     classAttribute.call(base, "_validators", { instanceWriter: false, default: new Map() });
+
+    // The module's own instance methods that this file (and
+    // `validations/with.rb:144-151`) declares as free functions rather than on
+    // the `Validations` prototype — `include()` copies a class module's
+    // prototype, so these need the second call.
+    include(base, {
+      contextForValidation,
+      runValidationsBang,
+      raiseValidationError,
+      readAttributeForValidation,
+      freeze,
+      validatesWith: withValidatesWith,
+    });
   }
 
   declare errors: Errors;

--- a/packages/activemodel/src/validations.ts
+++ b/packages/activemodel/src/validations.ts
@@ -14,6 +14,7 @@ import type { ValidatableRecord } from "./validator.js";
 import { I18n } from "./i18n.js";
 import { freeze as attributesFreeze, type AttributeInstanceHost } from "./attributes.js";
 
+import { Naming } from "./naming.js";
 import { Translation, raiseOnMissingTranslations as translationRaise } from "./translation.js";
 import { HelperMethods } from "./validations/helper-methods.js";
 import {
@@ -123,9 +124,11 @@ type IncludingClass = (new (...args: any[]) => any) & { prototype: object };
 export class Validations {
   /**
    * Rails' `included do` block (validations.rb:40-50). The `extend`s at :41-43
-   * install what their modules already export: `define_model_callbacks`
-   * (callbacks.rb:72) and the whole of Translation — `human_attribute_name`,
-   * `lookup_ancestors` and `i18n_scope` (translation.rb:20, :27, :44).
+   * install what their modules already export: `model_name` (naming.rb:270-277),
+   * `define_model_callbacks` (callbacks.rb:72) and the whole of Translation —
+   * `human_attribute_name`, `lookup_ancestors` and `i18n_scope`
+   * (translation.rb:20, :27, :44), which resolve through `model_name` and so
+   * need the `Naming` extend at :41 even on a host that never includes `API`.
    */
   static [included](base: IncludingClass): void {
     // `ActiveSupport::Concern#append_features` (concern.rb:135-138) mixes the
@@ -158,6 +161,7 @@ export class Validations {
       _parseValidatesOptions: Validates._parseValidatesOptions,
     });
 
+    extend(base, Naming);
     extend(base, Callbacks);
     extend(base, Translation);
     extend(base, HelperMethods);

--- a/scripts/api-compare/extract-ruby-api.test.ts
+++ b/scripts/api-compare/extract-ruby-api.test.ts
@@ -11,7 +11,15 @@ const HERE = __dirname;
 // script guards its env-dependent setup and auto-run behind
 // `__FILE__ == $PROGRAM_NAME`, so it is safe to `require_relative` here and
 // drive ApiExtractor directly.
-describe("Ruby extractor body call capture", () => {
+// Every case here shells out to a real `ruby` process through Ripper, so a case
+// costs a process spawn plus parse (~300-500ms locally) rather than the
+// microseconds vitest's default 5s timeout is tuned for. On a loaded 4-vCPU CI
+// runner that budget is thin enough to lose the race — it has timed out on a
+// case whose assertions were never reached — so the whole subprocess-driven
+// describe gets a wider one.
+const RUBY_SUBPROCESS_TIMEOUT_MS = 30_000;
+
+describe("Ruby extractor body call capture", { timeout: RUBY_SUBPROCESS_TIMEOUT_MS }, () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
   // Returns a map of "<fqn>#<method>" -> the named method_info array for the
@@ -188,22 +196,25 @@ describe("Ruby extractor body call capture", () => {
   });
 });
 
-describe("Ruby extractor inert-receiver call suppression", () => {
-  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+describe(
+  "Ruby extractor inert-receiver call suppression",
+  { timeout: RUBY_SUBPROCESS_TIMEOUT_MS },
+  () => {
+    const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  // Returns a map of "<fqn>#<method>" -> { calls, weakCalls }.
-  function rubyWeakCalls(
-    fixtures: Record<string, string>,
-  ): Record<string, { calls?: string[]; weakCalls?: string[] }> {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "weak-rb-"));
-    try {
-      for (const [rel, src] of Object.entries(fixtures)) {
-        const p = path.join(dir, rel);
-        fs.mkdirSync(path.dirname(p), { recursive: true });
-        fs.writeFileSync(p, src);
-      }
-      const rels = JSON.stringify(Object.keys(fixtures));
-      const driver = `
+    // Returns a map of "<fqn>#<method>" -> { calls, weakCalls }.
+    function rubyWeakCalls(
+      fixtures: Record<string, string>,
+    ): Record<string, { calls?: string[]; weakCalls?: string[] }> {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "weak-rb-"));
+      try {
+        for (const [rel, src] of Object.entries(fixtures)) {
+          const p = path.join(dir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, src);
+        }
+        const rels = JSON.stringify(Object.keys(fixtures));
+        const driver = `
         require_relative ${JSON.stringify(RUBY_SCRIPT)}
         require "json"
         ex = ApiExtractor.new
@@ -218,16 +229,16 @@ describe("Ruby extractor inert-receiver call suppression", () => {
         end
         puts JSON.generate(out)
       `;
-      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
-      return JSON.parse(stdout);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+        const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+        return JSON.parse(stdout);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
-  }
 
-  it("marks local-variable and literal receivers weak", () => {
-    const c = rubyWeakCalls({
-      "foo.rb": `
+    it("marks local-variable and literal receivers weak", () => {
+      const c = rubyWeakCalls({
+        "foo.rb": `
         class Foo
           def a(opts)
             xs = [1]
@@ -240,17 +251,17 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Foo#a"].weakCalls?.sort()).toEqual(
+        ["fetch", "first", "merge", "to_proc", "to_s", "upcase"].sort(),
+      );
     });
-    expect(c["Foo#a"].weakCalls?.sort()).toEqual(
-      ["fetch", "first", "merge", "to_proc", "to_s", "upcase"].sort(),
-    );
-  });
 
-  it("suppresses a paren-less qualified call on a local variable", () => {
-    // `opts.assert_valid_keys :a` parses as :command_call, not :call — the
-    // receiver check has to cover both or half the noise survives.
-    const c = rubyWeakCalls({
-      "cmd.rb": `
+    it("suppresses a paren-less qualified call on a local variable", () => {
+      // `opts.assert_valid_keys :a` parses as :command_call, not :call — the
+      // receiver check has to cover both or half the noise survives.
+      const c = rubyWeakCalls({
+        "cmd.rb": `
         class Cmd
           def d(opts)
             opts.assert_valid_keys :a
@@ -261,15 +272,15 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Cmd#d"].weakCalls).toEqual(["assert_valid_keys"]);
+      expect(c["Cmd#e"].calls).toContain("assert_valid_keys");
+      expect(c["Cmd#e"].weakCalls ?? []).toEqual([]);
     });
-    expect(c["Cmd#d"].weakCalls).toEqual(["assert_valid_keys"]);
-    expect(c["Cmd#e"].calls).toContain("assert_valid_keys");
-    expect(c["Cmd#e"].weakCalls ?? []).toEqual([]);
-  });
 
-  it("still records self, ivar, constant and method-chain receivers", () => {
-    const c = rubyWeakCalls({
-      "bar.rb": `
+    it("still records self, ivar, constant and method-chain receivers", () => {
+      const c = rubyWeakCalls({
+        "bar.rb": `
         class Bar
           def b
             self.save
@@ -279,16 +290,16 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Bar#b"].calls).toEqual(
+        expect.arrayContaining(["save", "reader", "build", "destroy"]),
+      );
+      expect(c["Bar#b"].weakCalls ?? []).toEqual([]);
     });
-    expect(c["Bar#b"].calls).toEqual(
-      expect.arrayContaining(["save", "reader", "build", "destroy"]),
-    );
-    expect(c["Bar#b"].weakCalls ?? []).toEqual([]);
-  });
 
-  it("keeps a name significant when any occurrence has a live receiver", () => {
-    const c = rubyWeakCalls({
-      "baz.rb": `
+    it("keeps a name significant when any occurrence has a live receiver", () => {
+      const c = rubyWeakCalls({
+        "baz.rb": `
         class Baz
           def c(list)
             list.save
@@ -296,14 +307,14 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Baz#c"].calls).toContain("save");
+      expect(c["Baz#c"].weakCalls ?? []).not.toContain("save");
     });
-    expect(c["Baz#c"].calls).toContain("save");
-    expect(c["Baz#c"].weakCalls ?? []).not.toContain("save");
-  });
 
-  it("drops a Ruby core method call in a core_ext body but keeps a ported one", () => {
-    const c = rubyWeakCalls({
-      "lib/active_support/core_ext/array/access.rb": `
+    it("drops a Ruby core method call in a core_ext body but keeps a ported one", () => {
+      const c = rubyWeakCalls({
+        "lib/active_support/core_ext/array/access.rb": `
         class Array
           def sole
             case count
@@ -313,16 +324,16 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      // `count`/`first` are Ruby core on the reopened receiver; `in_groups_of` is
+      // an ActiveSupport extension the port really does have to call.
+      expect(c["Array#sole"].weakCalls?.sort()).toEqual(["count", "first"]);
+      expect(c["Array#sole"].calls).toContain("in_groups_of");
     });
-    // `count`/`first` are Ruby core on the reopened receiver; `in_groups_of` is
-    // an ActiveSupport extension the port really does have to call.
-    expect(c["Array#sole"].weakCalls?.sort()).toEqual(["count", "first"]);
-    expect(c["Array#sole"].calls).toContain("in_groups_of");
-  });
 
-  it("keeps a Ruby core method name significant outside core_ext", () => {
-    const c = rubyWeakCalls({
-      "lib/active_record/relation.rb": `
+    it("keeps a Ruby core method name significant outside core_ext", () => {
+      const c = rubyWeakCalls({
+        "lib/active_record/relation.rb": `
         class Relation
           def sole
             count
@@ -330,13 +341,13 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Relation#sole"].weakCalls ?? []).toEqual([]);
     });
-    expect(c["Relation#sole"].weakCalls ?? []).toEqual([]);
-  });
 
-  it("drops a Ruby core call on an Array-literal constant receiver", () => {
-    const c = rubyWeakCalls({
-      "lib/active_support/inflector/transliterate.rb": `
+    it("drops a Ruby core call on an Array-literal constant receiver", () => {
+      const c = rubyWeakCalls({
+        "lib/active_support/inflector/transliterate.rb": `
         class Inflector
           ALLOWED = [Encoding::UTF_8, Encoding::US_ASCII].freeze
 
@@ -349,17 +360,17 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      // `ALLOWED` is an Array literal, so its `include?` is Array#include?;
+      // `I18N_RULES` is not a literal collection in this file, so its `include?`
+      // is still a call to a ported collaborator.
+      expect(c["Inflector#transliterate"].weakCalls).toEqual(["include?"]);
+      expect(c["Inflector#rules"].weakCalls ?? []).toEqual([]);
     });
-    // `ALLOWED` is an Array literal, so its `include?` is Array#include?;
-    // `I18N_RULES` is not a literal collection in this file, so its `include?`
-    // is still a call to a ported collaborator.
-    expect(c["Inflector#transliterate"].weakCalls).toEqual(["include?"]);
-    expect(c["Inflector#rules"].weakCalls ?? []).toEqual([]);
-  });
 
-  it("drops a Module method called unqualified inside a module_eval block", () => {
-    const c = rubyWeakCalls({
-      "lib/active_support/deprecation/method_wrappers.rb": `
+    it("drops a Module method called unqualified inside a module_eval block", () => {
+      const c = rubyWeakCalls({
+        "lib/active_support/deprecation/method_wrappers.rb": `
         class MethodWrappers
           def deprecate_methods(target_module, method_name)
             target_module.module_eval do
@@ -370,21 +381,21 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      // `self` inside the block is the module, so `define_method` /
+      // `redefine_method` there are Ruby metaprogramming; the same names outside
+      // the block, and the ported `deprecation_warning`, stay significant.
+      expect(c["MethodWrappers#deprecate_methods"].weakCalls?.sort()).toEqual([
+        "module_eval",
+        "redefine_method",
+      ]);
+      expect(c["MethodWrappers#deprecate_methods"].calls).toContain("define_method");
+      expect(c["MethodWrappers#deprecate_methods"].calls).toContain("deprecation_warning");
     });
-    // `self` inside the block is the module, so `define_method` /
-    // `redefine_method` there are Ruby metaprogramming; the same names outside
-    // the block, and the ported `deprecation_warning`, stay significant.
-    expect(c["MethodWrappers#deprecate_methods"].weakCalls?.sort()).toEqual([
-      "module_eval",
-      "redefine_method",
-    ]);
-    expect(c["MethodWrappers#deprecate_methods"].calls).toContain("define_method");
-    expect(c["MethodWrappers#deprecate_methods"].calls).toContain("deprecation_warning");
-  });
 
-  it("drops a call on a Ruby core class constant receiver", () => {
-    const c = rubyWeakCalls({
-      "lib/active_support/file_utils.rb": `
+    it("drops a call on a Ruby core class constant receiver", () => {
+      const c = rubyWeakCalls({
+        "lib/active_support/file_utils.rb": `
         class Writer
           def write(path)
             File.stat(path)
@@ -393,14 +404,14 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Writer#write"].weakCalls?.sort()).toEqual(["new"]);
+      expect(c["Writer#write"].calls).toContain("stat");
     });
-    expect(c["Writer#write"].weakCalls?.sort()).toEqual(["new"]);
-    expect(c["Writer#write"].calls).toContain("stat");
-  });
 
-  it("drops new at a Proc receiver while keeping it at a constant receiver", () => {
-    const c = rubyWeakCalls({
-      "qux.rb": `
+    it("drops new at a Proc receiver while keeping it at a constant receiver", () => {
+      const c = rubyWeakCalls({
+        "qux.rb": `
         class Qux
           def d
             callback = Proc.new { |x| x.run }
@@ -408,18 +419,18 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      // `Proc.new { ... }` ports to an arrow function, which names no callee, so
+      // the site can never be satisfied; `Wrapper.new` is a real construction the
+      // TS side records as `constructor`.
+      expect(c["Qux#d"].calls).toContain("new");
+      expect(c["Qux#d"].calls?.filter((n) => n === "new")).toEqual(["new"]);
+      expect(c["Qux#d"].calls).toContain("run");
     });
-    // `Proc.new { ... }` ports to an arrow function, which names no callee, so
-    // the site can never be satisfied; `Wrapper.new` is a real construction the
-    // TS side records as `constructor`.
-    expect(c["Qux#d"].calls).toContain("new");
-    expect(c["Qux#d"].calls?.filter((n) => n === "new")).toEqual(["new"]);
-    expect(c["Qux#d"].calls).toContain("run");
-  });
 
-  it("drops the new a raise builds its error with, keeping any other new", () => {
-    const c = rubyWeakCalls({
-      "raiser.rb": `
+    it("drops the new a raise builds its error with, keeping any other new", () => {
+      const c = rubyWeakCalls({
+        "raiser.rb": `
         class Raiser
           def f
             raise ArgumentError.new("bad") unless ok?
@@ -427,43 +438,47 @@ describe("Ruby extractor inert-receiver call suppression", () => {
           end
         end
       `,
+      });
+      // `raise Foo.new(msg)` and `raise Foo, msg` are one raise written two ways,
+      // and the port spells both `throw new Foo(msg)` — so the raise's own `new`
+      // carries no position (extract-ts-api.ts#isThrownConstruction drops the TS
+      // half). `Wrapper.new` still does, and lands after `ok?`.
+      expect(c["Raiser#f"].calls).toEqual(["ok?", "raise", "build", "new"]);
     });
-    // `raise Foo.new(msg)` and `raise Foo, msg` are one raise written two ways,
-    // and the port spells both `throw new Foo(msg)` — so the raise's own `new`
-    // carries no position (extract-ts-api.ts#isThrownConstruction drops the TS
-    // half). `Wrapper.new` still does, and lands after `ok?`.
-    expect(c["Raiser#f"].calls).toEqual(["ok?", "raise", "build", "new"]);
-  });
 
-  it("drops new entirely when Proc is the only receiver", () => {
-    const c = rubyWeakCalls({
-      "quux.rb": `
+    it("drops new entirely when Proc is the only receiver", () => {
+      const c = rubyWeakCalls({
+        "quux.rb": `
         class Quux
           def e
             Proc.new { greet }
           end
         end
       `,
+      });
+      expect(c["Quux#e"].calls ?? []).not.toContain("new");
+      expect(c["Quux#e"].calls).toContain("greet");
     });
-    expect(c["Quux#e"].calls ?? []).not.toContain("new");
-    expect(c["Quux#e"].calls).toContain("greet");
-  });
-});
+  },
+);
 
-describe("Ruby extractor call-argument Proc.new suppression", () => {
-  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+describe(
+  "Ruby extractor call-argument Proc.new suppression",
+  { timeout: RUBY_SUBPROCESS_TIMEOUT_MS },
+  () => {
+    const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  // Returns a map of "<fqn>#<method>" -> the recorded call sites' names.
-  function rubyCallSiteNames(fixtures: Record<string, string>): Record<string, string[]> {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "args-rb-"));
-    try {
-      for (const [rel, src] of Object.entries(fixtures)) {
-        const p = path.join(dir, rel);
-        fs.mkdirSync(path.dirname(p), { recursive: true });
-        fs.writeFileSync(p, src);
-      }
-      const rels = JSON.stringify(Object.keys(fixtures));
-      const driver = `
+    // Returns a map of "<fqn>#<method>" -> the recorded call sites' names.
+    function rubyCallSiteNames(fixtures: Record<string, string>): Record<string, string[]> {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "args-rb-"));
+      try {
+        for (const [rel, src] of Object.entries(fixtures)) {
+          const p = path.join(dir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, src);
+        }
+        const rels = JSON.stringify(Object.keys(fixtures));
+        const driver = `
         require_relative ${JSON.stringify(RUBY_SCRIPT)}
         require "json"
         ex = ApiExtractor.new
@@ -478,16 +493,16 @@ describe("Ruby extractor call-argument Proc.new suppression", () => {
         end
         puts JSON.generate(out)
       `;
-      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
-      return JSON.parse(stdout);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+        const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+        return JSON.parse(stdout);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
-  }
 
-  it("drops the Proc.new site while keeping a constant-receiver new site", () => {
-    const c = rubyCallSiteNames({
-      "qux.rb": `
+    it("drops the Proc.new site while keeping a constant-receiver new site", () => {
+      const c = rubyCallSiteNames({
+        "qux.rb": `
         class Qux
           def d
             callback = Proc.new { |x| x.run }
@@ -495,27 +510,28 @@ describe("Ruby extractor call-argument Proc.new suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Qux#d"].filter((n) => n === "new")).toEqual(["new"]);
+      expect(c["Qux#d"]).toContain("run");
     });
-    expect(c["Qux#d"].filter((n) => n === "new")).toEqual(["new"]);
-    expect(c["Qux#d"]).toContain("run");
-  });
 
-  it("drops the new site entirely when Proc is the only receiver", () => {
-    const c = rubyCallSiteNames({
-      "quux.rb": `
+    it("drops the new site entirely when Proc is the only receiver", () => {
+      const c = rubyCallSiteNames({
+        "quux.rb": `
         class Quux
           def e
             Proc.new { greet }
           end
         end
       `,
+      });
+      expect(c["Quux#e"]).not.toContain("new");
+      expect(c["Quux#e"]).toContain("greet");
     });
-    expect(c["Quux#e"]).not.toContain("new");
-    expect(c["Quux#e"]).toContain("greet");
-  });
-});
+  },
+);
 
-describe("Ruby extractor alias arity resolution", () => {
+describe("Ruby extractor alias arity resolution", { timeout: RUBY_SUBPROCESS_TIMEOUT_MS }, () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
   // Returns a map of "<fqn>#<method>" -> param-name array after running
@@ -1023,24 +1039,27 @@ describe("Ruby extractor alias arity resolution", () => {
   });
 });
 
-describe("Ruby extractor umbrella module-config scanning", () => {
-  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+describe(
+  "Ruby extractor umbrella module-config scanning",
+  { timeout: RUBY_SUBPROCESS_TIMEOUT_MS },
+  () => {
+    const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  // Lay out a package libPath with a `base.rb` and a sibling umbrella file
-  // one level above it, scan the package then the umbrella, and return the
-  // ActiveRecord::Base / ActiveRecord entries.
-  function scanWithUmbrella(
-    baseSrc: string,
-    umbrellaSrc: string,
-    full = false,
-  ): Record<string, ClassEntry> {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "umbrella-rb-"));
-    try {
-      const libPath = path.join(root, "active_record");
-      fs.mkdirSync(libPath, { recursive: true });
-      fs.writeFileSync(path.join(libPath, "base.rb"), baseSrc);
-      fs.writeFileSync(path.join(root, "active_record.rb"), umbrellaSrc);
-      const driver = `
+    // Lay out a package libPath with a `base.rb` and a sibling umbrella file
+    // one level above it, scan the package then the umbrella, and return the
+    // ActiveRecord::Base / ActiveRecord entries.
+    function scanWithUmbrella(
+      baseSrc: string,
+      umbrellaSrc: string,
+      full = false,
+    ): Record<string, ClassEntry> {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "umbrella-rb-"));
+      try {
+        const libPath = path.join(root, "active_record");
+        fs.mkdirSync(libPath, { recursive: true });
+        fs.writeFileSync(path.join(libPath, "base.rb"), baseSrc);
+        fs.writeFileSync(path.join(root, "active_record.rb"), umbrellaSrc);
+        const driver = `
         require_relative ${JSON.stringify(RUBY_SCRIPT)}
         require "json"
         ex = ApiExtractor.new
@@ -1052,20 +1071,20 @@ describe("Ruby extractor umbrella module-config scanning", () => {
         end
         puts JSON.generate(out)
       `;
-      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
-      return JSON.parse(stdout);
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
+        const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+        return JSON.parse(stdout);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
     }
-  }
 
-  interface ClassEntry {
-    classMethods: { name: string; umbrellaConfig?: boolean }[];
-    instanceMethods: { name: string; visibility: string }[];
-    file: string;
-  }
+    interface ClassEntry {
+      classMethods: { name: string; umbrellaConfig?: boolean }[];
+      instanceMethods: { name: string; visibility: string }[];
+      file: string;
+    }
 
-  const BASE_SRC = `
+    const BASE_SRC = `
     module ActiveRecord
       class Base
         def save; end
@@ -1073,102 +1092,102 @@ describe("Ruby extractor umbrella module-config scanning", () => {
     end
   `;
 
-  it("attributes module-level singleton_class config to <Module>::Base, tagged umbrellaConfig", () => {
-    const out = scanWithUmbrella(
-      BASE_SRC,
-      `
+    it("attributes module-level singleton_class config to <Module>::Base, tagged umbrellaConfig", () => {
+      const out = scanWithUmbrella(
+        BASE_SRC,
+        `
       module ActiveRecord
         singleton_class.attr_accessor :writing_role
         singleton_class.attr_reader :default_timezone
         def self.eager_load!; end
       end
     `,
-    );
-    const base = out["ActiveRecord::Base"];
-    const names = base.classMethods.map((m) => m.name);
-    // accessor → reader + writer; reader-only → reader only.
-    expect(names).toContain("writing_role");
-    expect(names).toContain("writing_role=");
-    expect(names).toContain("default_timezone");
-    expect(names).not.toContain("default_timezone=");
-    // Every redirected entry is tagged so compare can credit the port wherever
-    // it lands in the package.
-    for (const m of base.classMethods.filter((m) => m.name.startsWith("writing_role"))) {
-      expect(m.umbrellaConfig).toBe(true);
-    }
-    // The umbrella's `def self.` helpers are NOT harvested (not Base statics).
-    expect(names).not.toContain("eager_load!");
-  });
+      );
+      const base = out["ActiveRecord::Base"];
+      const names = base.classMethods.map((m) => m.name);
+      // accessor → reader + writer; reader-only → reader only.
+      expect(names).toContain("writing_role");
+      expect(names).toContain("writing_role=");
+      expect(names).toContain("default_timezone");
+      expect(names).not.toContain("default_timezone=");
+      // Every redirected entry is tagged so compare can credit the port wherever
+      // it lands in the package.
+      for (const m of base.classMethods.filter((m) => m.name.startsWith("writing_role"))) {
+        expect(m.umbrellaConfig).toBe(true);
+      }
+      // The umbrella's `def self.` helpers are NOT harvested (not Base statics).
+      expect(names).not.toContain("eager_load!");
+    });
 
-  it("redirects the `class << self; attr_accessor` block form to Base too", () => {
-    // active_record.rb uses the `singleton_class.attr_*` command form today, but
-    // the equivalent `class << self` block form is also module-level config and
-    // must redirect to Base rather than being silently dropped.
-    const out = scanWithUmbrella(
-      BASE_SRC,
-      `
+    it("redirects the `class << self; attr_accessor` block form to Base too", () => {
+      // active_record.rb uses the `singleton_class.attr_*` command form today, but
+      // the equivalent `class << self` block form is also module-level config and
+      // must redirect to Base rather than being silently dropped.
+      const out = scanWithUmbrella(
+        BASE_SRC,
+        `
       module ActiveRecord
         class << self
           attr_accessor :writing_role
         end
       end
     `,
-    );
-    const base = out["ActiveRecord::Base"];
-    const names = base.classMethods.map((m) => m.name);
-    expect(names).toContain("writing_role");
-    expect(names).toContain("writing_role=");
-    for (const m of base.classMethods.filter((m) => m.name.startsWith("writing_role"))) {
-      expect(m.umbrellaConfig).toBe(true);
-    }
-  });
+      );
+      const base = out["ActiveRecord::Base"];
+      const names = base.classMethods.map((m) => m.name);
+      expect(names).toContain("writing_role");
+      expect(names).toContain("writing_role=");
+      for (const m of base.classMethods.filter((m) => m.name.startsWith("writing_role"))) {
+        expect(m.umbrellaConfig).toBe(true);
+      }
+    });
 
-  it("does not leak umbrella config onto the ActiveRecord module's bucket", () => {
-    const out = scanWithUmbrella(
-      BASE_SRC,
-      `
+    it("does not leak umbrella config onto the ActiveRecord module's bucket", () => {
+      const out = scanWithUmbrella(
+        BASE_SRC,
+        `
       module ActiveRecord
         singleton_class.attr_accessor :writing_role
       end
     `,
-    );
-    const mod = out["ActiveRecord"];
-    const modNames = mod ? mod.classMethods.map((m) => m.name) : [];
-    expect(modNames).not.toContain("writing_role");
-  });
+      );
+      const mod = out["ActiveRecord"];
+      const modNames = mod ? mod.classMethods.map((m) => m.name) : [];
+      expect(modNames).not.toContain("writing_role");
+    });
 
-  it("skips umbrella config when the module has no ::Base to redirect to", () => {
-    // `ActiveSupport.error_reporter` lives on a module with no `::Base`; without
-    // a Base to credit it, recording it would leak onto the module's entity-file
-    // bucket as false-missing, so it must be skipped entirely.
-    const out = scanWithUmbrella(
-      `
+    it("skips umbrella config when the module has no ::Base to redirect to", () => {
+      // `ActiveSupport.error_reporter` lives on a module with no `::Base`; without
+      // a Base to credit it, recording it would leak onto the module's entity-file
+      // bucket as false-missing, so it must be skipped entirely.
+      const out = scanWithUmbrella(
+        `
       module ActiveSupport
         class NotBase
           def call; end
         end
       end
     `,
-      `
+        `
       module ActiveSupport
         singleton_class.attr_accessor :error_reporter
       end
     `,
-    );
-    const mod = out["ActiveSupport"];
-    const names = mod ? [...mod.classMethods, ...mod.instanceMethods].map((m) => m.name) : [];
-    expect(names).not.toContain("error_reporter");
-  });
+      );
+      const mod = out["ActiveSupport"];
+      const names = mod ? [...mod.classMethods, ...mod.instanceMethods].map((m) => m.name) : [];
+      expect(names).not.toContain("error_reporter");
+    });
 
-  // `vendor/i18n/lib/i18n.rb` is not an autoload manifest: it is where
-  // `I18n::Base`, the gem's whole public facade, is defined. The config-only
-  // scan above sees only its three aliases, so the ported facade is measured
-  // against a denominator of 3. UMBRELLA_FULL_SCAN_PACKAGES opts such a package
-  // into a full walk.
-  it("extracts the method definitions of an umbrella file scanned in full", () => {
-    const out = scanWithUmbrella(
-      BASE_SRC,
-      `
+    // `vendor/i18n/lib/i18n.rb` is not an autoload manifest: it is where
+    // `I18n::Base`, the gem's whole public facade, is defined. The config-only
+    // scan above sees only its three aliases, so the ported facade is measured
+    // against a denominator of 3. UMBRELLA_FULL_SCAN_PACKAGES opts such a package
+    // into a full walk.
+    it("extracts the method definitions of an umbrella file scanned in full", () => {
+      const out = scanWithUmbrella(
+        BASE_SRC,
+        `
       module ActiveRecord
         module Facade
           def translate(key, **options); end
@@ -1184,23 +1203,27 @@ describe("Ruby extractor umbrella module-config scanning", () => {
         extend Facade
       end
     `,
-      true,
-    );
-    const facade = out["ActiveRecord::Facade"];
-    expect(facade.instanceMethods.map((m) => m.name)).toEqual(["translate", "t", "translate_key"]);
-    expect(facade.instanceMethods.map((m) => m.visibility)).toEqual([
-      "public",
-      "public",
-      "private",
-    ]);
-    expect(facade.file).toBe("../active_record.rb");
-    expect(out["ActiveRecord"].classMethods.map((m) => m.name)).toContain("reserve_key");
-  });
+        true,
+      );
+      const facade = out["ActiveRecord::Facade"];
+      expect(facade.instanceMethods.map((m) => m.name)).toEqual([
+        "translate",
+        "t",
+        "translate_key",
+      ]);
+      expect(facade.instanceMethods.map((m) => m.visibility)).toEqual([
+        "public",
+        "public",
+        "private",
+      ]);
+      expect(facade.file).toBe("../active_record.rb");
+      expect(out["ActiveRecord"].classMethods.map((m) => m.name)).toContain("reserve_key");
+    });
 
-  it("keeps a config-only umbrella scan free of those definitions", () => {
-    const out = scanWithUmbrella(
-      BASE_SRC,
-      `
+    it("keeps a config-only umbrella scan free of those definitions", () => {
+      const out = scanWithUmbrella(
+        BASE_SRC,
+        `
       module ActiveRecord
         module Facade
           def translate(key, **options); end
@@ -1209,26 +1232,30 @@ describe("Ruby extractor umbrella module-config scanning", () => {
         def self.reserve_key(key); end
       end
     `,
-    );
-    expect(out["ActiveRecord::Facade"].instanceMethods).toEqual([]);
-    expect(out["ActiveRecord"].classMethods).toEqual([]);
-  });
-});
+      );
+      expect(out["ActiveRecord::Facade"].instanceMethods).toEqual([]);
+      expect(out["ActiveRecord"].classMethods).toEqual([]);
+    });
+  },
+);
 
-describe("Ruby extractor body digest (source-hash pinning)", () => {
-  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+describe(
+  "Ruby extractor body digest (source-hash pinning)",
+  { timeout: RUBY_SUBPROCESS_TIMEOUT_MS },
+  () => {
+    const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  // Returns a map of "<fqn>#<method>" -> bodyDigest for the given fixtures.
-  function rubyDigests(fixtures: Record<string, string>): Record<string, string | undefined> {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "digest-rb-"));
-    try {
-      for (const [rel, src] of Object.entries(fixtures)) {
-        const p = path.join(dir, rel);
-        fs.mkdirSync(path.dirname(p), { recursive: true });
-        fs.writeFileSync(p, src);
-      }
-      const rels = JSON.stringify(Object.keys(fixtures));
-      const driver = `
+    // Returns a map of "<fqn>#<method>" -> bodyDigest for the given fixtures.
+    function rubyDigests(fixtures: Record<string, string>): Record<string, string | undefined> {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "digest-rb-"));
+      try {
+        for (const [rel, src] of Object.entries(fixtures)) {
+          const p = path.join(dir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, src);
+        }
+        const rels = JSON.stringify(Object.keys(fixtures));
+        const driver = `
         require_relative ${JSON.stringify(RUBY_SCRIPT)}
         require "json"
         ex = ApiExtractor.new
@@ -1243,29 +1270,29 @@ describe("Ruby extractor body digest (source-hash pinning)", () => {
         end
         puts JSON.generate(out)
       `;
-      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
-      return JSON.parse(stdout);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+        const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+        return JSON.parse(stdout);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
-  }
 
-  it("emits a body digest for each method", () => {
-    const d = rubyDigests({
-      "foo.rb": `
+    it("emits a body digest for each method", () => {
+      const d = rubyDigests({
+        "foo.rb": `
         class Foo
           def save
             run_callbacks(:save)
           end
         end
       `,
+      });
+      expect(d["Foo#save"]).toMatch(/^[0-9a-f]{16}$/);
     });
-    expect(d["Foo#save"]).toMatch(/^[0-9a-f]{16}$/);
-  });
 
-  it("is unchanged by indentation, blank-line, and comment churn", () => {
-    const base = rubyDigests({
-      "a.rb": `
+    it("is unchanged by indentation, blank-line, and comment churn", () => {
+      const base = rubyDigests({
+        "a.rb": `
         class Foo
           def save
             validate!
@@ -1273,9 +1300,9 @@ describe("Ruby extractor body digest (source-hash pinning)", () => {
           end
         end
       `,
-    });
-    const churned = rubyDigests({
-      "a.rb": `
+      });
+      const churned = rubyDigests({
+        "a.rb": `
         class Foo
           def save
                 # a leading comment
@@ -1286,38 +1313,39 @@ describe("Ruby extractor body digest (source-hash pinning)", () => {
           end
         end
       `,
+      });
+      expect(churned["Foo#save"]).toBe(base["Foo#save"]);
     });
-    expect(churned["Foo#save"]).toBe(base["Foo#save"]);
-  });
 
-  it("changes when the body's code changes (drift)", () => {
-    const base = rubyDigests({
-      "a.rb": `
+    it("changes when the body's code changes (drift)", () => {
+      const base = rubyDigests({
+        "a.rb": `
         class Foo
           def save
             run_callbacks(:save)
           end
         end
       `,
-    });
-    const edited = rubyDigests({
-      "a.rb": `
+      });
+      const edited = rubyDigests({
+        "a.rb": `
         class Foo
           def save
             run_callbacks(:create)
           end
         end
       `,
+      });
+      expect(edited["Foo#save"]).not.toBe(base["Foo#save"]);
     });
-    expect(edited["Foo#save"]).not.toBe(base["Foo#save"]);
-  });
-});
+  },
+);
 
 // Per-method source lines let consumers (the file-structure method-order
 // manifest) interleave classMethods back into Rails source order instead of
 // appending them after instanceMethods — which inverts every Rails file that
 // opens with a `class << self` block (active_model/attribute.rb:7-24).
-describe("Ruby extractor method source lines", () => {
+describe("Ruby extractor method source lines", { timeout: RUBY_SUBPROCESS_TIMEOUT_MS }, () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
   // Returns "<fqn>#<method>" -> [bucket, line].
@@ -1387,20 +1415,23 @@ describe("Ruby extractor method source lines", () => {
   });
 });
 
-describe("Ruby extractor option-key const expansion", () => {
-  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+describe(
+  "Ruby extractor option-key const expansion",
+  { timeout: RUBY_SUBPROCESS_TIMEOUT_MS },
+  () => {
+    const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  // Returns a map of "<fqn>#<method>" -> the method's expanded option_keys.
-  function optionKeys(fixtures: Record<string, string>): Record<string, string[] | undefined> {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "optkeys-rb-"));
-    try {
-      for (const [rel, src] of Object.entries(fixtures)) {
-        const p = path.join(dir, rel);
-        fs.mkdirSync(path.dirname(p), { recursive: true });
-        fs.writeFileSync(p, src);
-      }
-      const rels = JSON.stringify(Object.keys(fixtures));
-      const driver = `
+    // Returns a map of "<fqn>#<method>" -> the method's expanded option_keys.
+    function optionKeys(fixtures: Record<string, string>): Record<string, string[] | undefined> {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "optkeys-rb-"));
+      try {
+        for (const [rel, src] of Object.entries(fixtures)) {
+          const p = path.join(dir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, src);
+        }
+        const rels = JSON.stringify(Object.keys(fixtures));
+        const driver = `
         require_relative ${JSON.stringify(RUBY_SCRIPT)}
         require "json"
         ex = ApiExtractor.new
@@ -1415,16 +1446,16 @@ describe("Ruby extractor option-key const expansion", () => {
         end
         puts JSON.generate(out)
       `;
-      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
-      return JSON.parse(stdout);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+        const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+        return JSON.parse(stdout);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
-  }
 
-  it("binds a leading :: option-key const to the top level, not a nested const", () => {
-    const r = optionKeys({
-      "abs_opt.rb": `
+    it("binds a leading :: option-key const to the top level, not a nested const", () => {
+      const r = optionKeys({
+        "abs_opt.rb": `
         module Foo
           KEYS = [:top_a, :top_b]
         end
@@ -1441,12 +1472,13 @@ describe("Ruby extractor option-key const expansion", () => {
           end
         end
       `,
+      });
+      expect(r["Bar::Rel#build"]).toEqual(["top_a", "top_b"]);
     });
-    expect(r["Bar::Rel#build"]).toEqual(["top_a", "top_b"]);
-  });
-});
+  },
+);
 
-describe("Ruby extractor file constants", () => {
+describe("Ruby extractor file constants", { timeout: RUBY_SUBPROCESS_TIMEOUT_MS }, () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
   function rubyFileConstants(src: string): Record<string, { kind: string }> {
@@ -1481,23 +1513,26 @@ describe("Ruby extractor file constants", () => {
   });
 });
 
-describe("Ruby extractor metaprogrammed method surface", () => {
-  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+describe(
+  "Ruby extractor metaprogrammed method surface",
+  { timeout: RUBY_SUBPROCESS_TIMEOUT_MS },
+  () => {
+    const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  type MetaMethod = {
-    name: string;
-    notes?: string;
-    visibility: string;
-    params: { kind: string }[];
-  };
+    type MetaMethod = {
+      name: string;
+      notes?: string;
+      visibility: string;
+      params: { kind: string }[];
+    };
 
-  // Returns "<fqn>" -> instance methods, so a test can assert both the
-  // generated names and the params lifted off the define_method block.
-  function metaMethods(src: string): Record<string, MetaMethod[]> {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meta-rb-"));
-    try {
-      fs.writeFileSync(path.join(dir, "meta.rb"), src);
-      const driver = `
+    // Returns "<fqn>" -> instance methods, so a test can assert both the
+    // generated names and the params lifted off the define_method block.
+    function metaMethods(src: string): Record<string, MetaMethod[]> {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "meta-rb-"));
+      try {
+        fs.writeFileSync(path.join(dir, "meta.rb"), src);
+        const driver = `
         require_relative ${JSON.stringify(RUBY_SCRIPT)}
         require "json"
         ex = ApiExtractor.new
@@ -1510,14 +1545,14 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         end
         puts JSON.generate(out)
       `;
-      return JSON.parse(execFileSync("ruby", ["-e", driver], { encoding: "utf-8" }));
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+        return JSON.parse(execFileSync("ruby", ["-e", driver], { encoding: "utf-8" }));
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
-  }
 
-  it("records define_method with a literal name", () => {
-    const m = metaMethods(`
+    it("records define_method with a literal name", () => {
+      const m = metaMethods(`
       module Engine
         define_method(:railtie_routes_url_helpers) { |include_path_helpers = true| nil }
         define_method "railtie_helpers_paths" do
@@ -1525,17 +1560,17 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         end
       end
     `);
-    const names = m["Engine"].map((x) => x.name);
-    expect(names).toContain("railtie_routes_url_helpers");
-    expect(names).toContain("railtie_helpers_paths");
-    const urlHelpers = m["Engine"].find((x) => x.name === "railtie_routes_url_helpers")!;
-    expect(urlHelpers.notes).toBe("define_method");
-    // The block's params are the generated method's params.
-    expect(urlHelpers.params.map((p) => p.kind)).toEqual(["optional"]);
-  });
+      const names = m["Engine"].map((x) => x.name);
+      expect(names).toContain("railtie_routes_url_helpers");
+      expect(names).toContain("railtie_helpers_paths");
+      const urlHelpers = m["Engine"].find((x) => x.name === "railtie_routes_url_helpers")!;
+      expect(urlHelpers.notes).toBe("define_method");
+      // The block's params are the generated method's params.
+      expect(urlHelpers.params.map((p) => p.kind)).toEqual(["optional"]);
+    });
 
-  it("synthesizes the accessors and initialize a Struct.new superclass generates", () => {
-    const m = metaMethods(`
+    it("synthesizes the accessors and initialize a Struct.new superclass generates", () => {
+      const m = metaMethods(`
       module Arel
         class Attribute < Struct.new :relation, :name
           def type_caster
@@ -1544,39 +1579,39 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         end
       end
     `);
-    expect(m["Arel::Attribute"].map((x) => x.name).sort()).toEqual([
-      "initialize",
-      "name",
-      "name=",
-      "relation",
-      "relation=",
-      "type_caster",
-    ]);
-    const init = m["Arel::Attribute"].find((x) => x.name === "initialize")!;
-    expect(init.params).toEqual([
-      { name: "relation", kind: "optional", default: "..." },
-      { name: "name", kind: "optional", default: "..." },
-    ]);
-    const reader = m["Arel::Attribute"].find((x) => x.name === "relation")!;
-    expect(reader.params).toEqual([]);
-  });
+      expect(m["Arel::Attribute"].map((x) => x.name).sort()).toEqual([
+        "initialize",
+        "name",
+        "name=",
+        "relation",
+        "relation=",
+        "type_caster",
+      ]);
+      const init = m["Arel::Attribute"].find((x) => x.name === "initialize")!;
+      expect(init.params).toEqual([
+        { name: "relation", kind: "optional", default: "..." },
+        { name: "name", kind: "optional", default: "..." },
+      ]);
+      const reader = m["Arel::Attribute"].find((x) => x.name === "relation")!;
+      expect(reader.params).toEqual([]);
+    });
 
-  it("synthesizes keyword params for a keyword_init Struct's initialize", () => {
-    const m = metaMethods(`
+    it("synthesizes keyword params for a keyword_init Struct's initialize", () => {
+      const m = metaMethods(`
       module ActiveSupport
         class Report < Struct.new(:error, :severity, keyword_init: true)
         end
       end
     `);
-    const init = m["ActiveSupport::Report"].find((x) => x.name === "initialize")!;
-    expect(init.params).toEqual([
-      { name: "error", kind: "keyword", default: "..." },
-      { name: "severity", kind: "keyword", default: "..." },
-    ]);
-  });
+      const init = m["ActiveSupport::Report"].find((x) => x.name === "initialize")!;
+      expect(init.params).toEqual([
+        { name: "error", kind: "keyword", default: "..." },
+        { name: "severity", kind: "keyword", default: "..." },
+      ]);
+    });
 
-  it("synthesizes the accessors a `CONST = Struct.new(...) do ... end` generates", () => {
-    const m = metaMethods(`
+    it("synthesizes the accessors a `CONST = Struct.new(...) do ... end` generates", () => {
+      const m = metaMethods(`
       module Arel
         Edge = Struct.new(:name, :from) do
           def to_s
@@ -1585,18 +1620,18 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         end
       end
     `);
-    expect(m["Arel::Edge"].map((x) => x.name).sort()).toEqual([
-      "from",
-      "from=",
-      "initialize",
-      "name",
-      "name=",
-      "to_s",
-    ]);
-  });
+      expect(m["Arel::Edge"].map((x) => x.name).sort()).toEqual([
+        "from",
+        "from=",
+        "initialize",
+        "name",
+        "name=",
+        "to_s",
+      ]);
+    });
 
-  it("unrolls a literal-array each loop that interpolates the loop variable", () => {
-    const m = metaMethods(`
+    it("unrolls a literal-array each loop that interpolates the loop variable", () => {
+      const m = metaMethods(`
       module ClassMethods
         [:before, :after, :around].each do |callback|
           define_method "#{callback}_action" do |*names, &blk|
@@ -1611,29 +1646,29 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         end
       end
     `);
-    const names = m["ClassMethods"].map((x) => x.name);
-    expect(names).toEqual([
-      "before_action",
-      "after_action",
-      "around_action",
-      "skip_before_action",
-      "skip_after_action",
-      "skip_around_action",
-      "append_before_action",
-      "append_after_action",
-      "append_around_action",
-    ]);
-    const beforeAction = m["ClassMethods"].find((x) => x.name === "before_action")!;
-    expect(beforeAction.params.map((p) => p.kind)).toEqual(["rest", "block"]);
-    const appendBefore = m["ClassMethods"].find((x) => x.name === "append_before_action")!;
-    expect(appendBefore.notes).toBe("alias");
-  });
+      const names = m["ClassMethods"].map((x) => x.name);
+      expect(names).toEqual([
+        "before_action",
+        "after_action",
+        "around_action",
+        "skip_before_action",
+        "skip_after_action",
+        "skip_around_action",
+        "append_before_action",
+        "append_after_action",
+        "append_around_action",
+      ]);
+      const beforeAction = m["ClassMethods"].find((x) => x.name === "before_action")!;
+      expect(beforeAction.params.map((p) => p.kind)).toEqual(["rest", "block"]);
+      const appendBefore = m["ClassMethods"].find((x) => x.name === "append_before_action")!;
+      expect(appendBefore.notes).toBe("alias");
+    });
 
-  it("records both block-less define_method shapes exactly once", () => {
-    // Bare command (action_view/layouts.rb:311's shape) and parenthesized
-    // (rack/utils.rb:183's). The block forms below must not be recorded twice
-    // by the generic descent re-reaching process_command / method_add_arg.
-    const m = metaMethods(`
+    it("records both block-less define_method shapes exactly once", () => {
+      // Bare command (action_view/layouts.rb:311's shape) and parenthesized
+      // (rack/utils.rb:183's). The block forms below must not be recorded twice
+      // by the generic descent re-reaching process_command / method_add_arg.
+      const m = metaMethods(`
       module Shapes
         define_method :from_proc, &_layout
         define_method(:from_method, Kernel.instance_method(:inspect))
@@ -1643,18 +1678,18 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         define_method(:with_brace_block) { |a| nil }
       end
     `);
-    expect(m["Shapes"].map((x) => x.name)).toEqual([
-      "from_proc",
-      "from_method",
-      "with_do_block",
-      "with_brace_block",
-    ]);
-    // Only the block forms can supply params; the block-less ones stay empty.
-    expect(m["Shapes"].map((x) => x.params.length)).toEqual([0, 0, 1, 1]);
-  });
+      expect(m["Shapes"].map((x) => x.name)).toEqual([
+        "from_proc",
+        "from_method",
+        "with_do_block",
+        "with_brace_block",
+      ]);
+      // Only the block forms can supply params; the block-less ones stay empty.
+      expect(m["Shapes"].map((x) => x.params.length)).toEqual([0, 0, 1, 1]);
+    });
 
-  it("buckets a `class << self` define_method as a class method", () => {
-    const m = metaMethods(`
+    it("buckets a `class << self` define_method as a class method", () => {
+      const m = metaMethods(`
       class Base
         class << self
           define_method(:configure) { nil }
@@ -1665,15 +1700,15 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         define_method(:normalize) { nil }
       end
     `);
-    expect(m["Base.self"].map((x) => x.name)).toEqual(["configure"]);
-    const normalize = m["Base"].find((x) => x.name === "normalize")!;
-    expect(normalize.visibility).toBe("private");
-  });
+      expect(m["Base.self"].map((x) => x.name)).toEqual(["configure"]);
+      const normalize = m["Base"].find((x) => x.name === "normalize")!;
+      expect(normalize.visibility).toBe("private");
+    });
 
-  it("keeps the literal def when a branch defines the same name both ways", () => {
-    // rack utils.rb:183 — `define_method(:escape_html, …)` or `def escape_html`
-    // off an `if defined?(…)`; the extractor walks both branches, only one is live.
-    const m = metaMethods(`
+    it("keeps the literal def when a branch defines the same name both ways", () => {
+      // rack utils.rb:183 — `define_method(:escape_html, …)` or `def escape_html`
+      // off an `if defined?(…)`; the extractor walks both branches, only one is live.
+      const m = metaMethods(`
       module Utils
         if defined?(ERB::Escape)
           define_method(:escape_html, ERB::Escape.instance_method(:html_escape))
@@ -1684,11 +1719,11 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         end
       end
     `);
-    expect(m["Utils"].map((x) => [x.name, x.notes])).toEqual([["escape_html", undefined]]);
-  });
+      expect(m["Utils"].map((x) => [x.name, x.notes])).toEqual([["escape_html", undefined]]);
+    });
 
-  it("skips a define_method whose name cannot be resolved to literals", () => {
-    const m = metaMethods(`
+    it("skips a define_method whose name cannot be resolved to literals", () => {
+      const m = metaMethods(`
       module Unresolvable
         SUFFIXES.each do |suffix|
           define_method "reader_#{suffix}" do
@@ -1707,12 +1742,13 @@ describe("Ruby extractor metaprogrammed method surface", () => {
         end
       end
     `);
-    expect(m["Unresolvable"] ?? []).toEqual([]);
-    expect(m["Unresolvable.self"] ?? []).toEqual([]);
-  });
-});
+      expect(m["Unresolvable"] ?? []).toEqual([]);
+      expect(m["Unresolvable.self"] ?? []).toEqual([]);
+    });
+  },
+);
 
-describe("Ruby extractor call-argument capture", () => {
+describe("Ruby extractor call-argument capture", { timeout: RUBY_SUBPROCESS_TIMEOUT_MS }, () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
   interface CallSite {
@@ -2036,7 +2072,7 @@ describe("Ruby extractor call-argument capture", () => {
   });
 });
 
-describe("Ruby extractor attr_reader flag", () => {
+describe("Ruby extractor attr_reader flag", { timeout: RUBY_SUBPROCESS_TIMEOUT_MS }, () => {
   const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
   type AttrMethod = { name: string; reader?: boolean };
@@ -2084,22 +2120,25 @@ describe("Ruby extractor attr_reader flag", () => {
   });
 });
 
-describe("Ruby extractor attr_reader read suppression", () => {
-  const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
+describe(
+  "Ruby extractor attr_reader read suppression",
+  { timeout: RUBY_SUBPROCESS_TIMEOUT_MS },
+  () => {
+    const RUBY_SCRIPT = path.join(HERE, "extract-ruby-api.rb");
 
-  // Returns a map of "<fqn>#<method>" -> [callArgs site names, calls].
-  function rubyStreams(
-    fixtures: Record<string, string>,
-  ): Record<string, { sites: string[]; calls: string[] }> {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "attr-rb-"));
-    try {
-      for (const [rel, src] of Object.entries(fixtures)) {
-        const p = path.join(dir, rel);
-        fs.mkdirSync(path.dirname(p), { recursive: true });
-        fs.writeFileSync(p, src);
-      }
-      const rels = JSON.stringify(Object.keys(fixtures));
-      const driver = `
+    // Returns a map of "<fqn>#<method>" -> [callArgs site names, calls].
+    function rubyStreams(
+      fixtures: Record<string, string>,
+    ): Record<string, { sites: string[]; calls: string[] }> {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), "attr-rb-"));
+      try {
+        for (const [rel, src] of Object.entries(fixtures)) {
+          const p = path.join(dir, rel);
+          fs.mkdirSync(path.dirname(p), { recursive: true });
+          fs.writeFileSync(p, src);
+        }
+        const rels = JSON.stringify(Object.keys(fixtures));
+        const driver = `
         require_relative ${JSON.stringify(RUBY_SCRIPT)}
         require "json"
         ex = ApiExtractor.new
@@ -2117,16 +2156,16 @@ describe("Ruby extractor attr_reader read suppression", () => {
         end
         puts JSON.generate(out)
       `;
-      const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
-      return JSON.parse(stdout);
-    } finally {
-      fs.rmSync(dir, { recursive: true, force: true });
+        const stdout = execFileSync("ruby", ["-e", driver], { encoding: "utf-8" });
+        return JSON.parse(stdout);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
-  }
 
-  it("drops a bare read of an attr_reader, which the port spells as a getter", () => {
-    const c = rubyStreams({
-      "scope.rb": `
+    it("drops a bare read of an attr_reader, which the port spells as a getter", () => {
+      const c = rubyStreams({
+        "scope.rb": `
         class Scope
           private
             attr_reader :value_transformation
@@ -2140,18 +2179,18 @@ describe("Ruby extractor attr_reader read suppression", () => {
             end
         end
       `,
+      });
+      // The reader read itself is gone, and the Proc invocation Ruby spells
+      // `.call` on it lands under the reader's name — what `this.valueTransformation(value)`
+      // records on the TS side.
+      expect(c["Scope#transform_value"].sites).toEqual(["value_transformation"]);
+      expect(c["Scope#transform_self"].sites).toEqual(["value_transformation"]);
+      expect(c["Scope#transform_value"].calls).toEqual(["value_transformation"]);
     });
-    // The reader read itself is gone, and the Proc invocation Ruby spells
-    // `.call` on it lands under the reader's name — what `this.valueTransformation(value)`
-    // records on the TS side.
-    expect(c["Scope#transform_value"].sites).toEqual(["value_transformation"]);
-    expect(c["Scope#transform_self"].sites).toEqual(["value_transformation"]);
-    expect(c["Scope#transform_value"].calls).toEqual(["value_transformation"]);
-  });
 
-  it("keeps a site that passes arguments to an attr_reader name", () => {
-    const c = rubyStreams({
-      "branch.rb": `
+    it("keeps a site that passes arguments to an attr_reader name", () => {
+      const c = rubyStreams({
+        "branch.rb": `
         class Branch
           attr_reader :association
 
@@ -2161,13 +2200,13 @@ describe("Ruby extractor attr_reader read suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Branch#preloaders_for_reflection"].sites).toEqual(["class", "association"]);
     });
-    expect(c["Branch#preloaders_for_reflection"].sites).toEqual(["class", "association"]);
-  });
 
-  it("keeps a bare call whose name is an attr_reader on a NESTED class only", () => {
-    const c = rubyStreams({
-      "outer.rb": `
+    it("keeps a bare call whose name is an attr_reader on a NESTED class only", () => {
+      const c = rubyStreams({
+        "outer.rb": `
         class Outer
           def read
             association
@@ -2178,7 +2217,8 @@ describe("Ruby extractor attr_reader read suppression", () => {
           end
         end
       `,
+      });
+      expect(c["Outer#read"].sites).toEqual(["association"]);
     });
-    expect(c["Outer#read"].sites).toEqual(["association"]);
-  });
-});
+  },
+);


### PR DESCRIPTION
`ActiveSupport::Concern` gives a Ruby includer the module's `ClassMethods` and
`included do` block from the one `include` line. Two trails modules were not
doing that half themselves — the includer was spelling it out — so a second host
could not get the module by including it.

## `Validations` (validations.rb:37)

`API.[included]` owned half of `Validations`' include contract: three `extend()`
calls (`ClassMethods` validations.rb:57-307, plus the reopenings at
`validations/with.rb:87` and `validations/validates.rb:110`) and an object
literal of the module's free-function instance half. `Validations.[included]`
now issues all of it — `ClassMethods` first, the way `append_features` extends
before it `class_eval`s the `included do` block — and api.rb:62 is back to the
one `include(base, Validations)` it is.

Regression cover: a plain class + `include(Host, Validations)` gets `validates`
and the runner with no `extend()` at the call site (fails on baseline —
`Host.validates` is undefined).

## `Attributes` (attributes.rb:30-39)

`ActiveModel::Attributes` is `include AttributeRegistration` +
`include AttributeMethods` (attributes.rb:32-33) plus its own `ClassMethods`
(:39) and `included do` (:35). `model.ts` was spelling all four out as six
statements, with `Attributes::ClassMethods` as an inline object literal.

- `AttributeRegistration::ClassMethods` (attribute_registration.rb:11-115,
  including the `private` half at :53) and `Attributes::ClassMethods`
  (attributes.rb:38-104) are now exported module objects at their Rails file.
- `Attributes.[included]` issues both extends, the `AttributeMethods` halves,
  its own `ClassMethods`, the `attribute_method_suffix "="` block, and
  `_write_attribute` / `attribute=` (:156-159), in Rails' order.
- `model.rb`'s attribute wiring in `model.ts` is now `include(Model, Attributes)`.

`AttributeRegistration` gets no `[included]` hook: attribute_registration.rb has
no `included do` block, so its whole contribution is the `ClassMethods` extend
its includer's `append_features` performs.

## Scope

Two stories, one per module, both claimed by this worker:

- `issue-the-validations-classmethods-extend-from-its-own-included-hook` — the
  `Validations` half (`api.ts`, `validations.ts`).
- `issue-attributes-mixin-contract-from-its-own-included-hook` — the `Attributes`
  half (`attributes.ts`, `attribute-registration.ts`, `model.ts`), filed against
  RFC 0115 to carve the wiring out of
  `move-attributes-and-attribute-methods-off-active-model-model`, whose own
  "What the Dirty slice learned" section names it as a prerequisite ("Adding
  `AttributeRegistration::ClassMethods` and `Attributes::ClassMethods` is a
  fidelity win in itself").

`move-attributes-and-attribute-methods-off-active-model-model` stays open and
unclaimed. The large slice it still owns — removing the stack from
`ActiveModel::Model`, wiring `ActiveRecord::Base` at base.rb:311/:316, and
re-declaring the class half across ~52 activemodel test models — is untouched
here; that story itself flags it as needing a per-module split. Its `blocked-by`
prose (and that of `trim-active-model-model-to-api-and-access` /
`relocate-active-record-shaped-mixins-off-active-model-model`) cites `model.ts`
lines this PR deletes and wants a refresh in the tasks repo.

Gates: `parity:api:calls` OK (359 baselined, 286 unreviewed), `parity:api:calls:args`
OK (141), `parity:api:extra:gate` OK, activemodel suite green (1910), AR
attribute-methods / base / attributes / dirty / validations / serialization /
inheritance green.

Closes-story: issue-the-validations-classmethods-extend-from-its-own-included-hook
Closes-story: issue-attributes-mixin-contract-from-its-own-included-hook
